### PR TITLE
`AdaptVQE` threshold improvements

### DIFF
--- a/qiskit/algorithms/minimum_eigensolvers/adapt_vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/adapt_vqe.py
@@ -136,7 +136,7 @@ class AdaptVQE(VariationalAlgorithm, MinimumEigensolver):
 
     @property
     @deprecate_func(
-        since="0.23.0",
+        since="0.24.0",
         pending=True,
         is_property=True,
         additional_msg="Instead, use the gradient_threshold attribute.",
@@ -150,6 +150,12 @@ class AdaptVQE(VariationalAlgorithm, MinimumEigensolver):
         return self.gradient_threshold
 
     @threshold.setter
+    @deprecate_func(
+        since="0.24.0",
+        pending=True,
+        is_property=True,
+        additional_msg="Instead, use the gradient_threshold attribute.",
+    )
     def threshold(self, threshold: float) -> None:
         self.gradient_threshold = threshold
 

--- a/qiskit/algorithms/minimum_eigensolvers/adapt_vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/adapt_vqe.py
@@ -18,7 +18,6 @@ from enum import Enum
 
 import re
 import logging
-import warnings
 from typing import Any
 
 import numpy as np
@@ -28,7 +27,7 @@ from qiskit.algorithms.list_or_dict import ListOrDict
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 from qiskit.opflow import OperatorBase, PauliSumOp
 from qiskit.circuit.library import EvolvedOperatorAnsatz
-from qiskit.utils.deprecation import deprecate_arg
+from qiskit.utils.deprecation import deprecate_arg, deprecate_func
 from qiskit.utils.validation import validate_min
 
 from .minimum_eigensolver import MinimumEigensolver
@@ -136,28 +135,22 @@ class AdaptVQE(VariationalAlgorithm, MinimumEigensolver):
         self._excitation_list: list[OperatorBase] = []
 
     @property
+    @deprecate_func(
+        since="0.23.0",
+        pending=True,
+        is_property=True,
+        additional_msg="Instead, use the gradient_threshold attribute.",
+    )
     def threshold(self) -> float:
         """The threshold for the gradients.
 
         Once all gradients have an absolute value smaller than this threshold, the algorithm has
         converged and terminates.
         """
-        msg = (
-            "threshold is pending deprecated as of qiskit-terra 0.24.0. It will be marked "
-            "deprecated in a future release, and then removed no earlier than 3 months after the "
-            "release date. Instead, use the gradient_threshold attribute."
-        )
-        warnings.warn(msg, category=PendingDeprecationWarning, stacklevel=3)
         return self.gradient_threshold
 
     @threshold.setter
     def threshold(self, threshold: float) -> None:
-        msg = (
-            "threshold is pending deprecated as of qiskit-terra 0.24.0. It will be marked "
-            "deprecated in a future release, and then removed no earlier than 3 months after the "
-            "release date. Instead, use the gradient_threshold attribute."
-        )
-        warnings.warn(msg, category=PendingDeprecationWarning, stacklevel=3)
         self.gradient_threshold = threshold
 
     @property

--- a/qiskit/algorithms/minimum_eigensolvers/adapt_vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/adapt_vqe.py
@@ -182,7 +182,7 @@ class AdaptVQE(VariationalAlgorithm, MinimumEigensolver):
     def _compute_gradients(
         self,
         theta: list[float],
-        operator: OperatorBase,
+        operator: BaseOperator | OperatorBase,
     ) -> list[tuple[complex, dict[str, Any]]]:
         """
         Computes the gradients for all available excitation operators.

--- a/qiskit/algorithms/minimum_eigensolvers/adapt_vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/adapt_vqe.py
@@ -85,11 +85,14 @@ class AdaptVQE(VariationalAlgorithm, MinimumEigensolver):
     Attributes:
         solver: a :class:`~.VQE` instance used internally to compute the minimum eigenvalues.
             It is a requirement that the :attr:`~.VQE.ansatz` of this solver is of type
-            :class:`qiskit.circuit.library.EvolvedOperatorAnsatz`.
+            :class:`~qiskit.circuit.library.EvolvedOperatorAnsatz`.
         gradient_threshold: once all gradients have an absolute value smaller than this threshold,
             the algorithm has converged and terminates.
         eigenvalue_threshold: once the eigenvalue has changed by less than this threshold from one
-            iteration to the next, the algorithm has converged and terminates.
+            iteration to the next, the algorithm has converged and terminates. When this case
+            occurs, the excitation included in the final iteration did not result in a significant
+            improvement of the eigenvalue and, thus, the results from this iteration are not
+            considered.
         max_iterations: the maximum number of iterations for the adaptive loop. If ``None``, the
             algorithm is not bound in its number of iterations.
     """
@@ -113,11 +116,14 @@ class AdaptVQE(VariationalAlgorithm, MinimumEigensolver):
         Args:
             solver: a :class:`~.VQE` instance used internally to compute the minimum eigenvalues.
                 It is a requirement that the :attr:`~.VQE.ansatz` of this solver is of type
-                :class:`qiskit.circuit.library.EvolvedOperatorAnsatz`.
+                :class:`~qiskit.circuit.library.EvolvedOperatorAnsatz`.
             gradient_threshold: once all gradients have an absolute value smaller than this
                 threshold, the algorithm has converged and terminates.
             eigenvalue_threshold: once the eigenvalue has changed by less than this threshold from
-                one iteration to the next, the algorithm has converged and terminates.
+                one iteration to the next, the algorithm has converged and terminates. When this
+                case occurs, the excitation included in the final iteration did not result in a
+                significant improvement of the eigenvalue and, thus, the results from this iteration
+                are not considered.
             max_iterations: the maximum number of iterations for the adaptive loop. If ``None``, the
                 algorithm is not bound in its number of iterations.
             threshold: once all gradients have an absolute value smaller than this threshold, the

--- a/releasenotes/notes/adapt-vqe-thresholds-239ed9f250c63e71.yaml
+++ b/releasenotes/notes/adapt-vqe-thresholds-239ed9f250c63e71.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Adds the new :attr:`~qiskit.algorithms.minimum_eigensolvers.AdaptVQE.eigenvalue_threshold`
+    setting which allows configuring a new kind of threshold to terminate the algorithm once
+    the eigenvalue changes less than a set value.
+  - |
+    Adds the new :attr:`~qiskit.algorithms.minimum_eigensolvers.AdaptVQE.gradient_threshold`
+    setting which will replace the :attr:`~qiskit.algorithms.minimum_eigensolvers.AdaptVQE.threshold`
+    in the future. Using the latter will now log a ``PendingDeprecationWarning``.

--- a/releasenotes/notes/adapt-vqe-thresholds-239ed9f250c63e71.yaml
+++ b/releasenotes/notes/adapt-vqe-thresholds-239ed9f250c63e71.yaml
@@ -7,4 +7,4 @@ features:
   - |
     Adds the new :attr:`~qiskit.algorithms.minimum_eigensolvers.AdaptVQE.gradient_threshold`
     setting which will replace the :attr:`~qiskit.algorithms.minimum_eigensolvers.AdaptVQE.threshold`
-    in the future. Using the latter will now log a ``PendingDeprecationWarning``.
+    in the future.

--- a/test/python/algorithms/minimum_eigensolvers/test_adapt_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_adapt_vqe.py
@@ -96,6 +96,21 @@ class TestAdaptVQE(QiskitAlgorithmsTestCase):
         self.assertAlmostEqual(res.eigenvalue, expected_eigenvalue, places=6)
         np.testing.assert_allclose(res.eigenvalue_history, [expected_eigenvalue], rtol=1e-6)
 
+    def test_with_quantum_info(self):
+        """Test behavior with quantum_info-based operators."""
+        ansatz = EvolvedOperatorAnsatz(
+            [op.primitive for op in self.excitation_pool],
+            initial_state=self.initial_state,
+        )
+
+        calc = AdaptVQE(VQE(Estimator(), ansatz, self.optimizer))
+        res = calc.compute_minimum_eigenvalue(operator=self.h2_op.primitive)
+
+        expected_eigenvalue = -1.85727503
+
+        self.assertAlmostEqual(res.eigenvalue, expected_eigenvalue, places=6)
+        np.testing.assert_allclose(res.eigenvalue_history, [expected_eigenvalue], rtol=1e-6)
+
     def test_converged(self):
         """Test to check termination criteria"""
         calc = AdaptVQE(

--- a/test/python/algorithms/minimum_eigensolvers/test_adapt_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_adapt_vqe.py
@@ -141,6 +141,17 @@ class TestAdaptVQE(QiskitAlgorithmsTestCase):
 
         self.assertEqual(res.termination_criterion, TerminationCriterion.CONVERGED)
 
+    def test_threshold_attribute(self):
+        """Test the (pending deprecated) threshold attribute"""
+        with self.assertWarns(PendingDeprecationWarning):
+            calc = AdaptVQE(
+                VQE(Estimator(), self.ansatz, self.optimizer),
+                threshold=1e-3,
+            )
+            res = calc.compute_minimum_eigenvalue(operator=self.h2_op)
+
+            self.assertEqual(res.termination_criterion, TerminationCriterion.CONVERGED)
+
     @data(
         ([1, 1], True),
         ([1, 11], False),

--- a/test/python/algorithms/minimum_eigensolvers/test_adapt_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_adapt_vqe.py
@@ -150,7 +150,7 @@ class TestAdaptVQE(QiskitAlgorithmsTestCase):
 
         calc = AdaptVQE(
             VQE(Estimator(), ansatz, self.optimizer),
-            eigenvalue_threshold=1e-3,
+            eigenvalue_threshold=1,
         )
         res = calc.compute_minimum_eigenvalue(operator)
 

--- a/test/python/algorithms/minimum_eigensolvers/test_adapt_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_adapt_vqe.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2022.
+# (C) Copyright IBM 2022, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -100,7 +100,7 @@ class TestAdaptVQE(QiskitAlgorithmsTestCase):
         """Test to check termination criteria"""
         calc = AdaptVQE(
             VQE(Estimator(), self.ansatz, self.optimizer),
-            threshold=1e-3,
+            gradient_threshold=1e-3,
         )
         res = calc.compute_minimum_eigenvalue(operator=self.h2_op)
 

--- a/test/python/algorithms/minimum_eigensolvers/test_adapt_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_adapt_vqe.py
@@ -142,8 +142,8 @@ class TestAdaptVQE(QiskitAlgorithmsTestCase):
         )
         ansatz = EvolvedOperatorAnsatz(
             [
-                PauliSumOp.from_list([("XY", 0.5)]),
-                PauliSumOp.from_list([("YX", 0.5)]),
+                PauliSumOp.from_list([("YZ", 0.4)]),
+                PauliSumOp.from_list([("ZY", 0.5)]),
             ],
             initial_state=QuantumCircuit(2),
         )

--- a/test/python/algorithms/minimum_eigensolvers/test_adapt_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_adapt_vqe.py
@@ -127,22 +127,10 @@ class TestAdaptVQE(QiskitAlgorithmsTestCase):
         )
         ansatz = EvolvedOperatorAnsatz(
             [
-                PauliSumOp(
-                    SparsePauliOp(
-                        ["XY"],
-                        coeffs=[0.5],
-                    ),
-                    coeff=1.0,
-                ),
-                PauliSumOp(
-                    SparsePauliOp(
-                        ["YX"],
-                        coeffs=[0.5],
-                    ),
-                    coeff=1.0,
-                ),
+                PauliSumOp.from_list([("XY", 0.5)]),
+                PauliSumOp.from_list([("YX", 0.5)]),
             ],
-            initial_state=QuantumCircuit(QuantumRegister(2)),
+            initial_state=QuantumCircuit(2),
         )
 
         calc = AdaptVQE(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

- adds a new `eigenvalue_threshold` setting to the `AdaptVQE` which allows a more fine-tuned control of the convergence based on a minimal change of the eigenvalue with respect to an increasing ansatz
- renames the previously existing `threshold` attribute of the `AdaptVQE` to be called `gradient_threshold` in order to disambiguate it from the other (new) threshold mentioned above (using the old attribute will now log a `PendingDeprecationWarning`)

### Details and comments


