### PR TITLE
Add experimental OpenQASM 3 support for switch

### DIFF
--- a/qiskit/qasm3/__init__.py
+++ b/qiskit/qasm3/__init__.py
@@ -47,7 +47,7 @@ Experimental features
 
 The OpenQASM 3 language is still evolving as hardware capabilities improve, so there is no final
 syntax that Qiskit can reliably target.  In order to represent the evolving language, we will
-sometimes release features before formal standardisation, which may need to change as the review
+sometimes release features before formal standardization, which may need to change as the review
 process in the OpenQASM 3 design committees progresses.  By default, the exporters will only support
 standardised features of the language.  To enable these early-release features, use the
 ``experimental`` keyword argument of :func:`dump` and :func:`dumps`.  The available feature flags

--- a/qiskit/qasm3/__init__.py
+++ b/qiskit/qasm3/__init__.py
@@ -42,6 +42,23 @@ All of these interfaces will raise :exc:`QASM3ExporterError` on failure.
 
 .. autoexception:: QASM3ExporterError
 
+Experimental features
+---------------------
+
+The OpenQASM 3 language is still evolving as hardware capabilities improve, so there is no final
+syntax that Qiskit can reliably target.  In order to represent the evolving language, we will
+sometimes release features before formal standardisation, which may need to change as the review
+process in the OpenQASM 3 design committees progresses.  By default, the exporters will only support
+standardised features of the language.  To enable these early-release features, use the
+``experimental`` keyword argument of :func:`dump` and :func:`dumps`.  The available feature flags
+are:
+
+.. autoclass:: ExperimentalFeatures
+    :members:
+
+If you want to enable multiple experimental features, you should combine the flags using the ``|``
+operator, such as ``flag1 | flag2``.
+
 
 Importing from OpenQASM 3
 =========================
@@ -124,6 +141,8 @@ convert it into a :class:`.QuantumCircuit`:
 """
 
 from qiskit.utils import optionals as _optionals
+
+from .experimental import ExperimentalFeatures
 from .exporter import Exporter
 from .exceptions import QASM3Error, QASM3ImporterError, QASM3ExporterError
 

--- a/qiskit/qasm3/__init__.py
+++ b/qiskit/qasm3/__init__.py
@@ -59,6 +59,25 @@ are:
 If you want to enable multiple experimental features, you should combine the flags using the ``|``
 operator, such as ``flag1 | flag2``.
 
+For example, to perform an export using the early semantics of ``switch`` support::
+
+    from qiskit import qasm3, QuantumCircuit, QuantumRegister, ClassicalRegister
+
+    # Build the circuit
+    qreg = QuantumRegister(3)
+    creg = ClassicalRegister(3)
+    qc = QuantumCircuit(qreg, creg)
+    with qc.switch(creg) as case:
+        with case(0):
+            qc.x(0)
+        with case(1, 2):
+            qc.x(1)
+        with case(case.DEFAULT):
+            qc.x(2)
+
+    # Export to an OpenQASM 3 string.
+    qasm_string = qasm3.dumps(qc, experimental=qasm3.ExperimentalFeatures.SWITCH_CASE_V1)
+
 
 Importing from OpenQASM 3
 =========================

--- a/qiskit/qasm3/ast.py
+++ b/qiskit/qasm3/ast.py
@@ -15,7 +15,7 @@
 """QASM3 AST Nodes"""
 
 import enum
-from typing import Optional, List, Union
+from typing import Optional, List, Union, Iterable, Tuple
 
 
 class ASTNode:
@@ -126,6 +126,13 @@ class FloatType(ClassicalType, enum.Enum):
     DOUBLE = 64
     QUAD = 128
     OCT = 256
+
+
+class IntType(ClassicalType):
+    """Type information for a signed integer."""
+
+    def __init__(self, size: Optional[int] = None):
+        self.size = size
 
 
 class BitArrayType(ClassicalType):
@@ -297,6 +304,14 @@ class ClassicalDeclaration(Statement):
         self.type = type_
         self.identifier = identifier
         self.initializer = initializer
+
+
+class AssignmentStatement(Statement):
+    """Assignment of an expression to an l-value."""
+
+    def __init__(self, lvalue: SubscriptedIdentifier, rvalue: Expression):
+        self.lvalue = lvalue
+        self.rvalue = rvalue
 
 
 class QuantumDeclaration(ASTNode):
@@ -629,3 +644,20 @@ class IODeclaration(ClassicalDeclaration):
     def __init__(self, modifier: IOModifier, type_: ClassicalType, identifier: Identifier):
         super().__init__(type_, identifier)
         self.modifier = modifier
+
+
+class DefaultCase(Expression):
+    """An object representing the `default` special label in switch statements."""
+
+    def __init__(self):
+        super().__init__(None)
+
+
+class SwitchStatement(Statement):
+    """AST node for the IBM-internal 'switch-case' extension to OpenQASM 3."""
+
+    def __init__(
+        self, target: Expression, cases: Iterable[Tuple[Iterable[Expression], ProgramBlock]]
+    ):
+        self.target = target
+        self.cases = [(tuple(values), case) for values, case in cases]

--- a/qiskit/qasm3/ast.py
+++ b/qiskit/qasm3/ast.py
@@ -654,7 +654,7 @@ class DefaultCase(Expression):
 
 
 class SwitchStatement(Statement):
-    """AST node for the IBM-internal 'switch-case' extension to OpenQASM 3."""
+    """AST node for the proposed 'switch-case' extension to OpenQASM 3."""
 
     def __init__(
         self, target: Expression, cases: Iterable[Tuple[Iterable[Expression], ProgramBlock]]

--- a/qiskit/qasm3/experimental.py
+++ b/qiskit/qasm3/experimental.py
@@ -1,0 +1,30 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Experimental feature flags."""
+
+import enum
+
+# This enumeration is shared between a bunch of parts of the exporter, so it gets its own file to
+# avoid cyclic dependencies.
+
+
+class ExperimentalFeatures(enum.Flag):
+    """Flags for experimental features that the OpenQASM 3 exporter supports.
+
+    These are experimental and are more liable to change, such as because the OpenQASM 3
+    specification has not formally accepted them yet, so the syntax may not be finalized."""
+
+    SWITCH_CASE_V1 = enum.auto()
+    """Support exporting switch-case statements as proposed by
+    https://github.com/openqasm/openqasm/pull/463 at `commit bfa787aa3078
+    <https://github.com/openqasm/openqasm/pull/463/commits/bfa787aa3078>`__."""

