### PR TITLE
Deprecate circuit-library Jupyter magic

### DIFF
--- a/qiskit/tools/jupyter/jupyter_magics.py
+++ b/qiskit/tools/jupyter/jupyter_magics.py
@@ -175,7 +175,7 @@ if _optionals.HAS_MATPLOTLIB and get_ipython():
 
     @register_line_magic
     @deprecate_func(
-        since="0.24.0",
+        since="0.25.0",
         additional_msg="This was originally only for internal documentation and is no longer used.",
     )
     def circuit_library_info(circuit: qiskit.QuantumCircuit) -> None:

--- a/qiskit/tools/jupyter/jupyter_magics.py
+++ b/qiskit/tools/jupyter/jupyter_magics.py
@@ -20,6 +20,7 @@ from IPython.core import magic_arguments
 from IPython.core.magic import cell_magic, line_magic, Magics, magics_class, register_line_magic
 
 from qiskit.utils import optionals as _optionals
+from qiskit.utils.deprecation import deprecate_func
 import qiskit
 from qiskit.tools.events.progressbar import TextProgressBar
 from .progressbar import HTMLProgressBar

--- a/qiskit/tools/jupyter/jupyter_magics.py
+++ b/qiskit/tools/jupyter/jupyter_magics.py
@@ -174,6 +174,10 @@ class ProgressBarMagic(Magics):
 if _optionals.HAS_MATPLOTLIB and get_ipython():
 
     @register_line_magic
+    @deprecate_func(
+        since="0.24.0",
+        additional_msg="This was originally only for internal documentation and is no longer used.",
+    )
     def circuit_library_info(circuit: qiskit.QuantumCircuit) -> None:
         """Displays library information for a quantum circuit.
 

--- a/qiskit/tools/jupyter/library.py
+++ b/qiskit/tools/jupyter/library.py
@@ -51,7 +51,7 @@ def _generate_circuit_library_visualization(circuit: QuantumCircuit):
 
 
 @deprecate_func(
-    since="0.24.0",
+    since="0.25.0",
     additional_msg="This is unused by Qiskit, and no replacement will be publicly provided.",
 )
 def circuit_data_table(circuit: QuantumCircuit) -> wid.HTML:
@@ -120,7 +120,7 @@ property_label = wid.HTML(
 
 
 @deprecate_func(
-    since="0.24.0",
+    since="0.25.0",
     additional_msg="This is unused by Qiskit, and no replacement will be publicly provided.",
 )
 def properties_widget(circuit: QuantumCircuit) -> wid.VBox:
@@ -140,7 +140,7 @@ def properties_widget(circuit: QuantumCircuit) -> wid.VBox:
 
 
 @deprecate_func(
-    since="0.24.0",
+    since="0.25.0",
     additional_msg="This is unused by Qiskit, and no replacement will be publicly provided.",
 )
 def qasm_widget(circuit: QuantumCircuit) -> wid.VBox:
@@ -204,7 +204,7 @@ def qasm_widget(circuit: QuantumCircuit) -> wid.VBox:
 
 
 @deprecate_func(
-    since="0.24.0",
+    since="0.25.0",
     additional_msg="This is unused by Qiskit, and no replacement will be publicly provided.",
 )
 def circuit_diagram_widget() -> wid.Box:
@@ -230,7 +230,7 @@ def circuit_diagram_widget() -> wid.Box:
 
 
 @deprecate_func(
-    since="0.24.0",
+    since="0.25.0",
     additional_msg="This is unused by Qiskit, and no replacement will be publicly provided.",
 )
 def circuit_library_widget(circuit: QuantumCircuit) -> None:

--- a/qiskit/tools/jupyter/library.py
+++ b/qiskit/tools/jupyter/library.py
@@ -19,6 +19,7 @@ from IPython.display import display
 from qiskit import QuantumCircuit
 from qiskit.exceptions import MissingOptionalLibraryError
 from qiskit.utils import optionals as _optionals
+from qiskit.utils.deprecation import deprecate_func
 
 try:
     import pygments
@@ -49,6 +50,10 @@ def _generate_circuit_library_visualization(circuit: QuantumCircuit):
     plt.show()
 
 
+@deprecate_func(
+    since="0.24.0",
+    additional_msg="This is unused by Qiskit, and no replacement will be publicly provided.",
+)
 def circuit_data_table(circuit: QuantumCircuit) -> wid.HTML:
     """Create a HTML table widget for a given quantum circuit.
 
