### PR TITLE
Use built-in IPython code highlighting in formatted OQ2 output

### DIFF
--- a/releasenotes/notes/openqasm-pygments-formatter-67087ea00ce2ae9b.yaml
+++ b/releasenotes/notes/openqasm-pygments-formatter-67087ea00ce2ae9b.yaml
@@ -1,0 +1,15 @@
+---
+upgrade:
+  - |
+    Rich output from the :meth:`.QuantumCircuit.qasm` method (i.e. by setting ``formatted=True``)
+    will now preferentially use the built-in IPython/Jupyter support for code blocks using a
+    Pygments lexer with alias ``qasm2`` if it is available.  A suitable lexer can be installed by
+    doing, for example:
+
+    .. code-block:: text
+
+      pip install openqasm-pygments
+
+    In the future, the built-in Qiskit lexer and styles for OpenQASM 2 will be removed. If you are
+    using them, you should plan to migrate to another package, such as the one mentioned above that
+    is maintained by the OpenQASM community.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

We currently have an option to `QuantumCircuit.qasm` that produces rich formatted output for IPython/Jupyter contexts.  This involves a lot of manual handling, while modern IPython has the `IPython.display.Code` object for representing things.  This commit switches over to preferentially using this, if the user has a Pygments lexer capable of handling the `qasm2` alias available.

This is part of an effort to fully deprecate the `qiskit.qasm` package (in favour of `qiskit.qasm2`, where appropriate), and to trim down extra components where there are supported alternatives.


### Details and comments

Depends on #9944.