--- a/qiskit/qasm3/experimental.py
+++ b/qiskit/qasm3/experimental.py
@@ -21,7 +21,7 @@ import enum
 class ExperimentalFeatures(enum.Flag):
     """Flags for experimental features that the OpenQASM 3 exporter supports.
 
-    These are experimental and are more liable to change, such as because the OpenQASM 3
+    These are experimental and are more liable to change, because the OpenQASM 3
     specification has not formally accepted them yet, so the syntax may not be finalized."""
 
     SWITCH_CASE_V1 = enum.auto()

--- a/qiskit/qasm3/exporter.py
+++ b/qiskit/qasm3/exporter.py
@@ -338,7 +338,7 @@ class QASM3Builder:
         self.includeslist = includeslist
         # `_global_io_declarations` and `_global_classical_declarations` are stateful, and any
         # operation that needs a parameter can append to them during the build.  We make all
-        # classical declarations global because the IBM QSS stack (our primary consumer of OQ3
+        # classical declarations global because the IBM QSS stack (our initial consumer of OQ3
         # strings) prefers declarations to all be global, and it's valid OQ3, so it's not vendor
         # lock-in.  It's possibly slightly memory inefficient, but that's not likely to be a problem
         # in the near term.

--- a/qiskit/qasm3/exporter.py
+++ b/qiskit/qasm3/exporter.py
@@ -18,7 +18,7 @@ import io
 import itertools
 import numbers
 from os.path import dirname, join, abspath
-from typing import Iterable, List, Sequence, Union
+from typing import Iterable, List, Sequence, Union, Generator
 
 from qiskit.circuit import (
     Barrier,
@@ -40,15 +40,18 @@ from qiskit.circuit.controlflow import (
     IfElseOp,
     ForLoopOp,
     WhileLoopOp,
+    SwitchCaseOp,
     ControlFlowOp,
     BreakLoopOp,
     ContinueLoopOp,
+    CASE_DEFAULT,
 )
 from qiskit.circuit.library import standard_gates
 from qiskit.circuit.register import Register
 from qiskit.circuit.tools import pi_check
 
 from . import ast
+from .experimental import ExperimentalFeatures
 from .exceptions import QASM3ExporterError
 from .printer import BasicPrinter
 
@@ -131,6 +134,7 @@ class Exporter:
         disable_constants: bool = False,
         alias_classical_registers: bool = False,
         indent: str = "  ",
+        experimental: ExperimentalFeatures = ExperimentalFeatures(0),
     ):
         """
         Args:
@@ -153,12 +157,15 @@ class Exporter:
                 :obj:`.ClassicalRegister`\\ s.
             indent: the indentation string to use for each level within an indented block.  Can be
                 set to the empty string to disable indentation.
+            experimental: any experimental features to enable during the export.  See
+                :class:`ExperimentalFeatures` for more details.
         """
         self.basis_gates = basis_gates
         self.disable_constants = disable_constants
         self.alias_classical_registers = alias_classical_registers
         self.includes = list(includes)
         self.indent = indent
+        self.experimental = experimental
 
     def dumps(self, circuit):
         """Convert the circuit to QASM 3, returning the result as a string."""
@@ -174,8 +181,11 @@ class Exporter:
             basis_gates=self.basis_gates,
             disable_constants=self.disable_constants,
             alias_classical_registers=self.alias_classical_registers,
+            experimental=self.experimental,
         )
-        BasicPrinter(stream, indent=self.indent).visit(builder.build_program())
+        BasicPrinter(stream, indent=self.indent, experimental=self.experimental).visit(
+            builder.build_program()
+        )
 
 
 class GlobalNamespace:
@@ -317,6 +327,7 @@ class QASM3Builder:
         basis_gates,
         disable_constants,
         alias_classical_registers,
+        experimental=ExperimentalFeatures(0),
     ):
         # This is a stack of stacks; the outer stack is a list of "outer" look-up contexts, and the
         # inner stack is for scopes within these.  A "outer" look-up context in this sense means
