### PR TITLE
Turn off Qiskit Bot notifications for code owners

### DIFF
--- a/qiskit_bot.yaml
+++ b/qiskit_bot.yaml
@@ -1,43 +1,46 @@
 ---
+# We use quotes around users who don`t want a GitHub notification,
+# but whom we still want their name in the Qiskit Bot message so
+# people know they are relevant.
 notifications:
     ".*":
-        - "@Qiskit/terra-core"
+        - "`@Qiskit/terra-core`"
     "visualization/pulse_v2":
-        - "@nkanazawa1989"
+        - "`@nkanazawa1989`"
     "visualization/timeline":
-        - "@nkanazawa1989"
+        - "`@nkanazawa1989`"
     "pulse":
-        - "@nkanazawa1989"
+        - "`@nkanazawa1989`"
     "scheduler":
-        - "@nkanazawa1989"
+        - "`@nkanazawa1989`"
     "qpy":
-        - "@mtreinish"
-        - "@nkanazawa1989"
+        - "`@mtreinish`"
+        - "`@nkanazawa1989`"
     "two_qubit_decompose":
-        - "@levbishop"
+        - "`@levbishop`"
     "quantum_info":
-        - "@ikkoham"
+        - "`@ikkoham`"
     "utils/run_circuits":
-        - "@woodsp-ibm"
+        - "`@woodsp-ibm`"
     "utils/quantum_instance":
-        - "@woodsp-ibm"
+        - "`@woodsp-ibm`"
     "opflow":
-        - "@woodsp-ibm"
-        - "@Cryoris"
+        - "`@woodsp-ibm`"
+        - "`@Cryoris`"
     "algorithms":
-        - "@ElePT"
-        - "@woodsp-ibm"
+        - "`@ElePT`"
+        - "`@woodsp-ibm`"
     "circuit/library":
-        - "@Cryoris"
-        - "@ajavadia"
+        - "`@Cryoris`"
+        - "`@ajavadia`"
     "primitives":
-        - "@ikkoham"
-        - "@t-imamichi"
-        - "@ajavadia"
-        - "@levbishop"
+        - "`@ikkoham`"
+        - "`@t-imamichi`"
+        - "`@ajavadia`"
+        - "`@levbishop`"
     ".*\\.rs$|^Cargo":
-        - "@mtreinish"
-        - "@kevinhartman"
+        - "`@mtreinish`"
+        - "`@kevinhartman`"
         - "@Eric-Arellano"
     "(?!.*pulse.*)\\bvisualization\\b":
         - "@enavarro51"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Every user who I changed in this PR was getting two forms of notifications when new PRs open up:

1. Code owners from GitHub, since the `CODEOWNERS` file matches them
2. An `@` mention from the Qiskit bot, due to our config file.

That's noisy. Instead, this PR turns off the bot notifications and relies on code owners.

### Details and comments

We still think it's valuable to list these people in the Qiskit bot comment so contributors know who is relevant to the code. But, we escape the users with \` so that they don't get the notification.