### PR TITLE
Don't cancel GHA runs on subsequent push events

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,7 +5,9 @@ on:
     branches: ['main']
 concurrency:
   group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}-${{ github.workflow }}
-  cancel-in-progress: true
+  # Only cancel in PR mode.  In push mode, don't cancel so we don't see spurious test "failures",
+  # and we get coverage reports on Coveralls for every push.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   coverage:
     name: Coverage

--- a/.github/workflows/neko.yml
+++ b/.github/workflows/neko.yml
@@ -5,7 +5,8 @@ on:
     branches: ['main', 'stable/*']
 concurrency:
   group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}-${{ github.workflow }}
-  cancel-in-progress: true
+  # Only cancel in PR mode.  In push mode, don't cancel so we don't see spurious test "failures".
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   neko:
     name: Qiskit Neko Integration Tests


### PR DESCRIPTION
### Summary

With our switch to using the GitHub merge queue with speculative merging, it's now possible for us to have two push events to a protected branch (like `main`) within a couple of minutes.  If this happens, the eager cancellation rules we have set for the coverage and Neko runs in GHA trigger, causing a spurious build failure to appear in the commit logs, and for the coverage history to be lost for one commit.

Instead, we can set the cancel-on-update behaviour to only trigger on PR sync events, not branch-push events.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

We also likely want to set the workflows to only trigger on pushes to Qiskit repos so users' notifications don't get spammed, and we're not just burning the planet running unnecessary CI, but that's a separate logical change.