### PR TITLE
Pin pygments in CI

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ reno>=3.4.0
 Sphinx>=5.0
 qiskit-sphinx-theme>=1.6
 sphinx-design>=0.2.0
-pygments>=2.4
+pygments>=2.4,<2.15
 scikit-learn>=0.20.0
 scikit-quant<=0.7;platform_system != 'Windows'
 jax;platform_system != 'Windows'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The recent release of pygments 2.15.0 [1] has started emitting an error in the custom qasm pygments lexer included in qiskit in OpenQASMLexer. In the interest of not blocking CI this commit pins the pygments version we're installing in CI. Longer term, we should probably look at just deprecating the qiskit version and just using openqasm-pygments which is the pygments tools for OpenQASM maintained by the openqasm community.

### Details and comments

[1] https://pypi.org/project/Pygments/2.15.0/