### PR TITLE
add option to show node_id in dag visualization

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -1850,7 +1850,7 @@ class DAGCircuit:
         }
         return summary
 
-    def draw(self, scale=0.7, filename=None, style="color"):
+    def draw(self, scale=0.7, filename=None, style="color", **kwargs):
         """
         Draws the dag circuit.
 
@@ -1863,6 +1863,7 @@ class DAGCircuit:
             style (str):
                 'plain': B&W graph;
                 'color' (default): color input/output/op nodes
+            kwargs (dict): additional keyword arguments understood by dag_drawer
 
         Returns:
             Ipython.display.Image: if in Jupyter notebook and not saving to file,
@@ -1870,4 +1871,4 @@ class DAGCircuit:
         """
         from qiskit.visualization.dag_visualization import dag_drawer
 
-        return dag_drawer(dag=self, scale=scale, filename=filename, style=style)
+        return dag_drawer(dag=self, scale=scale, filename=filename, style=style, **kwargs)

--- a/qiskit/visualization/dag_visualization.py
+++ b/qiskit/visualization/dag_visualization.py
@@ -25,7 +25,7 @@ from .exceptions import VisualizationError
 
 
 @_optionals.HAS_GRAPHVIZ.require_in_call
-def dag_drawer(dag, scale=0.7, filename=None, style="color"):
+def dag_drawer(dag, scale=0.7, filename=None, style="color", show_node_id=False):
     """Plot the directed acyclic graph (dag) to represent operation dependencies
     in a quantum circuit.
 
@@ -38,6 +38,7 @@ def dag_drawer(dag, scale=0.7, filename=None, style="color"):
         filename (str): file path to save image to (format inferred from name)
         style (str): 'plain': B&W graph
                      'color' (default): color input/output/op nodes
+        show_node_id (bool): show the graph node_id for each node
 
     Returns:
         PIL.Image: if in Jupyter notebook and not saving to file,
@@ -143,6 +144,8 @@ def dag_drawer(dag, scale=0.7, filename=None, style="color"):
                     n["color"] = "black"
                     n["style"] = "filled"
                     n["fillcolor"] = "red"
+                if show_node_id:
+                    n["label"] = f"{node._node_id}: {n['label']}"
                 return n
             else:
                 raise VisualizationError("Invalid style %s" % style)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Adds an option to show the node_id in DAGCircuit visualization. This can be useful when debugging transpiler passes.


### Details and comments


