### PR TITLE
Switch from Qiskit Bot notificiations to GitHub code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,17 +23,32 @@
 * @Qiskit/terra-core
 
 # Qiskit folders (also their corresponding tests)
-algorithms/           @Qiskit/terra-core @woodsp-ibm @ElePT
-opflow/               @Qiskit/terra-core @woodsp-ibm @ikkoham
-qiskit/utils/         @Qiskit/terra-core @woodsp-ibm
-providers/            @Qiskit/terra-core @jyu00
-quantum_info/         @Qiskit/terra-core @ikkoham
-qpy/                  @Qiskit/terra-core
-pulse/                @Qiskit/terra-core @eggerdj @wshanks
-synthesis/            @Qiskit/terra-core @alexanderivrii @ShellyGarion
-scheduler/            @Qiskit/terra-core @eggerdj @wshanks
-visualization/        @Qiskit/terra-core @nonhermitian
-primitives/           @Qiskit/terra-core @ikkoham @t-imamichi
+.azure/                @Qiskit/terra-core @Eric-Arellano
+.github/               @Qiskit/terra-core @Eric-Arellano
+algorithms/            @Qiskit/terra-core @woodsp-ibm @ElePT
+circuit/library/       @Qiskit/terra-core @Cryoris @ajavadia
+docs/                  @Qiskit/terra-core @javabster @HuangJunye @Eric-Arellano
+opflow/                @Qiskit/terra-core @woodsp-ibm @ikkoham @Cryoris
+qiskit/utils/          @Qiskit/terra-core @woodsp-ibm
+providers/             @Qiskit/terra-core @jyu00
+quantum_info/          @Qiskit/terra-core @ikkoham
+qpy/                   @Qiskit/terra-core @mtreinish @nkanazawa1989
+primitives/            @Qiskit/terra-core @ikkoham @t-imamichi @ajavadia @levbishop
+pulse/                 @Qiskit/terra-core @eggerdj @wshanks @nkanazawa1989
+synthesis/             @Qiskit/terra-core @alexanderivrii @ShellyGarion
+scheduler/             @Qiskit/terra-core @eggerdj @wshanks @nkanazawa1989
+visualization/         @Qiskit/terra-core @nonhermitian
+visualization/pulse_v2 @Qiskit/terra-core @nonhermitian @nkanazawa1989
+visualization/timeline @Qiskit/terra-core @nonhermitian @nkanazawa1989
+
+# Specific files / globs.
+*.rs                             @Qiskit/terra-core @mtreinish @kevinhartman @Eric-Arellano
+Cargo*                           @Qiskit/terra-core @mtreinish @kevinhartman @Eric-Arellano
+synthesis/two_qubit_decompose.py @Qiskit/terra-core @levbishop
+utils/run_circuits.py            @Qiskit/terra-core @woodsp-ibm
+utils/quantum_instance.py        @Qiskit/terra-core @woodsp-ibm
+utils/quantum_instance.py        @Qiskit/terra-core @woodsp-ibm
+
 # Override the release notes directories to have _no_ code owners, so any review
 # from somebody with write access is acceptable.
 /releasenotes/notes

--- a/qiskit_bot.yaml
+++ b/qiskit_bot.yaml
@@ -1,48 +1,6 @@
 ---
 notifications:
-    ".*":
-        - "@Qiskit/terra-core"
-    "visualization/pulse_v2":
-        - "@nkanazawa1989"
-    "visualization/timeline":
-        - "@nkanazawa1989"
-    "pulse":
-        - "@nkanazawa1989"
-    "scheduler":
-        - "@nkanazawa1989"
-    "qpy":
-        - "@mtreinish"
-        - "@nkanazawa1989"
-    "two_qubit_decompose":
-        - "@levbishop"
-    "quantum_info":
-        - "@ikkoham"
-    "utils/run_circuits":
-        - "@woodsp-ibm"
-    "utils/quantum_instance":
-        - "@woodsp-ibm"
-    "opflow":
-        - "@woodsp-ibm"
-        - "@Cryoris"
-    "algorithms":
-        - "@ElePT"
-        - "@woodsp-ibm"
-    "circuit/library":
-        - "@Cryoris"
-        - "@ajavadia"
-    "primitives":
-        - "@ikkoham"
-        - "@t-imamichi"
-        - "@ajavadia"
-        - "@levbishop"
-    ".*\\.rs$|^Cargo":
-        - "@mtreinish"
-        - "@kevinhartman"
-        - "@Eric-Arellano"
     "(?!.*pulse.*)\\bvisualization\\b":
         - "@enavarro51"
-    "^docs/":
-        - "@javabster"
-        - "@HuangJunye"
-        - "@Eric-Arellano"
+
 always_notify: true


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

We currently have two ways of notifying developers to changes relevant to them:

1. GitHub code owners
2. The Qiskit bot, which leaves a comment and `@`s people

We've discussed in the dev meeting that it's frustrating the bot `@` mentions, which is the highest level of notification. Instead, GitHub code owners will only notify that a review is requested.

Generally, it's also tedious to maintain two separate but related lists, e.g. https://github.com/Qiskit/qiskit-terra/pull/9923.

### Details and comments

The major limitation of code owners is that you must have write access for it to work. I checked that every one migrated is a member of Qiskit, other than `@enavarro51`, who is kept with the Qiskit Bot.

This PR also means that more people will be able to approve PRs than before. There were some rules where people were notified but not given ownership, such as the `docs/` folder with me, Abby, and Junye.
