### PR TITLE
Remove circular dependency on `qiskit.qasm.pi`

### DIFF
--- a/qiskit/circuit/library/standard_gates/equivalence_library.py
+++ b/qiskit/circuit/library/standard_gates/equivalence_library.py
@@ -13,7 +13,9 @@
 """Standard gates."""
 
 from __future__ import annotations
-from qiskit.qasm import pi
+
+from math import pi
+
 from qiskit.circuit import (
     EquivalenceLibrary,
     Parameter,

--- a/qiskit/circuit/library/standard_gates/h.py
+++ b/qiskit/circuit/library/standard_gates/h.py
@@ -11,13 +11,12 @@
 # that they have been altered from the originals.
 
 """Hadamard gate."""
-from math import sqrt
+from math import sqrt, pi
 from typing import Optional, Union
 import numpy
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
-from qiskit.qasm import pi
 from .t import TGate, TdgGate
 from .s import SGate, SdgGate
 

--- a/qiskit/circuit/library/standard_gates/r.py
+++ b/qiskit/circuit/library/standard_gates/r.py
@@ -14,9 +14,9 @@
 
 import math
 from cmath import exp
+from math import pi
 from typing import Optional
 import numpy
-from qiskit.qasm import pi
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.parameterexpression import ParameterValueType

--- a/qiskit/circuit/library/standard_gates/rx.py
+++ b/qiskit/circuit/library/standard_gates/rx.py
@@ -13,10 +13,10 @@
 """Rotation around the X axis."""
 
 import math
+from math import pi
 from typing import Optional, Union
 import numpy
 
-from qiskit.qasm import pi
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister

--- a/qiskit/circuit/library/standard_gates/ry.py
+++ b/qiskit/circuit/library/standard_gates/ry.py
@@ -13,9 +13,9 @@
 """Rotation around the Y axis."""
 
 import math
+from math import pi
 from typing import Optional, Union
 import numpy
-from qiskit.qasm import pi
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister

--- a/qiskit/circuit/library/standard_gates/s.py
+++ b/qiskit/circuit/library/standard_gates/s.py
@@ -12,6 +12,7 @@
 
 """The S, Sdg, CS and CSdg gates."""
 
+from math import pi
 from typing import Optional, Union
 
 import numpy
@@ -20,7 +21,6 @@ from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.library.standard_gates.p import CPhaseGate, PhaseGate
 from qiskit.circuit.quantumregister import QuantumRegister
-from qiskit.qasm import pi
 
 
 class SGate(Gate):

--- a/qiskit/circuit/library/standard_gates/sx.py
+++ b/qiskit/circuit/library/standard_gates/sx.py
@@ -12,9 +12,9 @@
 
 """Sqrt(X) and C-Sqrt(X) gates."""
 
+from math import pi
 from typing import Optional, Union
 import numpy
-from qiskit.qasm import pi
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister

--- a/qiskit/circuit/library/standard_gates/t.py
+++ b/qiskit/circuit/library/standard_gates/t.py
@@ -12,6 +12,7 @@
 
 """T and Tdg gate."""
 import math
+from math import pi
 from typing import Optional
 
 import numpy
@@ -19,7 +20,6 @@ import numpy
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.library.standard_gates.p import PhaseGate
 from qiskit.circuit.quantumregister import QuantumRegister
-from qiskit.qasm import pi
 
 
 class TGate(Gate):

--- a/qiskit/circuit/library/standard_gates/u2.py
+++ b/qiskit/circuit/library/standard_gates/u2.py
@@ -11,11 +11,10 @@
 # that they have been altered from the originals.
 
 """One-pulse single-qubit gate."""
-from math import sqrt
+from math import sqrt, pi
 from cmath import exp
 from typing import Optional
 import numpy
-from qiskit.qasm import pi
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit.circuit.quantumregister import QuantumRegister

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -13,13 +13,12 @@
 """X, CX, CCX and multi-controlled X gates."""
 from __future__ import annotations
 from typing import Optional, Union, Type
-from math import ceil
+from math import ceil, pi
 import numpy
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit._utils import _compute_control_matrix, _ctrl_state_to_int
-from qiskit.qasm import pi
 from .h import HGate
 from .t import TGate, TdgGate
 from .u1 import U1Gate

--- a/qiskit/circuit/library/standard_gates/xx_minus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_minus_yy.py
@@ -13,6 +13,7 @@
 """Two-qubit XX-YY gate."""
 import math
 from cmath import exp
+from math import pi
 from typing import Optional
 
 import numpy as np
@@ -26,7 +27,6 @@ from qiskit.circuit.library.standard_gates.x import CXGate
 from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.circuit.quantumregister import QuantumRegister
-from qiskit.qasm import pi
 
 
 class XXMinusYYGate(Gate):

--- a/qiskit/circuit/library/standard_gates/xx_plus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_plus_yy.py
@@ -13,8 +13,8 @@
 """Two-qubit XX+YY gate."""
 import math
 from cmath import exp
+from math import pi
 from typing import Optional
-from qiskit.qasm import pi
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.parameterexpression import ParameterValueType

--- a/qiskit/circuit/library/standard_gates/y.py
+++ b/qiskit/circuit/library/standard_gates/y.py
@@ -12,9 +12,9 @@
 
 """Y and CY gates."""
 
+from math import pi
 from typing import Optional, Union
 import numpy
-from qiskit.qasm import pi
 
 # pylint: disable=cyclic-import
 from qiskit.circuit.controlledgate import ControlledGate

--- a/qiskit/circuit/library/standard_gates/z.py
+++ b/qiskit/circuit/library/standard_gates/z.py
@@ -12,6 +12,7 @@
 
 """Z, CZ and CCZ gates."""
 
+from math import pi
 from typing import Optional, Union
 
 import numpy
@@ -20,7 +21,6 @@ from qiskit.circuit._utils import _compute_control_matrix
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
-from qiskit.qasm import pi
 
 from .p import PhaseGate
 

--- a/test/python/circuit/test_extensions_standard.py
+++ b/test/python/circuit/test_extensions_standard.py
@@ -14,13 +14,13 @@
 
 import unittest
 from inspect import signature
+from math import pi
 
 import numpy as np
 from scipy.linalg import expm
 from ddt import data, ddt, unpack
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister, execute
-from qiskit.qasm import pi
 from qiskit.exceptions import QiskitError
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.test import QiskitTestCase

--- a/test/python/qasm3/test_export.py
+++ b/test/python/qasm3/test_export.py
@@ -16,6 +16,7 @@
 # pylint: disable=line-too-long
 
 from io import StringIO
+from math import pi
 import re
 import unittest
 
@@ -27,7 +28,6 @@ from qiskit.test import QiskitTestCase
 from qiskit.qasm3 import Exporter, dumps, dump, QASM3ExporterError
 from qiskit.qasm3.exporter import QASM3Builder
 from qiskit.qasm3.printer import BasicPrinter
-from qiskit.qasm import pi
 
 
 # Tests marked with this decorator should be restored after gate definition with parameters is fixed


### PR DESCRIPTION
### Summary

Prior to 4a6eb32337 (gh-3156), the value `qiskit.qasm.pi` was a re-export of a Sympy object, so it had some value.  Since then, we no longer use Sympy at all, let alone as the default type for parameters, and the export served no real purpose.  It did, however, cause a bunch of problematic circular dependencies between `qiskit.circuit` and `qiskit.qasm`, since `qiskit.qasm` is logically higher in the module hierarchy than `qiskit.circuit`.

Solving this circular dependency is another step down the path of being able to fully deprecate and remove the legacy `qiskit.qasm` code.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments


