### PR TITLE
Add equivlences of ECR, SX and SXdg gates to the equivalence library

### DIFF
--- a/qiskit/circuit/library/standard_gates/equivalence_library.py
+++ b/qiskit/circuit/library/standard_gates/equivalence_library.py
@@ -644,6 +644,25 @@ for inst, qargs, cargs in [
     def_ecr_cliff.append(inst, qargs, cargs)
 _sel.add_equivalence(ECRGate(), def_ecr_cliff)
 
+# CXGate decomposed using an ECRGate and Clifford 1-qubit gates
+#                global phase: π/4
+# q_0: ──■──          ┌─────┐ ┌──────┐┌───┐
+#      ┌─┴─┐  ≡  q_0: ┤ Sdg ├─┤0     ├┤ X ├
+# q_1: ┤ X ├          ├─────┴┐│  Ecr │└───┘
+#      └───┘     q_1: ┤ √Xdg ├┤1     ├─────
+#                     └──────┘└──────┘
+
+q = QuantumRegister(2, "q")
+def_ecr_to_cx_cliff = QuantumCircuit(q, global_phase=pi / 4)
+for inst, qargs, cargs in [
+    (SdgGate(), [q[0]], []),
+    (SXdgGate(), [q[1]], []),
+    (ECRGate(), [q[0], q[1]], []),
+    (XGate(), [q[0]], []),
+]:
+    def_ecr_to_cx_cliff.append(inst, qargs, cargs)
+_sel.add_equivalence(CXGate(), def_ecr_to_cx_cliff)
+
 # SGate
 #
 #    ┌───┐        ┌─────────┐
@@ -781,6 +800,17 @@ for inst, qargs, cargs in [(SdgGate(), [q[0]], []), (HGate(), [q[0]], []), (SdgG
     def_sx.append(inst, qargs, cargs)
 _sel.add_equivalence(SXGate(), def_sx)
 
+# HGate decomposed into SXGate and SGate
+#              global phase: -π/4
+#    ┌───┐        ┌───┐┌────┐┌───┐
+# q: ┤ H ├  ≡  q: ┤ S ├┤ √X ├┤ S ├
+#    └───┘        └───┘└────┘└───┘
+q = QuantumRegister(1, "q")
+def_h_to_sx = QuantumCircuit(q, global_phase=-pi / 4)
+for inst, qargs, cargs in [(SGate(), [q[0]], []), (SXGate(), [q[0]], []), (SGate(), [q[0]], [])]:
+    def_h_to_sx.append(inst, qargs, cargs)
+_sel.add_equivalence(HGate(), def_h_to_sx)
+
 # SXGate
 #               global phase: π/4
 #    ┌────┐        ┌─────────┐
@@ -801,6 +831,21 @@ def_sxdg = QuantumCircuit(q, global_phase=-pi / 4)
 for inst, qargs, cargs in [(SGate(), [q[0]], []), (HGate(), [q[0]], []), (SGate(), [q[0]], [])]:
     def_sxdg.append(inst, qargs, cargs)
 _sel.add_equivalence(SXdgGate(), def_sxdg)
+
+# HGate decomposed into SXdgGate and SdgGate
+#              global phase: π/4
+#    ┌───┐        ┌─────┐┌──────┐┌─────┐
+# q: ┤ H ├  ≡  q: ┤ Sdg ├┤ √Xdg ├┤ Sdg ├
+#    └───┘        └─────┘└──────┘└─────┘
+q = QuantumRegister(1, "q")
+def_h_to_sxdg = QuantumCircuit(q, global_phase=pi / 4)
+for inst, qargs, cargs in [
+    (SdgGate(), [q[0]], []),
+    (SXdgGate(), [q[0]], []),
+    (SdgGate(), [q[0]], []),
+]:
+    def_h_to_sxdg.append(inst, qargs, cargs)
+_sel.add_equivalence(HGate(), def_h_to_sxdg)
 
 # SXdgGate
 #                 global phase: 7π/4

--- a/releasenotes/notes/add-ecr-sx-equivalences-5b6fe73ec599d1a4.yaml
+++ b/releasenotes/notes/add-ecr-sx-equivalences-5b6fe73ec599d1a4.yaml
@@ -1,5 +1,5 @@
 ---
-feature:
+features:
   - |
     Added a decomposition of an :class:`.CXGate` into :class:`.ECRGate` and 1-qubit Clifford gates
     (up to a global phase) into the :class:`.EquivalenceLibrary`.

--- a/releasenotes/notes/add-ecr-sx-equivalences-5b6fe73ec599d1a4.yaml
+++ b/releasenotes/notes/add-ecr-sx-equivalences-5b6fe73ec599d1a4.yaml
@@ -1,7 +1,11 @@
 ---
-fixes:
+feature:
   - |
-    Add a decomposition of an :class:`.CXGate` into :class:`.ECRGate` and 1-qubit Clifford gates
+    Added a decomposition of an :class:`.CXGate` into :class:`.ECRGate` and 1-qubit Clifford gates
     (up to a global phase) into the :class:`.EquivalenceLibrary`.
-    Add decompositions of an :class:`.HGate` into :class:`.SXGate` (respectively :class:`.SXdgGate`)
-    and :class:`.SGate` (respectively :class:`.SdgGate`) (up to a global phase) into the :class:`.EquivalenceLibrary`.
+  - |
+    Added a decomposition of an :class:`.HGate` into :class:`.SXGate` and :class:`.SGate`
+    (up to a global phase) into the :class:`.EquivalenceLibrary`.
+  - |
+    Added a decomposition of an :class:`.HGate` into :class:`.SXdgGate` and :class:`.SdgGate`
+    (up to a global phase) into the :class:`.EquivalenceLibrary`.

--- a/releasenotes/notes/add-ecr-sx-equivalences-5b6fe73ec599d1a4.yaml
+++ b/releasenotes/notes/add-ecr-sx-equivalences-5b6fe73ec599d1a4.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Add a decomposition of an :class:`.CXGate` into :class:`.ECRGate` and 1-qubit Clifford gates
+    (up to a global phase) into the :class:`.EquivalenceLibrary`.
+    Add decompositions of an :class:`.HGate` into :class:`.SXGate` (respectively :class:`.SXdgGate`)
+    and :class:`.SGate` (respectively :class:`.SdgGate`) (up to a global phase) into the :class:`.EquivalenceLibrary`.

--- a/test/python/transpiler/test_basis_translator.py
+++ b/test/python/transpiler/test_basis_translator.py
@@ -897,18 +897,19 @@ class TestBasisExamples(QiskitTestCase):
         in_dag = circuit_to_dag(bell)
         out_dag = BasisTranslator(std_eqlib, ["ecr", "u"]).run(in_dag)
 
-        #         ┌────────────┐  ┌─────────────┐┌──────────┐┌──────┐
-        # q_0: ───┤ U(π/2,0,π) ├──┤ U(0,0,-π/2) ├┤ U(π,0,0) ├┤0     ├
-        #      ┌──┴────────────┴─┐└─────────────┘└──────────┘│  Ecr │
-        # q_1: ┤ U(π/2,-π/2,π/2) ├───────────────────────────┤1     ├
-        #      └─────────────────┘                           └──────┘
+        #         ┌────────────┐   ┌─────────────┐┌──────┐┌──────────┐
+        # q_0: ───┤ U(π/2,0,π) ├───┤ U(0,0,-π/2) ├┤0     ├┤ U(π,0,π) ├
+        #      ┌──┴────────────┴──┐└─────────────┘│  Ecr │└──────────┘
+        # q_1: ┤ U(-π/2,-π/2,π/2) ├───────────────┤1     ├────────────
+        #      └──────────────────┘               └──────┘
+
         qr = QuantumRegister(2, "q")
         expected = QuantumCircuit(2)
         expected.u(pi / 2, 0, pi, qr[0])
         expected.u(0, 0, -pi / 2, qr[0])
-        expected.u(pi, 0, 0, qr[0])
-        expected.u(pi / 2, -pi / 2, pi / 2, qr[1])
+        expected.u(-pi / 2, -pi / 2, pi / 2, qr[1])
         expected.ecr(0, 1)
+        expected.u(pi, 0, pi, qr[0])
         expected_dag = circuit_to_dag(expected)
 
         self.assertEqual(out_dag, expected_dag)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

close #9907 
Add equivalences of to the equivalence library:

- CX decomposed into ECR and 1-qubit Clifford gates
- H decomposed into SX and S gates
- H decomposed into SXdg and Sdg gates


### Details and comments


