### PR TITLE
Unify OpenQASM 2 exceptions

### DIFF
--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -40,7 +40,6 @@ import numpy
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.classicalregister import ClassicalRegister, Clbit
-from qiskit.qasm.exceptions import QasmError
 from qiskit.qobj.qasm_qobj import QasmQobjInstruction
 from qiskit.circuit.parameter import ParameterExpression
 from qiskit.circuit.operation import Operation
@@ -438,10 +437,12 @@ class Instruction(Operation):
 
     def _qasmif(self, string):
         """Print an if statement if needed."""
+        from qiskit.qasm2 import QASM2ExportError  # pylint: disable=cyclic-import
+
         if self.condition is None:
             return string
         if not isinstance(self.condition[0], ClassicalRegister):
-            raise QasmError(
+            raise QASM2ExportError(
                 "OpenQASM 2 can only condition on registers, but got '{self.condition[0]}'"
             )
         return "if(%s==%d) " % (self.condition[0].name, self.condition[1]) + string

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -46,7 +46,6 @@ from qiskit.utils.multiprocessing import is_main_process
 from qiskit.circuit.instruction import Instruction
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.parameter import Parameter
-from qiskit.qasm.exceptions import QasmError
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.utils import optionals as _optionals
 from .parameterexpression import ParameterExpression, ParameterValueType
@@ -1630,11 +1629,14 @@ class QuantumCircuit:
         Raises:
             MissingOptionalLibraryError: If pygments is not installed and ``formatted`` is
                 ``True``.
-            QasmError: If circuit has free parameters.
+            QASM2ExportError: If circuit has free parameters.
         """
+        from qiskit.qasm2 import QASM2ExportError  # pylint: disable=cyclic-import
 
         if self.num_parameters > 0:
-            raise QasmError("Cannot represent circuits with unbound parameters in OpenQASM 2.")
+            raise QASM2ExportError(
+                "Cannot represent circuits with unbound parameters in OpenQASM 2."
+            )
 
         existing_gate_names = {
             "barrier",

--- a/qiskit/qasm/__init__.py
+++ b/qiskit/qasm/__init__.py
@@ -24,7 +24,6 @@ QASM Routines
    :toctree: ../stubs/
 
    Qasm
-   QasmError
 
 
 Pygments

--- a/qiskit/qasm/exceptions.py
+++ b/qiskit/qasm/exceptions.py
@@ -10,21 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""
-Exception for errors raised while parsing OPENQASM.
-"""
+"""Exception for errors raised while handling OpenQASM 2.0."""
 
-from qiskit.exceptions import QiskitError
-
-
-class QasmError(QiskitError):
-    """Base class for errors raised while parsing OPENQASM."""
-
-    def __init__(self, *msg):
-        """Set the error message."""
-        super().__init__(*msg)
-        self.msg = " ".join(msg)
-
-    def __str__(self):
-        """Return the message."""
-        return repr(self.msg)
+# Re-export from the new place to ensure that old code continues to work.
+from qiskit.qasm2.exceptions import QASM2Error as QasmError  # pylint: disable=unused-import

--- a/test/python/circuit/test_gate_definitions.py
+++ b/test/python/circuit/test_gate_definitions.py
@@ -282,6 +282,8 @@ class TestGateEquivalenceEqual(QiskitTestCase):
         "PermutationGate",
         "Commuting2qBlock",
         "PauliEvolutionGate",
+        "_U0Gate",
+        "_DefinedGate",
     }
     # Amazingly, Python's scoping rules for class bodies means that this is the closest we can get
     # to a "natural" comprehension or functional iterable definition:


### PR DESCRIPTION
### Summary

Since gh-9784 added a new `qiskit.qasm2` package and suitable exceptions for both import and export of OpenQASM 2 programs, this commit now unifies the exception handling through the rest of the library to use these exceptions.

To avoid breaks in compatibility, the old `qiskit.qasm.QasmError` is now a re-export of `qiskit.qasm2.QASM2Error`.  This is the base error of both the exporter and importers, despite the old documentation of `QasmError` claiming to be specifically for parser errors.  In practice, the exporter also emitted `QasmError`, so having that be `QASM2Error` allows people catching that error to get the same behaviour in these new forms.  The actual exporter and importer are updated to emit the precise subclasses.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Probably this will clash a little with #9955 (and this PR technically probably wants to merge before that one) and potentially #9953.  I'll fix any merge conflicts as they arise.

This PR is preparing for a later total deprecation and removal of the `qiskit.qasm` namespace, likely starting in Terra 0.26, since we've begun the process of moving to `qiskit.qasm2` and `qiskit.qasm3` as explicitly versioned packages, to avoid confusion in the future.