@@ -325,6 +336,14 @@ class QASM3Builder:
         self._circuit_ctx = []
         self.push_context(quantumcircuit)
         self.includeslist = includeslist
+        # `_global_io_declarations` and `_global_classical_declarations` are stateful, and any
+        # operation that needs a parameter can append to them during the build.  We make all
+        # classical declarations global because the IBM QSS stack (our primary consumer of OQ3
+        # strings) prefers declarations to all be global, and it's valid OQ3, so it's not vendor
+        # lock-in.  It's possibly slightly memory inefficient, but that's not likely to be a problem
+        # in the near term.
+        self._global_io_declarations = []
+        self._global_classical_declarations = []
         self._gate_to_declare = {}
         self._subroutine_to_declare = {}
         self._opaque_to_declare = {}
@@ -337,6 +356,14 @@ class QASM3Builder:
         self.disable_constants = disable_constants
         self.alias_classical_registers = alias_classical_registers
         self.global_namespace = GlobalNamespace(includeslist, basis_gates)
+        self.experimental = experimental
+
+    def _unique_name(self, prefix: str, scope: _Scope) -> str:
+        table = scope.symbol_map
+        name = basename = _escape_invalid_identifier(prefix)
+        while name in table or name in _RESERVED_KEYWORDS:
+            name = f"{basename}__generated{next(self._counter)}"
+        return name
 
     def _register_gate(self, gate):
         self.global_namespace.register(gate)
@@ -351,8 +378,8 @@ class QASM3Builder:
             self.global_namespace.register(instruction)
             self._opaque_to_declare[id(instruction)] = instruction
 
-    def _register_variable(self, variable, name=None) -> ast.Identifier:
-        """Register a variable in the symbol table for the current scope, returning the name that
+    def _register_variable(self, variable, scope: _Scope, name=None) -> ast.Identifier:
+        """Register a variable in the symbol table for the given scope, returning the name that
         should be used to refer to the variable.  The same name will be returned by subsequent calls
         to :meth:`_lookup_variable` within the same scope.
 
@@ -362,7 +389,7 @@ class QASM3Builder:
         # in the current scope, not just one that's available.  This is a rough implementation of
         # the shadowing proposal currently being drafted for OpenQASM 3, though we expect it to be
         # expanded and modified in the future (2022-03-07).
-        table = self.current_scope().symbol_map
+        table = scope.symbol_map
         if name is not None:
             if name in _RESERVED_KEYWORDS:
                 raise QASM3ExporterError(f"cannot reserve the keyword '{name}' as a variable name")
@@ -371,16 +398,14 @@ class QASM3Builder:
                     f"tried to reserve '{name}', but it is already used by '{table[name]}'"
                 )
         else:
-            name = basename = _escape_invalid_identifier(variable.name)
-            while name in table:
-                name = f"{basename}__generated{next(self._counter)}"
+            name = self._unique_name(variable.name, scope)
         identifier = ast.Identifier(name)
         table[identifier.string] = variable
         table[variable] = identifier
         return identifier
 
-    def _reserve_variable_name(self, name: ast.Identifier) -> ast.Identifier:
-        """Reserve a variable name in the current scope, raising a :class:`.QASM3ExporterError` if
+    def _reserve_variable_name(self, name: ast.Identifier, scope: _Scope) -> ast.Identifier:
+        """Reserve a variable name in the given scope, raising a :class:`.QASM3ExporterError` if
         the name is already in use.
 
         This is useful for autogenerated names that the exporter itself reserves when dealing with
@@ -388,7 +413,7 @@ class QASM3Builder:
         circuit qubits, so cannot be placed into the symbol table by the normal means.
 
         Returns the same identifier, for convenience in chaining."""
-        table = self.current_scope().symbol_map
+        table = scope.symbol_map
         if name.string in table:
             variable = table[name.string]
             raise QASM3ExporterError(
@@ -535,8 +560,10 @@ class QASM3Builder:
             ;
         """
         definitions = self.build_definitions()
-        inputs, outputs, variables = self.build_variable_declarations()
-        bit_declarations = self.build_classical_declarations()
+        # These two "declarations" functions populate stateful variables, since the calls to
+        # `build_quantum_instructions` might also append to those declarations.
+        self.build_parameter_declarations()
+        self.build_classical_declarations()
         context = self.global_scope(assert_=True).circuit
         if getattr(context, "_layout", None) is not None:
             self._physical_qubit = True
@@ -549,11 +576,11 @@ class QASM3Builder:
         return [
             statement
             for source in (
-                inputs,
-                outputs,
+                # In older versions of the reference OQ3 grammar, IO declarations had to come before
+                # anything else, so we keep doing that as a courtesy.
+                self._global_io_declarations,
                 definitions,
-                variables,
-                bit_declarations,
+                self._global_classical_declarations,
                 quantum_declarations,
                 quantum_instructions,
             )
@@ -604,9 +631,12 @@ class QASM3Builder:
             )
         name = self.global_namespace[instruction]
         self.push_context(instruction.definition)
