### PR TITLE
Add support to `switch` in `transpile`

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -29,7 +29,7 @@ from typing import Generator, Any, List
 import numpy as np
 import rustworkx as rx
 
-from qiskit.circuit import ControlFlowOp, ForLoopOp, IfElseOp, WhileLoopOp
+from qiskit.circuit import ControlFlowOp, ForLoopOp, IfElseOp, WhileLoopOp, SwitchCaseOp
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit.quantumregister import QuantumRegister, Qubit
 from qiskit.circuit.classicalregister import ClassicalRegister, Clbit
@@ -700,38 +700,31 @@ class DAGCircuit:
             new_condition = (new_creg, new_cond_val)
         return new_condition
 
-    def _map_condition_with_import(self, op, wire_map, creg_map):
-        """Map the condition in ``op`` to its counterpart in ``self`` using ``wire_map`` and
-        ``creg_map`` as lookup caches.  All single-bit conditions should have a cache hit in the
-        ``wire_map``, but registers may involve a full linear search the first time they are
-        encountered.  ``creg_map`` is mutated by this function.  ``wire_map`` is not; it is an error
-        if a wire is not in the map.
+    def _map_classical_resource_with_import(self, resource, wire_map, creg_map):
+        """Map the classical ``resource`` (a bit or register) in its counterpart in ``self`` using
+        ``wire_map`` and ``creg_map`` as lookup caches.  All single-bit conditions should have a
+        cache hit in the ``wire_map``, but registers may involve a full linear search the first time
+        they are encountered.  ``creg_map`` is mutated by this function.  ``wire_map`` is not; it is
+        an error if a wire is not in the map.
 
-        This is different to ``_map_condition`` because it always succeeds; since the mapping for
-        all wires in the condition is assumed to exist, there can be no fragmented registers.  If
-        there is no matching register (has the same bits in the same order) in ``self``, a new
-        register alias is added to represent the condition.  This does not change the bits available
-        to ``self``, it just adds a new aliased grouping of them."""
-        op_condition = getattr(op, "condition", None)
-        if op_condition is None:
-            return op
-        new_op = copy.copy(op)
-        target, value = op_condition
-        if isinstance(target, Clbit):
-            new_op.condition = (wire_map[target], value)
-        else:
-            if target.name not in creg_map:
-                mapped_bits = [wire_map[bit] for bit in target]
-                for our_creg in self.cregs.values():
-                    if mapped_bits == list(our_creg):
-                        new_target = our_creg
-                        break
-                else:
-                    new_target = ClassicalRegister(bits=[wire_map[bit] for bit in target])
-                    self.add_creg(new_target)
-                creg_map[target.name] = new_target
-            new_op.condition = (creg_map[target.name], value)
-        return new_op
+        This is different to the logic in ``_map_condition`` because it always succeeds; since the
+        mapping for all wires in the condition is assumed to exist, there can be no fragmented
+        registers.  If there is no matching register (has the same bits in the same order) in
+        ``self``, a new register alias is added to represent the condition.  This does not change
+        the bits available to ``self``, it just adds a new aliased grouping of them."""
+        if isinstance(resource, Clbit):
+            return wire_map[resource]
+        if resource.name not in creg_map:
+            mapped_bits = [wire_map[bit] for bit in resource]
+            for our_creg in self.cregs.values():
+                if mapped_bits == list(our_creg):
+                    new_resource = our_creg
+                    break
+            else:
+                new_resource = ClassicalRegister(bits=[wire_map[bit] for bit in resource])
+                self.add_creg(new_resource)
+            creg_map[resource.name] = new_resource
+        return creg_map[resource.name]
 
     def compose(self, other, qubits=None, clbits=None, front=False, inplace=True):
         """Compose the ``other`` circuit onto the output of this circuit.
@@ -908,7 +901,9 @@ class DAGCircuit:
         """
         length = len(self._multi_graph) - 2 * len(self._wires)
         if not recurse:
-            if any(x in self._op_names for x in ("for_loop", "while_loop", "if_else")):
+            if any(
+                x in self._op_names for x in ("for_loop", "while_loop", "if_else", "switch_case")
+            ):
                 raise DAGCircuitError(
                     "Size with control flow is ambiguous."
                     " You may use `recurse=True` to get a result,"
@@ -924,7 +919,7 @@ class DAGCircuit:
                 inner = len(indexset) * circuit_to_dag(node.op.blocks[0]).size(recurse=True)
             elif isinstance(node.op, WhileLoopOp):
                 inner = circuit_to_dag(node.op.blocks[0]).size(recurse=True)
-            elif isinstance(node.op, IfElseOp):
+            elif isinstance(node.op, (IfElseOp, SwitchCaseOp)):
                 inner = sum(circuit_to_dag(block).size(recurse=True) for block in node.op.blocks)
             else:
                 raise DAGCircuitError(f"unknown control-flow type: '{node.op.name}'")
@@ -970,7 +965,9 @@ class DAGCircuit:
                 return node_lookup.get(target, 1)
 
         else:
-            if any(x in self._op_names for x in ("for_loop", "while_loop", "if_else")):
+            if any(
+                x in self._op_names for x in ("for_loop", "while_loop", "if_else", "switch_case")
+            ):
                 raise DAGCircuitError(
                     "Depth with control flow is ambiguous."
                     " You may use `recurse=True` to get a result,"
@@ -1327,7 +1324,23 @@ class DAGCircuit:
         for old_node_index, new_node_index in node_map.items():
             # update node attributes
             old_node = in_dag._multi_graph[old_node_index]
-            m_op = self._map_condition_with_import(old_node.op, wire_map, creg_map)
+            if isinstance(old_node.op, SwitchCaseOp):
+                m_op = SwitchCaseOp(
+                    self._map_classical_resource_with_import(
+                        old_node.op.target, wire_map, creg_map
+                    ),
+                    old_node.op.cases_specifier(),
+                    label=old_node.op.label,
+                )
+            elif getattr(old_node.op, "condition", None) is not None:
+                cond_target, cond_value = old_node.op.condition
+                m_op = copy.copy(old_node.op)
+                m_op.condition = (
+                    self._map_classical_resource_with_import(cond_target, wire_map, creg_map),
+                    cond_value,
+                )
+            else:
+                m_op = old_node.op
             m_qargs = [wire_map[x] for x in old_node.qargs]
             m_cargs = [wire_map[x] for x in old_node.cargs]
             new_node = DAGOpNode(m_op, qargs=m_qargs, cargs=m_cargs)

--- a/qiskit/transpiler/passes/routing/stochastic_swap.py
+++ b/qiskit/transpiler/passes/routing/stochastic_swap.py
@@ -25,7 +25,16 @@ from qiskit.dagcircuit import DAGCircuit
 from qiskit.circuit.library.standard_gates import SwapGate
 from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.target import Target
-from qiskit.circuit import IfElseOp, WhileLoopOp, ForLoopOp, ControlFlowOp, Instruction
+from qiskit.circuit import (
+    Clbit,
+    IfElseOp,
+    WhileLoopOp,
+    ForLoopOp,
+    SwitchCaseOp,
+    ControlFlowOp,
+    Instruction,
+    CASE_DEFAULT,
+)
 from qiskit._accelerate import stochastic_swap as stochastic_swap_rs
 from qiskit._accelerate import nlayout
 from qiskit.transpiler.passes.layout import disjoint_utils
@@ -385,7 +394,7 @@ class StochasticSwap(TransformationPass):
 
         """
         node = layer_dag.op_nodes()[0]
-        if not isinstance(node.op, (IfElseOp, ForLoopOp, WhileLoopOp)):
+        if not isinstance(node.op, (IfElseOp, ForLoopOp, WhileLoopOp, SwitchCaseOp)):
             raise TranspilerError(f"unsupported control flow operation: {node}")
         # For each block, expand it up be the full width of the containing DAG so we can be certain
         # that it is routable, then route it within that.  When we recombine later, we'll reduce all
@@ -398,18 +407,15 @@ class StochasticSwap(TransformationPass):
             block_layouts.append(inner_pass.property_set["final_layout"].copy())
 
         # Determine what layout we need to go towards.  For some blocks (such as `for`), we must
-        # guarantee that the final layout is the same as the initial or the loop won't work.  For an
-        # `if` with an `else`, we don't need that as long as the two branches are the same.  We have
-        # to be careful with `if` _without_ an else, though - the `if` needs to restore the layout
-        # in case it isn't taken; we can't have two different virtual layouts.
-        if not (isinstance(node.op, IfElseOp) and len(node.op.blocks) == 2):
-            final_layout = current_layout
-        else:
+        # guarantee that the final layout is the same as the initial or the loop won't work.
+        if _controlflow_exhaustive_acyclic(node.op):
             # We heuristically just choose to use the layout of whatever the deepest block is, to
             # avoid extending the total depth by too much.
             final_layout = max(
                 zip(block_layouts, block_dags), key=lambda x: x[1].depth(recurse=True)
             )[0]
+        else:
+            final_layout = current_layout
         if self.fake_run:
             return final_layout
 
@@ -455,6 +461,18 @@ class StochasticSwap(TransformationPass):
             fake_run=self.fake_run,
             initial_layout=initial_layout,
         )
+
+
+def _controlflow_exhaustive_acyclic(operation: ControlFlowOp):
+    """Return True if the entire control-flow operation represents a block that is guaranteed to be
+    entered, and does not cycle back to the initial layout."""
+    if isinstance(operation, IfElseOp):
+        return len(operation.blocks) == 2
+    if isinstance(operation, SwitchCaseOp):
+        cases = operation.cases()
+        max_matches = 2 if isinstance(operation.target, Clbit) else 1 << len(operation.target)
+        return CASE_DEFAULT in cases or len(cases) == max_matches
+    return False
 
 
 def _dag_from_block(block, node, root_dag):

--- a/qiskit/transpiler/preset_passmanagers/common.py
+++ b/qiskit/transpiler/preset_passmanagers/common.py
@@ -52,7 +52,7 @@ from qiskit.transpiler.passes.layout.vf2_post_layout import VF2PostLayoutStopRea
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.layout import Layout
 
-_CONTROL_FLOW_OP_NAMES = {"for_loop", "if_else", "while_loop"}
+_CONTROL_FLOW_OP_NAMES = {"for_loop", "if_else", "while_loop", "switch_case"}
 
 _ControlFlowState = collections.namedtuple("_ControlFlowState", ("working", "not_working"))
 

--- a/releasenotes/notes/switch-case-9b6611d0603d36c0.yaml
+++ b/releasenotes/notes/switch-case-9b6611d0603d36c0.yaml
@@ -31,9 +31,9 @@ features:
       construct), and it will serialize to QPY.
 
       The ``switch`` statement is not currently a feature of OpenQASM 3, but `it is under active
-      design and consideration <https://github.com/openqasm/openqasm/pull/463>`__, and we fully
-      expect it to be adopted in the near future.  Qiskit Terra has experimental support for
-      exporting this statement to the OpenQASM 3 syntax proposed in the linked request, using
+      design and consideration <https://github.com/openqasm/openqasm/pull/463>`__, which is
+      expected to be adopted in the near future.  Qiskit Terra has experimental support for
+      exporting this statement to the OpenQASM 3 syntax proposed in the linked pull request, using
       an experimental feature flag.  To export a ``switch`` statement circuit (such as the one
       created above) to OpenQASM 3 using this speculative support, do::
 

--- a/releasenotes/notes/switch-case-9b6611d0603d36c0.yaml
+++ b/releasenotes/notes/switch-case-9b6611d0603d36c0.yaml
@@ -6,3 +6,37 @@ features:
     input (such as a classical register or bit) and executing the circuit that corresponds to the
     matching value.  Multiple values can point to the same circuit, and :data:`.CASE_DEFAULT` can be
     used as an always-matching label.
+
+    You can also use a builder interface, similar to the other control-flow constructs to build up
+    these switch statements::
+
+      from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
+
+      qreg = QuantumRegister(2)
+      creg = ClassicalRegister(2)
+      qc = QuantumCircuit(qreg, creg)
+
+      qc.h([0, 1])
+      qc.measure([0, 1], [0, 1])
+      with qc.switch(creg) as case:
+        with case(0):  # if the register is '00'
+          qc.z(0)
+        with case(1, 2):  # if the register is '01' or '10'
+          qc.cx(0, 1)
+        with case(case.DEFAULT):  # the default case
+          qc.h(0)
+
+      The ``switch`` statement has support throughout the Qiskit compiler stack; you can
+      :func:`.transpile` circuits containing it (if the backend advertises its support for the
+      construct), and it will serialize to QPY.
+
+      The ``switch`` statement is not currently a feature of OpenQASM 3, but `it is under active
+      design and consideration <https://github.com/openqasm/openqasm/pull/463>`__, and we fully
+      expect it to be adopted in the near future.  Qiskit Terra has experimental support for
+      exporting this statement to the OpenQASM 3 syntax proposed in the linked request, using
+      an experimental feature flag.  To export a ``switch`` statement circuit (such as the one
+      created above) to OpenQASM 3 using this speculative support, do::
+
+        from qiskit import qasm3
+
+        qasm3.dumps(qc, experimental=qasm3.ExperimentalFeatures.SWITCH_CASE_V1)

--- a/test/python/providers/test_fake_backends.py
+++ b/test/python/providers/test_fake_backends.py
@@ -62,7 +62,14 @@ from qiskit.quantum_info.operators.channel.kraus import Kraus
 from qiskit.quantum_info.operators.channel import SuperOp
 from qiskit.extensions import Initialize, UnitaryGate
 from qiskit.extensions.quantum_initializer import DiagonalGate, UCGate
-from qiskit.circuit.controlflow import IfElseOp, WhileLoopOp, ForLoopOp, ContinueLoopOp, BreakLoopOp
+from qiskit.circuit.controlflow import (
+    IfElseOp,
+    WhileLoopOp,
+    ForLoopOp,
+    ContinueLoopOp,
+    BreakLoopOp,
+    SwitchCaseOp,
+)
 
 FAKE_PROVIDER_FOR_BACKEND_V2 = FakeProviderForBackendV2()
 FAKE_PROVIDER = FakeProvider()
@@ -429,6 +436,7 @@ class TestFakeBackends(QiskitTestCase):
                 "if_else": IfElseOp,
                 "while_loop": WhileLoopOp,
                 "for_loop": ForLoopOp,
+                "switch_case": SwitchCaseOp,
                 "break_loop": BreakLoopOp,
                 "continue_loop": ContinueLoopOp,
                 "save_statevector": SaveStatevector,

--- a/test/python/transpiler/test_gates_in_basis_pass.py
+++ b/test/python/transpiler/test_gates_in_basis_pass.py
@@ -12,7 +12,7 @@
 
 """Test GatesInBasis pass."""
 
-from qiskit.circuit import QuantumCircuit, ForLoopOp, IfElseOp, Clbit
+from qiskit.circuit import QuantumCircuit, ForLoopOp, IfElseOp, SwitchCaseOp, Clbit
 from qiskit.circuit.library import HGate, CXGate, UGate, XGate, ZGate
 from qiskit.circuit.measure import Measure
 from qiskit.circuit.equivalence_library import SessionEquivalenceLibrary
@@ -247,6 +247,7 @@ class TestGatesInBasisPass(QiskitTestCase):
             ForLoopOp((), None, QuantumCircuit(4)),
             CXGate(),
             IfElseOp((Clbit(), True), QuantumCircuit(2), QuantumCircuit(2)),
+            SwitchCaseOp(Clbit(), [(False, QuantumCircuit(2)), (True, QuantumCircuit(2))]),
             XGate(),
             ZGate(),
         ]

--- a/test/python/transpiler/test_target.py
+++ b/test/python/transpiler/test_target.py
@@ -30,7 +30,7 @@ from qiskit.circuit.library import (
     RZXGate,
     CZGate,
 )
-from qiskit.circuit import IfElseOp, ForLoopOp, WhileLoopOp
+from qiskit.circuit import IfElseOp, ForLoopOp, WhileLoopOp, SwitchCaseOp
 from qiskit.circuit.measure import Measure
 from qiskit.circuit.parameter import Parameter
 from qiskit import pulse
@@ -1320,6 +1320,7 @@ class TestGlobalVariableWidthOperations(QiskitTestCase):
         self.target_global_gates_only.add_instruction(IfElseOp, name="if_else")
         self.target_global_gates_only.add_instruction(ForLoopOp, name="for_loop")
         self.target_global_gates_only.add_instruction(WhileLoopOp, name="while_loop")
+        self.target_global_gates_only.add_instruction(SwitchCaseOp, name="switch_case")
         self.ibm_target = Target()
         i_props = {
             (0,): InstructionProperties(duration=35.5e-9, error=0.000413),
@@ -1375,6 +1376,7 @@ class TestGlobalVariableWidthOperations(QiskitTestCase):
         self.ibm_target.add_instruction(IfElseOp, name="if_else")
         self.ibm_target.add_instruction(ForLoopOp, name="for_loop")
         self.ibm_target.add_instruction(WhileLoopOp, name="while_loop")
+        self.ibm_target.add_instruction(SwitchCaseOp, name="switch_case")
         self.aqt_target = Target(description="AQT Target")
         rx_props = {
             (0,): None,
@@ -1442,6 +1444,7 @@ class TestGlobalVariableWidthOperations(QiskitTestCase):
         self.aqt_target.add_instruction(IfElseOp, name="if_else")
         self.aqt_target.add_instruction(ForLoopOp, name="for_loop")
         self.aqt_target.add_instruction(WhileLoopOp, name="while_loop")
+        self.aqt_target.add_instruction(SwitchCaseOp, name="switch_case")
 
     def test_qargs(self):
         expected_ibm = {
@@ -1510,19 +1513,42 @@ class TestGlobalVariableWidthOperations(QiskitTestCase):
         self.assertIsNone(self.target_global_gates_only.qargs_for_operation_name("cx"))
         self.assertIsNone(self.ibm_target.qargs_for_operation_name("if_else"))
         self.assertIsNone(self.aqt_target.qargs_for_operation_name("while_loop"))
+        self.assertIsNone(self.aqt_target.qargs_for_operation_name("switch_case"))
 
     def test_instruction_names(self):
         self.assertEqual(
             self.ibm_target.operation_names,
-            {"rz", "id", "sx", "x", "cx", "measure", "if_else", "while_loop", "for_loop"},
+            {
+                "rz",
+                "id",
+                "sx",
+                "x",
+                "cx",
+                "measure",
+                "if_else",
+                "while_loop",
+                "for_loop",
+                "switch_case",
+            },
         )
         self.assertEqual(
             self.aqt_target.operation_names,
-            {"rz", "ry", "rx", "rxx", "r", "measure", "if_else", "while_loop", "for_loop"},
+            {
+                "rz",
+                "ry",
+                "rx",
+                "rxx",
+                "r",
+                "measure",
+                "if_else",
+                "while_loop",
+                "for_loop",
+                "switch_case",
+            },
         )
         self.assertEqual(
             self.target_global_gates_only.operation_names,
-            {"u", "cx", "measure", "if_else", "while_loop", "for_loop"},
+            {"u", "cx", "measure", "if_else", "while_loop", "for_loop", "switch_case"},
         )
 
     def test_operations_for_qargs(self):
@@ -1535,6 +1561,7 @@ class TestGlobalVariableWidthOperations(QiskitTestCase):
             IfElseOp,
             ForLoopOp,
             WhileLoopOp,
+            SwitchCaseOp,
         ]
         res = self.ibm_target.operations_for_qargs((0,))
         self.assertEqual(len(expected), len(res))
@@ -1545,6 +1572,7 @@ class TestGlobalVariableWidthOperations(QiskitTestCase):
             IfElseOp,
             ForLoopOp,
             WhileLoopOp,
+            SwitchCaseOp,
         ]
         res = self.ibm_target.operations_for_qargs((0, 1))
         self.assertEqual(len(expected), len(res))
@@ -1559,12 +1587,13 @@ class TestGlobalVariableWidthOperations(QiskitTestCase):
             IfElseOp,
             ForLoopOp,
             WhileLoopOp,
+            SwitchCaseOp,
         ]
         res = self.aqt_target.operations_for_qargs((0,))
         self.assertEqual(len(expected), len(res))
         for x in expected:
             self.assertIn(x, res)
-        expected = [RXXGate(self.theta), IfElseOp, ForLoopOp, WhileLoopOp]
+        expected = [RXXGate(self.theta), IfElseOp, ForLoopOp, WhileLoopOp, SwitchCaseOp]
         res = self.aqt_target.operations_for_qargs((0, 1))
         self.assertEqual(len(expected), len(res))
         for x in expected:
@@ -1580,6 +1609,7 @@ class TestGlobalVariableWidthOperations(QiskitTestCase):
             "if_else",
             "for_loop",
             "while_loop",
+            "switch_case",
         }
         self.assertEqual(expected, self.ibm_target.operation_names_for_qargs((0,)))
         expected = {
@@ -1587,6 +1617,7 @@ class TestGlobalVariableWidthOperations(QiskitTestCase):
             "if_else",
             "for_loop",
             "while_loop",
+            "switch_case",
         }
         self.assertEqual(expected, self.ibm_target.operation_names_for_qargs((0, 1)))
         expected = {
@@ -1598,9 +1629,10 @@ class TestGlobalVariableWidthOperations(QiskitTestCase):
             "if_else",
             "for_loop",
             "while_loop",
+            "switch_case",
         }
         self.assertEqual(self.aqt_target.operation_names_for_qargs((0,)), expected)
-        expected = {"rxx", "if_else", "for_loop", "while_loop"}
+        expected = {"rxx", "if_else", "for_loop", "while_loop", "switch_case"}
         self.assertEqual(self.aqt_target.operation_names_for_qargs((0, 1)), expected)
 
     def test_operations(self):
@@ -1614,6 +1646,7 @@ class TestGlobalVariableWidthOperations(QiskitTestCase):
             WhileLoopOp,
             IfElseOp,
             ForLoopOp,
+            SwitchCaseOp,
         ]
         for gate in ibm_expected:
             self.assertIn(gate, self.ibm_target.operations)
@@ -1626,6 +1659,7 @@ class TestGlobalVariableWidthOperations(QiskitTestCase):
             ForLoopOp,
             IfElseOp,
             WhileLoopOp,
+            SwitchCaseOp,
         ]
         for gate in aqt_expected:
             self.assertIn(gate, self.aqt_target.operations)
@@ -1636,6 +1670,7 @@ class TestGlobalVariableWidthOperations(QiskitTestCase):
             ForLoopOp,
             WhileLoopOp,
             IfElseOp,
+            SwitchCaseOp,
         ]
         for gate in fake_expected:
             self.assertIn(gate, self.target_global_gates_only.operations)
@@ -1684,6 +1719,7 @@ class TestGlobalVariableWidthOperations(QiskitTestCase):
             (IfElseOp, None),
             (ForLoopOp, None),
             (WhileLoopOp, None),
+            (SwitchCaseOp, None),
         ]
         self.assertEqual(ibm_expected, self.ibm_target.instructions)
         ideal_sim_expected = [
@@ -1693,6 +1729,7 @@ class TestGlobalVariableWidthOperations(QiskitTestCase):
             (IfElseOp, None),
             (ForLoopOp, None),
             (WhileLoopOp, None),
+            (SwitchCaseOp, None),
         ]
         self.assertEqual(ideal_sim_expected, self.target_global_gates_only.instructions)
 
@@ -1705,6 +1742,9 @@ class TestGlobalVariableWidthOperations(QiskitTestCase):
         self.assertTrue(self.aqt_target.instruction_supported("while_loop", (0, 1, 2, 3)))
         self.assertTrue(
             self.aqt_target.instruction_supported(operation_class=WhileLoopOp, qargs=(0, 1, 2, 3))
+        )
+        self.assertTrue(
+            self.aqt_target.instruction_supported(operation_class=SwitchCaseOp, qargs=(0, 1, 2, 3))
         )
         self.assertFalse(
             self.ibm_target.instruction_supported(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

For the most part, the heavy lifting for this was already done in the previous support for control flow.  This commit refactors some of the handling into larger, more descriptive helper functions, and most of the rest of the work is in testing.

I'm fairly confident there are some register-related problems to do with mappings in `DAGCircuit.substitute_node_*` and `QuantumCircuit.compose` right now, in both existing control flow and the new switch statement, which will need revisiting.

### Details and comments

~Depends on #9916, #9919, #9926.  This PR currently contains a cherry-pick of all three of those, which will be rebased out before merge.~