### PR TITLE
Add `max_trials` parameter to `VF2PostLayout`.

### DIFF
--- a/qiskit/transpiler/passes/layout/vf2_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_layout.py
@@ -218,7 +218,7 @@ class VF2Layout(AnalysisPass):
                 )
                 chosen_layout = layout
                 chosen_layout_score = layout_score
-            if self.max_trials is not None and self.max_trials > 0 and trials >= self.max_trials:
+            if self.max_trials and trials >= self.max_trials:
                 logger.debug("Trial %s is >= configured max trials %s", trials, self.max_trials)
                 break
             elapsed_time = time.time() - start_time

--- a/qiskit/transpiler/passes/layout/vf2_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_layout.py
@@ -218,7 +218,7 @@ class VF2Layout(AnalysisPass):
                 )
                 chosen_layout = layout
                 chosen_layout_score = layout_score
-            if self.max_trials and trials >= self.max_trials:
+            if self.max_trials is not None and self.max_trials > 0 and trials >= self.max_trials:
                 logger.debug("Trial %s is >= configured max trials %s", trials, self.max_trials)
                 break
             elapsed_time = time.time() - start_time

--- a/qiskit/transpiler/passes/layout/vf2_post_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_post_layout.py
@@ -134,6 +134,7 @@ class VF2PostLayout(AnalysisPass):
                 the target set of instructions.
             max_trials (int): The maximum number of trials to run VF2 to find
                 a layout. A value of ``0`` (the default) means 'unlimited'.
+
         Raises:
             TypeError: At runtime, if neither ``coupling_map`` or ``target`` are provided.
         """

--- a/qiskit/transpiler/passes/layout/vf2_post_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_post_layout.py
@@ -106,6 +106,7 @@ class VF2PostLayout(AnalysisPass):
         call_limit=None,
         time_limit=None,
         strict_direction=True,
+        max_trials=0,
     ):
         """Initialize a ``VF2PostLayout`` pass instance
 
@@ -131,7 +132,8 @@ class VF2PostLayout(AnalysisPass):
                 However, if ``strict_direction=True`` the pass expects the input
                 :class:`~.DAGCircuit` object to :meth:`~.VF2PostLayout.run` to be in
                 the target set of instructions.