+        scope = self.current_scope()
         quantum_arguments = [
             ast.QuantumArgument(
-                self._reserve_variable_name(ast.Identifier(f"{self.gate_qubit_prefix}_{n_qubit}"))
+                self._reserve_variable_name(
+                    ast.Identifier(f"{self.gate_qubit_prefix}_{n_qubit}"), scope
+                )
             )
             for n_qubit in range(len(instruction.definition.qubits))
         ]
@@ -630,33 +660,33 @@ class QASM3Builder:
         params = []
         definition = gate.definition
         # Dummy parameters
+        scope = self.current_scope()
         for num in range(len(gate.params) - len(definition.parameters)):
             param_name = f"{self.gate_parameter_prefix}_{num}"
-            params.append(self._reserve_variable_name(ast.Identifier(param_name)))
-        params += [self._register_variable(param) for param in definition.parameters]
+            params.append(self._reserve_variable_name(ast.Identifier(param_name), scope))
+        params += [self._register_variable(param, scope) for param in definition.parameters]
         quantum_arguments = [
-            self._reserve_variable_name(ast.Identifier(f"{self.gate_qubit_prefix}_{n_qubit}"))
+            self._reserve_variable_name(
+                ast.Identifier(f"{self.gate_qubit_prefix}_{n_qubit}"), scope
+            )
             for n_qubit in range(len(definition.qubits))
         ]
         return ast.QuantumGateSignature(ast.Identifier(name), quantum_arguments, params or None)
 
-    def build_variable_declarations(self):
+    def build_parameter_declarations(self):
         """Builds lists of the input, output and standard variables used in this program."""
-        inputs, outputs, variables = [], [], []
-        global_scope = self.global_scope(assert_=True).circuit
-        for parameter in global_scope.parameters:
-            parameter_name = self._register_variable(parameter)
-            declaration = _infer_variable_declaration(global_scope, parameter, parameter_name)
+        global_scope = self.global_scope(assert_=True)
+        for parameter in global_scope.circuit.parameters:
+            parameter_name = self._register_variable(parameter, global_scope)
+            declaration = _infer_variable_declaration(
+                global_scope.circuit, parameter, parameter_name
+            )
             if declaration is None:
                 continue
             if isinstance(declaration, ast.IODeclaration):
-                if declaration.modifier is ast.IOModifier.INPUT:
-                    inputs.append(declaration)
-                else:
-                    outputs.append(declaration)
+                self._global_io_declarations.append(declaration)
             else:
-                variables.append(declaration)
-        return inputs, outputs, variables
+                self._global_classical_declarations.append(declaration)
 
     @property
     def base_classical_register_name(self):
@@ -675,7 +705,8 @@ class QASM3Builder:
         return name
 
     def build_classical_declarations(self):
-        """Return a list of AST nodes declaring all the classical bits and registers.
+        """Extend the global classical declarations with AST nodes declaring all the classical bits
+        and registers.
 
         The behaviour of this function depends on the setting ``alias_classical_registers``. If this
         is ``True``, then the output will be in the same form as the output of
