### PR TITLE
Add flag to filter faulty qubits and gates to BackendV2Converter

### DIFF
--- a/qiskit/providers/backend_compat.py
+++ b/qiskit/providers/backend_compat.py
@@ -36,6 +36,7 @@ def convert_to_target(
     defaults: PulseDefaults = None,
     custom_name_mapping: Optional[Dict[str, Any]] = None,
     add_delay: bool = False,
+    filter_faulty: bool = False,
 ):
     """Uses configuration, properties and pulse defaults
     to construct and return Target class.
@@ -70,6 +71,12 @@ def convert_to_target(
                 )
 
             qubits = tuple(gate.qubits)
+            if filter_faulty:
+                if any(not properties.is_qubit_operational(qubit) for qubit in qubits):
+                    continue
+                if not properties.is_gate_operational(name, gate.qubits):
+                    continue
+
             gate_props = {}
             for param in gate.parameters:
                 if param.name == "gate_error":
@@ -83,6 +90,9 @@ def convert_to_target(
         # Create measurement instructions:
         measure_props = {}
         for qubit, _ in enumerate(properties.qubits):
+            if filter_faulty:
+                if not properties.is_qubit_operational(qubit):
+                    continue
             measure_props[(qubit,)] = InstructionProperties(
                 duration=properties.readout_length(qubit),
                 error=properties.readout_error(qubit),
@@ -116,6 +126,9 @@ def convert_to_target(
         target.acquire_alignment = configuration.timing_constraints.get("acquire_alignment")
     # If a pulse defaults exists use that as the source of truth
     if defaults is not None:
+        faulty_qubits = set()
+        if filter_faulty and properties is not None:
+            faulty_qubits = set(properties.faulty_qubits())
         inst_map = defaults.instruction_schedule_map
         for inst in inst_map.instructions:
             for qarg in inst_map.qubits_with_instruction(inst):
@@ -129,8 +142,12 @@ def convert_to_target(
                 if inst in target:
                     if inst == "measure":
                         for qubit in qargs:
+                            if filter_faulty and qubit in faulty_qubits:
+                                continue
                             target[inst][(qubit,)].calibration = calibration_entry
                     elif qargs in target[inst]:
+                        if filter_faulty and any(qubit in faulty_qubits for qubit in qargs):
+                            continue
                         target[inst][qargs].calibration = calibration_entry
     combined_global_ops = set()
     if configuration.basis_gates:
@@ -196,6 +213,7 @@ class BackendV2Converter(BackendV2):
         backend: BackendV1,
         name_mapping: Optional[Dict[str, Any]] = None,
         add_delay: bool = False,
+        filter_faulty: bool = False,
     ):
         """Initialize a BackendV2 converter instance based on a BackendV1 instance.
 
@@ -211,6 +229,9 @@ class BackendV2Converter(BackendV2):
             add_delay: If set to true a :class:`~qiskit.circuit.Delay` operation
                 will be added to the target as a supported operation for all
                 qubits