-
+            max_trials (int): The maximum number of trials to run VF2 to find
+                a layout. A value of ``0`` (the default) means 'unlimited'.
         Raises:
             TypeError: At runtime, if neither ``coupling_map`` or ``target`` are provided.
         """
@@ -141,6 +143,7 @@ class VF2PostLayout(AnalysisPass):
         self.properties = properties
         self.call_limit = call_limit
         self.time_limit = time_limit
+        self.max_trials = max_trials
         self.seed = seed
         self.strict_direction = strict_direction
         self.avg_error_map = None
@@ -310,6 +313,11 @@ class VF2PostLayout(AnalysisPass):
                 )
                 chosen_layout = layout
                 chosen_layout_score = layout_score
+
+            if self.max_trials and trials >= self.max_trials:
+                logger.debug("Trial %s is >= configured max trials %s", trials, self.max_trials)
+                break
+
             elapsed_time = time.time() - start_time
             if self.time_limit is not None and elapsed_time >= self.time_limit:
                 logger.debug(

--- a/releasenotes/notes/vf2-post-layout-max-trials-98b1c736e2e33861.yaml
+++ b/releasenotes/notes/vf2-post-layout-max-trials-98b1c736e2e33861.yaml
@@ -2,7 +2,11 @@
 features:
   - |
     Added a new parameter ``max_trials`` to pass :class:`~.VF2PostLayout`
-    which, when specified,limits the number of trials performed when
-    searching for the best layout. Previously, all possible layouts were
-    always considered, which is not suitable when performing layout of
-    multiple connected components on large devices.
+    which, when specified, limits the number of layouts discovered and
+    compared when searching for the best layout.
+    This differs from existing parameters ``call_limit`` and ``time_limit``
+    (which are used to limit the number of state visits performed by the VF2
+    algorithm and the total time spent by pass :class:`~.VF2PostLayout`,
+    respectively) in that it is used to place an upper bound on the time
+    spent scoring potential layouts, which may be useful for larger
+    devices.

--- a/releasenotes/notes/vf2-post-layout-max-trials-98b1c736e2e33861.yaml
+++ b/releasenotes/notes/vf2-post-layout-max-trials-98b1c736e2e33861.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Added a new parameter ``max_trials`` to pass :class:`~.VF2PostLayout`
+    which, when specified,limits the number of trials performed when
+    searching for the best layout. Previously, all possible layouts were
+    always considered, which is not suitable when performing layout of
+    multiple connected components on large devices.

--- a/test/python/transpiler/test_vf2_post_layout.py
+++ b/test/python/transpiler/test_vf2_post_layout.py
@@ -264,7 +264,7 @@ class TestVF2PostLayout(QiskitTestCase):
         ) as cm:
             pass_.run(dag)
         self.assertIn(
-            f"DEBUG:qiskit.transpiler.passes.layout.vf2_post_layout:Trial {max_trials}"
+            f"DEBUG:qiskit.transpiler.passes.layout.vf2_post_layout:Trial {max_trials} "
             f"is >= configured max trials {max_trials}",
             cm.output,
         )

--- a/test/python/transpiler/test_vf2_post_layout.py
+++ b/test/python/transpiler/test_vf2_post_layout.py
@@ -239,6 +239,34 @@ class TestVF2PostLayout(QiskitTestCase):
         self.assertLayout(dag, cmap, pass_.property_set)
         self.assertNotEqual(pass_.property_set["post_layout"], initial_layout)
 
+    def test_2q_circuit_5q_backend_max_trials(self):
+        """A simple example, without considering the direction
+          0 - 1
+        qr1 - qr0
+        """
+        max_trials = 11
+        backend = FakeYorktown()
+
+        qr = QuantumRegister(2, "qr")
+        circuit = QuantumCircuit(qr)
+        circuit.cx(qr[1], qr[0])  # qr1 -> qr0
+        tqc = transpile(circuit, backend, layout_method="dense")
+        initial_layout = tqc._layout
+        dag = circuit_to_dag(tqc)
+        cmap = CouplingMap(backend.configuration().coupling_map)
+        props = backend.properties()
+        pass_ = VF2PostLayout(coupling_map=cmap, properties=props, seed=self.seed, max_trials=max_trials)
+
+        with self.assertLogs("qiskit.transpiler.passes.layout.vf2_post_layout", level="DEBUG") as cm:
+            pass_.run(dag)
+        self.assertIn(
+            f"DEBUG:qiskit.transpiler.passes.layout.vf2_post_layout:Trial {max_trials} is >= configured max trials {max_trials}",
+            cm.output,
+        )
+
+        self.assertLayout(dag, cmap, pass_.property_set)
+        self.assertNotEqual(pass_.property_set["post_layout"], initial_layout)
+
     def test_best_mapping_ghz_state_full_device_multiple_qregs_v2(self):
         """Test best mappings with multiple registers"""
         backend = FakeLimaV2()

--- a/test/python/transpiler/test_vf2_post_layout.py
+++ b/test/python/transpiler/test_vf2_post_layout.py
@@ -255,12 +255,17 @@ class TestVF2PostLayout(QiskitTestCase):
         dag = circuit_to_dag(tqc)
         cmap = CouplingMap(backend.configuration().coupling_map)
         props = backend.properties()
-        pass_ = VF2PostLayout(coupling_map=cmap, properties=props, seed=self.seed, max_trials=max_trials)
+        pass_ = VF2PostLayout(
+            coupling_map=cmap, properties=props, seed=self.seed, max_trials=max_trials
+        )
 
-        with self.assertLogs("qiskit.transpiler.passes.layout.vf2_post_layout", level="DEBUG") as cm:
+        with self.assertLogs(
+            "qiskit.transpiler.passes.layout.vf2_post_layout", level="DEBUG"
+        ) as cm:
             pass_.run(dag)
         self.assertIn(
-            f"DEBUG:qiskit.transpiler.passes.layout.vf2_post_layout:Trial {max_trials} is >= configured max trials {max_trials}",
+            f"DEBUG:qiskit.transpiler.passes.layout.vf2_post_layout:Trial {max_trials}"
+            f"is >= configured max trials {max_trials}",
             cm.output,
         )
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Adds a new parameter `max_trials` to pass `VF2PostLayout` which, when specified, limits the number of layouts discovered and compared when searching for the best layout.

This can be used to place an upper bound on the time spent scoring potential layouts, which may be useful for larger devices. In a follow-up PR, we'll specify the parameter accordingly when invoking VF2 post layout within the preset pass managers.