@@ -686,16 +717,22 @@ class QASM3Builder:
 
         This function populates the lookup table ``self._loose_clbit_index_lookup``.
         """
+        global_scope = self.global_scope()
         circuit = self.current_scope().circuit
         if self.alias_classical_registers:
             self._loose_clbit_index_lookup = {
                 bit: index for index, bit in enumerate(circuit.clbits)
             }
-            flat_declaration = self.build_clbit_declaration(
-                len(circuit.clbits),
-                self._reserve_variable_name(ast.Identifier(self.base_classical_register_name)),
+            self._global_classical_declarations.append(
+                self.build_clbit_declaration(
+                    len(circuit.clbits),
+                    self._reserve_variable_name(
+                        ast.Identifier(self.base_classical_register_name), global_scope
+                    ),
+                )
             )
-            return [flat_declaration] + self.build_aliases(circuit.cregs)
+            self._global_classical_declarations.extend(self.build_aliases(circuit.cregs))
+            return
         loose_register_size = 0
         for index, bit in enumerate(circuit.clbits):
             found_bit = circuit.find_bit(bit)
@@ -708,18 +745,20 @@ class QASM3Builder:
                 self._loose_clbit_index_lookup[bit] = loose_register_size
                 loose_register_size += 1
         if loose_register_size > 0:
-            loose = [
+            self._global_classical_declarations.append(
                 self.build_clbit_declaration(
                     loose_register_size,
-                    self._reserve_variable_name(ast.Identifier(self.base_classical_register_name)),
+                    self._reserve_variable_name(
+                        ast.Identifier(self.base_classical_register_name), global_scope
+                    ),
                 )
-            ]
-        else:
-            loose = []
-        return loose + [
-            self.build_clbit_declaration(len(register), self._register_variable(register))
+            )
+        self._global_classical_declarations.extend(
+            self.build_clbit_declaration(
+                len(register), self._register_variable(register, global_scope)
+            )
             for register in circuit.cregs
-        ]
+        )
 
     def build_clbit_declaration(
         self, n_clbits: int, name: ast.Identifier
@@ -736,9 +775,12 @@ class QASM3Builder:
 
     def build_qubit_declarations(self):
         """Return a declaration of all the :obj:`.Qubit`\\ s in the current scope."""
+        global_scope = self.global_scope(assert_=True)
         # Base register
         return ast.QuantumDeclaration(
-            self._reserve_variable_name(ast.Identifier(self.base_quantum_register_name)),
+            self._reserve_variable_name(
+                ast.Identifier(self.base_quantum_register_name), global_scope
+            ),
             ast.Designator(self.build_integer(self.current_scope().circuit.num_qubits)),
         )
 
@@ -746,6 +788,7 @@ class QASM3Builder:
         """Return a list of alias declarations for the given registers.  The registers can be either
         classical or quantum."""
         out = []
+        scope = self.current_scope()
         for register in registers:
             elements = []
             # Greedily consolidate runs of bits into ranges.  We don't bother trying to handle
@@ -784,7 +827,7 @@ class QASM3Builder:
                         ),
                     )
                 )
-            out.append(ast.AliasStatement(self._register_variable(register), elements))
+            out.append(ast.AliasStatement(self._register_variable(register, scope), elements))
         return out
 
     def build_quantum_instructions(self, instructions):
@@ -799,6 +842,9 @@ class QASM3Builder:
                 continue
             if isinstance(instruction.operation, IfElseOp):
                 ret.append(self.build_if_statement(instruction))
+                continue
+            if isinstance(instruction.operation, SwitchCaseOp):
+                ret.extend(self.build_switch_statement(instruction))
                 continue
             # Build the node, ignoring any condition.
             if isinstance(instruction.operation, Gate):
@@ -853,6 +899,44 @@ class QASM3Builder:
         self.pop_scope()
         return ast.BranchingStatement(condition, true_body, false_body)
 
+    def build_switch_statement(
+        self, instruction: CircuitInstruction
+    ) -> Generator[ast.Statement, None, None]:
+        """Build a :obj:`.SwitchCaseOp` into a :class:`.ast.SwitchStatement`."""
+        if ExperimentalFeatures.SWITCH_CASE_V1 not in self.experimental:
+            raise QASM3ExporterError(
+                "'switch' statements are not stabilised in OpenQASM 3 yet."
+                " To enable experimental support, set the flag"
+                " 'ExperimentalFeatures.SWITCH_CASE_V1' in the 'experimental' keyword"
+                " argument of the exporter."
+            )
+        if isinstance(instruction.operation.target, Clbit):
+            target = self.build_single_bit_reference(instruction.operation.target)
+        else:
+            real_target = self._lookup_variable(instruction.operation.target)
+            global_scope = self.global_scope()
+            target = self._reserve_variable_name(
+                ast.Identifier(self._unique_name("switch_dummy", global_scope)), global_scope
+            )
+            self._global_classical_declarations.append(
+                ast.ClassicalDeclaration(ast.IntType(), target, None)
+            )
+            yield ast.AssignmentStatement(target, real_target)
+
+        def case(values, case_block):
+            values = [
+                ast.DefaultCase() if v is CASE_DEFAULT else self.build_integer(v) for v in values
+            ]
+            self.push_scope(case_block, instruction.qubits, instruction.clbits)
+            case_body = self.build_program_block(case_block.data)
+            self.pop_scope()
+            return values, case_body
+
+        yield ast.SwitchStatement(
+            target,
+            (case(values, block) for values, block in instruction.operation.cases_specifier()),
+        )
+
     def build_while_loop(self, instruction: CircuitInstruction) -> ast.WhileLoopStatement:
         """Build a :obj:`.WhileLoopOp` into a :obj:`.ast.WhileLoopStatement`."""
         condition = self.build_eqcondition(instruction.operation.condition)
@@ -866,12 +950,13 @@ class QASM3Builder:
         """Build a :obj:`.ForLoopOp` into a :obj:`.ast.ForLoopStatement`."""
         indexset, loop_parameter, loop_circuit = instruction.operation.params
         self.push_scope(loop_circuit, instruction.qubits, instruction.clbits)
+        scope = self.current_scope()
         if loop_parameter is None:
             # The loop parameter is implicitly declared by the ``for`` loop (see also
             # _infer_parameter_declaration), so it doesn't matter that we haven't declared this.
-            loop_parameter_ast = self._reserve_variable_name(ast.Identifier("_"))
+            loop_parameter_ast = self._reserve_variable_name(ast.Identifier("_"), scope)
         else:
-            loop_parameter_ast = self._register_variable(loop_parameter)
+            loop_parameter_ast = self._register_variable(loop_parameter, scope)
         if isinstance(indexset, range):
             # QASM 3 uses inclusive ranges on both ends, unlike Python.
             indexset_ast = ast.Range(

--- a/qiskit/qasm3/exporter.py
+++ b/qiskit/qasm3/exporter.py
@@ -905,7 +905,7 @@ class QASM3Builder:
         """Build a :obj:`.SwitchCaseOp` into a :class:`.ast.SwitchStatement`."""
         if ExperimentalFeatures.SWITCH_CASE_V1 not in self.experimental:
             raise QASM3ExporterError(
-                "'switch' statements are not stabilised in OpenQASM 3 yet."
+                "'switch' statements are not stabilized in OpenQASM 3 yet."
                 " To enable experimental support, set the flag"
                 " 'ExperimentalFeatures.SWITCH_CASE_V1' in the 'experimental' keyword"
                 " argument of the exporter."

--- a/qiskit/qasm3/printer.py
+++ b/qiskit/qasm3/printer.py
@@ -15,7 +15,8 @@
 import io
 from typing import Sequence
 
-from . import ast
+from . import ast, ExperimentalFeatures
+from .exceptions import QASM3ExporterError
 
 
 class BasicPrinter:
@@ -40,7 +41,14 @@ class BasicPrinter:
     # The visitor names include the class names, so they mix snake_case with PascalCase.
     # pylint: disable=invalid-name
 
-    def __init__(self, stream: io.TextIOBase, *, indent: str, chain_else_if: bool = False):
+    def __init__(
+        self,
+        stream: io.TextIOBase,
+        *,
+        indent: str,
+        chain_else_if: bool = False,
+        experimental: ExperimentalFeatures = ExperimentalFeatures(0),
+    ):
         """
         Args:
             stream (io.TextIOBase): the stream that the output will be written to.