@@ -114,6 +119,10 @@ property_label = wid.HTML(
 )
 
 
+@deprecate_func(
+    since="0.24.0",
+    additional_msg="This is unused by Qiskit, and no replacement will be publicly provided.",
+)
 def properties_widget(circuit: QuantumCircuit) -> wid.VBox:
     """Create a HTML table widget with header for a given quantum circuit.
 
@@ -130,6 +139,10 @@ def properties_widget(circuit: QuantumCircuit) -> wid.VBox:
     return properties
 
 
+@deprecate_func(
+    since="0.24.0",
+    additional_msg="This is unused by Qiskit, and no replacement will be publicly provided.",
+)
 def qasm_widget(circuit: QuantumCircuit) -> wid.VBox:
     """Generate a QASM widget with header for a quantum circuit.
 
@@ -190,6 +203,10 @@ def qasm_widget(circuit: QuantumCircuit) -> wid.VBox:
     return qasm
 
 
+@deprecate_func(
+    since="0.24.0",
+    additional_msg="This is unused by Qiskit, and no replacement will be publicly provided.",
+)
 def circuit_diagram_widget() -> wid.Box:
     """Create a circuit diagram widget.
 
@@ -212,6 +229,10 @@ def circuit_diagram_widget() -> wid.Box:
     return top
 
 
+@deprecate_func(
+    since="0.24.0",
+    additional_msg="This is unused by Qiskit, and no replacement will be publicly provided.",
+)
 def circuit_library_widget(circuit: QuantumCircuit) -> None:
     """Create a circuit library widget.
 

--- a/releasenotes/notes/deprecate-circuit-library-jupyter-629f927e8dd5cc22.yaml
+++ b/releasenotes/notes/deprecate-circuit-library-jupyter-629f927e8dd5cc22.yaml
@@ -1,0 +1,14 @@
+---
+deprecations:
+  - |
+    The Jupyter magic ``%circuit_library_info`` and the objects in ``qiskit.tools.jupyter.library``
+    it calls in turn:
+
+    - ``circuit_data_table``
+    - ``properties_widget``
+    - ``qasm_widget``
+    - ``circuit_digram_widget``
+    - ``circuit_library_widget``
+
+    are deprecated and will be removed in Terra 0.26.  These objects were only intended for use in
+    the documentation build. They are no longer used there, so are no longer supported or maintained.

--- a/releasenotes/notes/deprecate-circuit-library-jupyter-629f927e8dd5cc22.yaml
+++ b/releasenotes/notes/deprecate-circuit-library-jupyter-629f927e8dd5cc22.yaml
@@ -10,5 +10,5 @@ deprecations:
     - ``circuit_digram_widget``
     - ``circuit_library_widget``
 
-    are deprecated and will be removed in Terra 0.26.  These objects were only intended for use in
+    are deprecated and will be removed in Terra 0.27.  These objects were only intended for use in
     the documentation build. They are no longer used there, so are no longer supported or maintained.


### PR DESCRIPTION
### Summary

This has not been used since the switch away from using `jupyter-execute` in gh-9346, so is neither maintained nor necessary. Any improvements to styling should be made to the new paths, not to these.  These objects were originally intended only for the documentation so we expect user impact to be minimal, and the objects are not maintained anyway.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

These are the only direct users of the Pygments lexer that caused us problems that needed a fix in #9938.  We planned to deprecate these in https://github.com/Qiskit/qiskit-terra/pull/9346#discussion_r1063358895, but we failed to follow up on it at the time.