### PR TITLE
Fix docs build with Pygments 2.15

### DIFF
--- a/qiskit/qasm/__init__.py
+++ b/qiskit/qasm/__init__.py
@@ -30,13 +30,14 @@ QASM Routines
 Pygments
 ========
 
-.. autosummary::
-   :toctree: ../stubs/
+.. autoclass:: OpenQASMLexer
+    :class-doc-from: class
 
-   OpenQASMLexer
-   QasmHTMLStyle
-   QasmTerminalStyle
+.. autoclass:: QasmHTMLStyle
+    :class-doc-from: class
 
+.. autoclass:: QasmTerminalStyle
+    :class-doc-from: class
 """
 
 from numpy import pi

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ reno>=3.4.0
 Sphinx>=5.0
 qiskit-sphinx-theme>=1.6
 sphinx-design>=0.2.0
-pygments>=2.4,<2.15
+pygments>=2.4
 scikit-learn>=0.20.0
 scikit-quant<=0.7;platform_system != 'Windows'
 jax;platform_system != 'Windows'


### PR DESCRIPTION
### Summary

The problem was because the latest version of Pygments included a docstring in `Lexer.__init__` that includes a crossreference to an object that Qiskit naturally doesn't have.  We don't need to inherit the `__init__` docstring for this object; we're only interested in documenting the existence of object itself.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

This is the proper fix for the problem that #9938 quick-fixed.