@@ -76,6 +84,7 @@ class BasicPrinter:
         self.indent = indent
         self._current_indent = 0
         self._chain_else_if = chain_else_if
+        self._experimental = experimental
 
     def visit(self, node: ast.ASTNode) -> None:
         """Visit this node of the AST, printing it out to the stream in this class instance.
@@ -156,6 +165,11 @@ class BasicPrinter:
     def _visit_FloatType(self, node: ast.FloatType) -> None:
         self.stream.write(f"float[{self._FLOAT_WIDTH_LOOKUP[node]}]")
 
+    def _visit_IntType(self, node: ast.IntType) -> None:
+        self.stream.write("int")
+        if node.size is not None:
+            self.stream.write(f"[{node.size}]")
+
     def _visit_BitArrayType(self, node: ast.BitArrayType) -> None:
         self.stream.write(f"bit[{node.size}]")
 
@@ -235,6 +249,13 @@ class BasicPrinter:
         if node.initializer is not None:
             self.stream.write(" = ")
             self.visit(node.initializer)
+        self._end_statement()
+
+    def _visit_AssignmentStatement(self, node: ast.AssignmentStatement) -> None:
+        self._start_line()
+        self.visit(node.lvalue)
+        self.stream.write(" = ")
+        self.visit(node.rvalue)
         self._end_statement()
 
     def _visit_IODeclaration(self, node: ast.IODeclaration) -> None:
@@ -430,3 +451,44 @@ class BasicPrinter:
         self.stream.write(") ")
         self.visit(node.body)
         self._end_line()
+
+    def _visit_SwitchStatement(self, node: ast.SwitchStatement) -> None:
+        if ExperimentalFeatures.SWITCH_CASE_V1 not in self._experimental:
+            raise QASM3ExporterError(
+                "'switch' statements are not stabilised in OpenQASM 3 yet."
+                " To enable experimental support, set the flag"
+                " 'ExperimentalFeatures.SWITCH_CASE_V1' in the 'experimental' keyword"
+                " argument of the printer."
+            )
+        self._start_line()
+        self.stream.write("switch (")
+        self.visit(node.target)
+        self.stream.write(") {")
+        self._end_line()
+        self._current_indent += 1
+        for labels, case in node.cases:
+            if not labels:
+                continue
+            for label in labels[:-1]:
+                self._start_line()
+                self.stream.write("case ")
+                self.visit(label)
+                self.stream.write(":")
+                self._end_line()
+            self._start_line()
+            if isinstance(labels[-1], ast.DefaultCase):
+                self.visit(labels[-1])
+            else:
+                self.stream.write("case ")
+                self.visit(labels[-1])
+            self.stream.write(": ")
+            self.visit(case)
+            self._end_line()
+            self._write_statement("break")
+        self._current_indent -= 1
+        self._start_line()
+        self.stream.write("}")
+        self._end_line()
+
+    def _visit_DefaultCase(self, _node: ast.DefaultCase) -> None:
+        self.stream.write("default")

--- a/qiskit/qasm3/printer.py
+++ b/qiskit/qasm3/printer.py
@@ -15,7 +15,8 @@
 import io
 from typing import Sequence
 
-from . import ast, ExperimentalFeatures
+from . import ast
+from .experimental import ExperimentalFeatures
 from .exceptions import QASM3ExporterError
 
 

--- a/test/python/qasm3/test_export.py
+++ b/test/python/qasm3/test_export.py
@@ -23,8 +23,9 @@ from ddt import ddt, data
 
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit, transpile
 from qiskit.circuit import Parameter, Qubit, Clbit, Instruction, Gate, Delay, Barrier
+from qiskit.circuit.controlflow import CASE_DEFAULT
 from qiskit.test import QiskitTestCase
-from qiskit.qasm3 import Exporter, dumps, dump, QASM3ExporterError
+from qiskit.qasm3 import Exporter, dumps, dump, QASM3ExporterError, ExperimentalFeatures
 from qiskit.qasm3.exporter import QASM3Builder
 from qiskit.qasm3.printer import BasicPrinter
 from qiskit.qasm import pi
@@ -1774,6 +1775,268 @@ if (c[0] == 1) {
   barrier q[0], q[1];
 }"""
         self.assertEqual(dumps(qc).strip(), expected.strip())
