### PR TITLE
Handle edge case in XXDecomposer when no basis fidelity is known

### DIFF
--- a/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
+++ b/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
@@ -150,7 +150,7 @@ class XXDecomposer:
         heapq.heappush(priority_queue, (0, []))
         canonical_coordinate = np.array(canonical_coordinate)
 
-        while True:
+        while priority_queue:
             sequence_cost, sequence = heapq.heappop(priority_queue)
 
             strength_polytope = XXPolytope.from_strengths(*[x / 2 for x in sequence])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the XXDecomposer class when run as part of the unitary synthesis pass there was a bug when the input value of the basis_fidelity field on the constructor was an empty dictionary. In that case when trying to find the best decomposition the code that loops over the possible decompositions would fail because there are no known fidelities to use for comparison. This commit fixes this issue by changing an infinite loop which was supposed to break on finding the best decomposition to only iterate while there are available decompositions to evaluate. Without this it is possible the loop will continue to try to iterate after there are no further decompositions to evaluate which when basis_fidelity is always on the second iteration because there is nothing to compare against.

### Details and comments

Fixes #9935