+            filter_faulty: If the :class:`~.BackendProperties` object (if present) for
+                ``backend`` has any qubits or gates flagged as non-operational filter
+                those from the output target.
         """
         self._backend = backend
         self._config = self._backend.configuration()
@@ -229,6 +250,7 @@ class BackendV2Converter(BackendV2):
         self._target = None
         self._name_mapping = name_mapping
         self._add_delay = add_delay
+        self._filter_faulty = filter_faulty
 
     @property
     def target(self):
@@ -247,6 +269,7 @@ class BackendV2Converter(BackendV2):
                 self._defaults,
                 custom_name_mapping=self._name_mapping,
                 add_delay=self._add_delay,
+                filter_faulty=self._filter_faulty,
             )
         return self._target
 

--- a/releasenotes/notes/filter-faulty-qubits-and-gates-v2-converter-b56dac9c0ce8057f.yaml
+++ b/releasenotes/notes/filter-faulty-qubits-and-gates-v2-converter-b56dac9c0ce8057f.yaml
@@ -1,0 +1,18 @@
+---
+features:
+  - |
+    The :class:`~.BackendV2Converter` class has a new keyword argument,
+    ``filter_faulty``, on its constructor. When this argument is set to ``True``
+    the converter class will filter out any qubits or operations listed
+    as non-operational in the :class:`~.BackendProperties` payload for the
+    input :class:`~.BackendV1`. While not extensively used a
+    :class:`~.BackendProperties` object supports annotating both qubits
+    and gates as being non-operational. Previously, if a backend had set that
+    flag on any qubits or gates the output :class:`BackendV2` instance and
+    its :class:`~.Target` would include all operations whether they were
+    listed as operational or not. By leveraging the new flag you can filter
+    out these non-operational qubits and gates from the :class:`~.Target`.
+    When the flag is set the output backend will still be listed as the full
+    width (e.g. a 24 qubit backend with 4 qubits listed as not operational will
+    still show it has 24 qubits) but the faulty qubits will not have any
+    operations listed as being supported in the :class:`~.Target`.

--- a/test/python/providers/test_fake_backends.py
+++ b/test/python/providers/test_fake_backends.py
@@ -13,6 +13,7 @@
 # pylint: disable=missing-class-docstring,missing-function-docstring
 # pylint: disable=missing-module-docstring
 
+import datetime
 import operator
 import unittest
 
@@ -31,8 +32,10 @@ from qiskit.providers.fake_provider import (
     FakeMumbaiV2,
     FakeYorktown,
     FakeMumbai,
+    FakeWashington,
 )
 from qiskit.providers.backend_compat import BackendV2Converter
+from qiskit.providers.models.backendproperties import BackendProperties
 from qiskit.providers.backend import BackendV2
 from qiskit.utils import optionals
 from qiskit.circuit.library import (
@@ -460,3 +463,108 @@ class TestFakeBackends(QiskitTestCase):
         counts = result.get_counts()
         max_count = max(counts.items(), key=operator.itemgetter(1))[0]
         self.assertEqual(max_count, "11")
+
+    def test_filter_faulty_qubits_backend_v2_converter(self):
+        """Test faulty qubits in v2 conversion."""
+        backend = FakeWashington()
+        # Get properties dict to make it easier to work with the properties API
+        # is difficult to edit because of the multiple layers of nesting and
+        # different object types
+        props_dict = backend.properties().to_dict()
+        for i in range(62, 67):
+            non_operational = {
+                "date": datetime.datetime.utcnow(),
+                "name": "operational",
+                "unit": "",
+                "value": 0,
+            }
+            props_dict["qubits"][i].append(non_operational)
+        backend._properties = BackendProperties.from_dict(props_dict)
+        v2_backend = BackendV2Converter(backend, filter_faulty=True)
+        for i in range(62, 67):
+            for qarg in v2_backend.target.qargs:
+                self.assertNotIn(i, qarg)
+
+    def test_filter_faulty_qubits_and_gates_backend_v2_converter(self):
+        """Test faulty gates and qubits."""
+        backend = FakeWashington()
+        # Get properties dict to make it easier to work with the properties API
+        # is difficult to edit because of the multiple layers of nesting and
+        # different object types
+        props_dict = backend.properties().to_dict()
+        for i in range(62, 67):
+            non_operational = {
+                "date": datetime.datetime.utcnow(),
+                "name": "operational",
+                "unit": "",
+                "value": 0,
+            }
+            props_dict["qubits"][i].append(non_operational)
+        invalid_cx_edges = {
+            (113, 114),
+            (114, 113),
+            (96, 100),
+            (100, 96),
+            (114, 109),
+            (109, 114),
+            (24, 34),
+            (34, 24),
+        }
+        non_operational_gate = {
+            "date": datetime.datetime.utcnow(),
+            "name": "operational",
+            "unit": "",
+            "value": 0,
+        }
+        for gate in props_dict["gates"]:
+            if tuple(gate["qubits"]) in invalid_cx_edges:
+                gate["parameters"].append(non_operational_gate)
+
+        backend._properties = BackendProperties.from_dict(props_dict)
+        v2_backend = BackendV2Converter(backend, filter_faulty=True)
+        for i in range(62, 67):
+            for qarg in v2_backend.target.qargs:
+                self.assertNotIn(i, qarg)
+        for edge in invalid_cx_edges:
+            self.assertNotIn(edge, v2_backend.target["cx"])
+
+    def test_filter_faulty_gates_v2_converter(self):
+        """Test just faulty gates in conversion."""
+        backend = FakeWashington()
+        # Get properties dict to make it easier to work with the properties API
+        # is difficult to edit because of the multiple layers of nesting and
+        # different object types
+        props_dict = backend.properties().to_dict()
+        invalid_cx_edges = {
+            (113, 114),
+            (114, 113),
+            (96, 100),
+            (100, 96),
+            (114, 109),
+            (109, 114),
+            (24, 34),
+            (34, 24),
+        }
+        non_operational_gate = {
+            "date": datetime.datetime.utcnow(),
+            "name": "operational",
+            "unit": "",
+            "value": 0,
+        }
+        for gate in props_dict["gates"]:
+            if tuple(gate["qubits"]) in invalid_cx_edges:
+                gate["parameters"].append(non_operational_gate)
+
+        backend._properties = BackendProperties.from_dict(props_dict)
+        v2_backend = BackendV2Converter(backend, filter_faulty=True)
+        for i in range(62, 67):
+            self.assertIn((i,), v2_backend.target.qargs)
+        for edge in invalid_cx_edges:
+            self.assertNotIn(edge, v2_backend.target["cx"])
+
+    def test_filter_faulty_no_faults_v2_converter(self):
+        """Test that faulty qubit filtering does nothing with all operational qubits and gates."""
+        backend = FakeWashington()
+        v2_backend = BackendV2Converter(backend, filter_faulty=True)
+        for i in range(v2_backend.num_qubits):
+            self.assertIn((i,), v2_backend.target.qargs)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Add flag to filter faulty qubits and gates to BackendV2Converter
    
This commit adds a flag to filter faulty qubits or gates from the
created target when using `BackendV2Converter`. The BackendProperties
object had a rarely used feature to annotate qubits or gates as being
non-operational and previously the BackendV2Converter would
unconditionally include qubits and gates with this flag set in the
output Target and BackendV2 instance. This new flag will enable users to
filter these if that is more desireable behavior. When filtering is set
the backend will still be listed as full width but any faulty qubits
will just not include any operations.

### Details and comments

Fixes #9910