+
+
+class TestExperimentalFeatures(QiskitTestCase):
+    """Tests of features that are hidden behind experimental flags."""
+
+    maxDiff = None
+
+    def test_switch_forbidden_without_flag(self):
+        """Omitting the feature flag should raise an error."""
+        case = QuantumCircuit(1)
+        circuit = QuantumCircuit(1, 1)
+        circuit.switch(circuit.clbits[0], [((True, False), case)], [0], [])
+        with self.assertRaisesRegex(QASM3ExporterError, "'switch' statements are not stabilised"):
+            dumps(circuit)
+
+    def test_switch_clbit(self):
+        """Test that a switch statement can be constructed with a bit as a condition."""
+        qubit = Qubit()
+        clbit = Clbit()
+        case1 = QuantumCircuit([qubit, clbit])
+        case1.x(0)
+        case2 = QuantumCircuit([qubit, clbit])
+        case2.z(0)
+        circuit = QuantumCircuit([qubit, clbit])
+        circuit.switch(clbit, [(True, case1), (False, case2)], [0], [0])
+
+        test = dumps(circuit, experimental=ExperimentalFeatures.SWITCH_CASE_V1)
+        expected = """\
+OPENQASM 3;
+include "stdgates.inc";
+bit[1] _loose_clbits;
+qubit[1] _all_qubits;
+switch (_loose_clbits[0]) {
+  case 1: {
+    x _all_qubits[0];
+  }
+  break;
+  case 0: {
+    z _all_qubits[0];
+  }
+  break;
+}
+"""
+        self.assertEqual(test, expected)
+
+    def test_switch_register(self):
+        """Test that a switch statement can be constructed with a register as a condition."""
+        qubit = Qubit()
+        creg = ClassicalRegister(2, "c")
+        case1 = QuantumCircuit([qubit], creg)
+        case1.x(0)
+        case2 = QuantumCircuit([qubit], creg)
+        case2.y(0)
+        case3 = QuantumCircuit([qubit], creg)
+        case3.z(0)
+
+        circuit = QuantumCircuit([qubit], creg)
+        circuit.switch(creg, [(0, case1), (1, case2), (2, case3)], [0], circuit.clbits)
+
+        test = dumps(circuit, experimental=ExperimentalFeatures.SWITCH_CASE_V1)
+        expected = """\
+OPENQASM 3;
+include "stdgates.inc";
+bit[2] c;
+int switch_dummy;
+qubit[1] _all_qubits;
+switch_dummy = c;
+switch (switch_dummy) {
+  case 0: {
+    x _all_qubits[0];
+  }
+  break;
+  case 1: {
+    y _all_qubits[0];
+  }
+  break;
+  case 2: {
+    z _all_qubits[0];
+  }
+  break;
+}
+"""
+        self.assertEqual(test, expected)
+
+    def test_switch_with_default(self):
+        """Test that a switch statement can be constructed with a default case at the end."""
+        qubit = Qubit()
+        creg = ClassicalRegister(2, "c")
+        case1 = QuantumCircuit([qubit], creg)
+        case1.x(0)
+        case2 = QuantumCircuit([qubit], creg)
+        case2.y(0)
+        case3 = QuantumCircuit([qubit], creg)
+        case3.z(0)
+
+        circuit = QuantumCircuit([qubit], creg)
+        circuit.switch(creg, [(0, case1), (1, case2), (CASE_DEFAULT, case3)], [0], circuit.clbits)
+
+        test = dumps(circuit, experimental=ExperimentalFeatures.SWITCH_CASE_V1)
+        expected = """\
+OPENQASM 3;
+include "stdgates.inc";
+bit[2] c;
+int switch_dummy;
+qubit[1] _all_qubits;
+switch_dummy = c;
+switch (switch_dummy) {
+  case 0: {
+    x _all_qubits[0];
+  }
+  break;
+  case 1: {
+    y _all_qubits[0];
+  }
+  break;
+  default: {
+    z _all_qubits[0];
+  }
+  break;
+}
+"""
+        self.assertEqual(test, expected)
+
+    def test_switch_multiple_cases_to_same_block(self):
+        """Test that it is possible to add multiple cases that apply to the same block, if they are
+        given as a compound value.  This is an allowed special case of block fall-through."""
+        qubit = Qubit()
+        creg = ClassicalRegister(2, "c")
+        case1 = QuantumCircuit([qubit], creg)
+        case1.x(0)
+        case2 = QuantumCircuit([qubit], creg)
+        case2.y(0)
+
+        circuit = QuantumCircuit([qubit], creg)
+        circuit.switch(creg, [(0, case1), ((1, 2), case2)], [0], circuit.clbits)
+
+        test = dumps(circuit, experimental=ExperimentalFeatures.SWITCH_CASE_V1)
+        expected = """\
+OPENQASM 3;
+include "stdgates.inc";
+bit[2] c;
+int switch_dummy;
+qubit[1] _all_qubits;
+switch_dummy = c;
+switch (switch_dummy) {
+  case 0: {
+    x _all_qubits[0];
+  }
+  break;
+  case 1:
+  case 2: {
+    y _all_qubits[0];
+  }
+  break;
+}
+"""
+        self.assertEqual(test, expected)
+
+    def test_multiple_switches_dont_clash_on_dummy(self):
+        """Test that having more than one switch statement in the circuit doesn't cause naming
+        clashes in the dummy integer value used."""
+        qubit = Qubit()
+        creg = ClassicalRegister(2, "switch_dummy")
+        case1 = QuantumCircuit([qubit], creg)
+        case1.x(0)
+        case2 = QuantumCircuit([qubit], creg)
+        case2.y(0)
+
+        circuit = QuantumCircuit([qubit], creg)
+        circuit.switch(creg, [(0, case1), ((1, 2), case2)], [0], circuit.clbits)
+        circuit.switch(creg, [(0, case1), ((1, 2), case2)], [0], circuit.clbits)
+
+        test = dumps(circuit, experimental=ExperimentalFeatures.SWITCH_CASE_V1)
+        expected = """\
+OPENQASM 3;
+include "stdgates.inc";
+bit[2] switch_dummy;
+int switch_dummy__generated0;
+int switch_dummy__generated1;
+qubit[1] _all_qubits;
+switch_dummy__generated0 = switch_dummy;
+switch (switch_dummy__generated0) {
+  case 0: {
+    x _all_qubits[0];
+  }
+  break;
+  case 1:
+  case 2: {
+    y _all_qubits[0];
+  }
+  break;
+}
+switch_dummy__generated1 = switch_dummy;
+switch (switch_dummy__generated1) {
+  case 0: {
+    x _all_qubits[0];
+  }
+  break;
+  case 1:
+  case 2: {
+    y _all_qubits[0];
+  }
+  break;
+}
+"""
+        self.assertEqual(test, expected)
+
+    def test_switch_nested_in_if(self):
+        """Test that the switch statement works when in a nested scope, including the dummy
+        classical variable being declared globally.  This isn't necessary in the OQ3 language, but
+        it is universally valid and the IBM QSS stack prefers that.  They're our primary consumers
+        of OQ3 strings, so it's best to play nicely with them."""
+        qubit = Qubit()
+        creg = ClassicalRegister(2, "c")
+        case1 = QuantumCircuit([qubit], creg)
+        case1.x(0)
+        case2 = QuantumCircuit([qubit], creg)
+        case2.y(0)
+
+        body = QuantumCircuit([qubit], creg)
+        body.switch(creg, [(0, case1), ((1, 2), case2)], [0], body.clbits)
+
+        circuit = QuantumCircuit([qubit], creg)
+        circuit.if_else((creg, 1), body.copy(), body, [0], body.clbits)
+
+        test = dumps(circuit, experimental=ExperimentalFeatures.SWITCH_CASE_V1)
+        expected = """\
+OPENQASM 3;
+include "stdgates.inc";
+bit[2] c;
+int switch_dummy;
+int switch_dummy__generated0;
+qubit[1] _all_qubits;
+if (c == 1) {
+  switch_dummy = c;
+  switch (switch_dummy) {
+    case 0: {
+      x _all_qubits[0];
+    }
+    break;
+    case 1:
+    case 2: {
+      y _all_qubits[0];
+    }
+    break;
+  }
+} else {
+  switch_dummy__generated0 = c;
+  switch (switch_dummy__generated0) {
+    case 0: {
+      x _all_qubits[0];
+    }
+    break;
+    case 1:
+    case 2: {
+      y _all_qubits[0];
+    }
+    break;
+  }
+}
+"""
+        self.assertEqual(test, expected)
 
 
 @ddt

--- a/test/python/qasm3/test_export.py
+++ b/test/python/qasm3/test_export.py
@@ -1787,7 +1787,7 @@ class TestExperimentalFeatures(QiskitTestCase):
         case = QuantumCircuit(1)
         circuit = QuantumCircuit(1, 1)
         circuit.switch(circuit.clbits[0], [((True, False), case)], [0], [])
-        with self.assertRaisesRegex(QASM3ExporterError, "'switch' statements are not stabilised"):
+        with self.assertRaisesRegex(QASM3ExporterError, "'switch' statements are not stabilized"):
             dumps(circuit)
 
     def test_switch_clbit(self):


### PR DESCRIPTION
### Summary

This changes Terra's OpenQASM 3 exporter to add support for the IBM QSS `switch` extension to the OpenQASM 3 language.  This is currently only a pull request to the OpenQASM 3 specification, so its syntax might be subject to some amount of change, and it is hidden behind an "experimental" flag in the exporter.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

See openqasm/openqasm#463.  Since the PR is not formally accepted yet, it is possible that the syntax might change slightly.  Terra is adding support for the feature eagerly, before acceptance, but essentially hidden behind a "vendor" flag (c.f. web browsers' `--moz`, `--webkit` etc CSS prefixes) until the proposal is formally accepted into the language.  The experimental feature flag is versioned as a precaution, so we can eagerly add support for new syntaxes if they are suggested, but the merge process still takes time.  Without any flag specified, Terra will not produce any extra-spec OpenQASM 3, but instead will raise an exception.

---

~Note: before merge, I need to re-verify that this can pass all the way through the IBM QSS stack.  I last did that in December, so there's a chance that I've screwed something up / things have changed a little since.~