### PR TITLE
Wrap `io::Error` in `QASM2ParseError` on failed file read

### DIFF
--- a/test/python/qasm2/test_parse_errors.py
+++ b/test/python/qasm2/test_parse_errors.py
@@ -220,6 +220,11 @@ class TestIncompleteStructure(QiskitTestCase):
         with self.assertRaisesRegex(qiskit.qasm2.QASM2ParseError, "unexpected end-of-file"):
             qiskit.qasm2.loads(full)
 
+    def test_loading_directory(self):
+        """Test that the correct error is raised when a file fails to open."""
+        with self.assertRaisesRegex(qiskit.qasm2.QASM2ParseError, "failed to read"):
+            qiskit.qasm2.load(".")
+
 
 class TestVersion(QiskitTestCase):
     def test_invalid_version(self):


### PR DESCRIPTION
### Summary

Previously, if Python thought the target file for `qasm2.load` existed, but Rust was unable to open it, the result `io:Error` would be propagated up to Python space verbatim, and these situations usually have confusing error messages.  This could happen, for example, if the target was a directory on Windows.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Detected while doing #9955 preparing for 0.25.  This PR is a bugfix for #9784, though, so wants to be in 0.24.