### PR TITLE
Invoke `pip install` by module not executable

### DIFF
--- a/.azure/docs-linux.yml
+++ b/.azure/docs-linux.yml
@@ -22,7 +22,7 @@ jobs:
       - bash: |
           set -e
           python -m pip install --upgrade pip setuptools wheel
-          pip install -U "tox<4.4.0"
+          python -m pip install -U "tox<4.4.0"
           sudo apt-get update
           sudo apt-get install -y graphviz
         displayName: 'Install dependencies'

--- a/.azure/lint-linux.yml
+++ b/.azure/lint-linux.yml
@@ -21,8 +21,8 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel virtualenv
           virtualenv test-job
           source test-job/bin/activate
-          pip install -U pip setuptools wheel
-          pip install -U \
+          python -m pip install -U pip setuptools wheel
+          python -m pip install -U \
             -c constraints.txt \
             -r requirements.txt \
             -r requirements-dev.txt \

--- a/.azure/test-linux.yml
+++ b/.azure/test-linux.yml
@@ -60,11 +60,11 @@ jobs:
             # Use stable Rust, rather than MSRV, to spot-check that stable builds properly.
             rustup override set stable
             source test-job/bin/activate
-            pip install -U pip setuptools wheel
+            python -m pip install -U pip setuptools wheel
             # Install setuptools-rust for building sdist
-            pip install -U -c constraints.txt setuptools-rust
+            python -m pip install -U -c constraints.txt setuptools-rust
             python setup.py sdist
-            pip install -U \
+            python -m pip install -U \
               -c constraints.txt \
               -r requirements.txt \
               -r requirements-dev.txt \
@@ -75,7 +75,7 @@ jobs:
         - bash: |
             set -e
             source test-job/bin/activate
-            pip install -U \
+            python -m pip install -U \
               -c constraints.txt \
               -r requirements.txt \
               -r requirements-dev.txt \
@@ -87,7 +87,7 @@ jobs:
       - bash: |
           set -e
           source test-job/bin/activate
-          pip install -U \
+          python -m pip install -U \
             -c constraints.txt \
             "cplex ; python_version < '3.11'" \
             "qiskit-aer" \
@@ -119,7 +119,7 @@ jobs:
           set -e
           source test-job/bin/activate
           cp tools/subunit_to_junit.py /tmp/terra-tests/.
-          pip install -U junitxml
+          python -m pip install -U junitxml
           pushd /tmp/terra-tests
           mkdir -p junit
           stestr last --subunit | ./subunit_to_junit.py -o junit/test-results.xml
@@ -174,7 +174,7 @@ jobs:
         - bash: |
             set -e
             virtualenv image_tests
-            image_tests/bin/pip install -U \
+            image_tests/bin/python -m pip install -U \
               -c constraints.txt \
               -r requirements.txt \
               -e ".[visualization]"

--- a/.azure/test-macos.yml
+++ b/.azure/test-macos.yml
@@ -34,8 +34,8 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel virtualenv
           virtualenv test-job
           source test-job/bin/activate
-          pip install -U pip setuptools wheel
-          pip install -U \
+          python -m pip install -U pip setuptools wheel
+          python -m pip install -U \
             -c constraints.txt \
             -r requirements.txt \
             -r requirements-dev.txt \
@@ -59,7 +59,7 @@ jobs:
       - bash: |
           set -e
           source test-job/bin/activate
-          pip install -U junitxml
+          python -m pip install -U junitxml
           mkdir -p junit
           stestr last --subunit | tools/subunit_to_junit.py -o junit/test-results.xml
           pushd .stestr

--- a/.azure/test-windows.yml
+++ b/.azure/test-windows.yml
@@ -33,8 +33,8 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel virtualenv
           virtualenv test-job
           source test-job/Scripts/activate
-          pip install -U pip setuptools wheel
-          pip install -U \
+          python -m pip install -U pip setuptools wheel
+          python -m pip install -U \
             -c constraints.txt \
             -r requirements.txt \
             -r requirements-dev.txt \
@@ -63,7 +63,7 @@ jobs:
           set -e
           chcp.com 65001
           source test-job/Scripts/activate
-          pip install -U junitxml
+          python -m pip install -U junitxml
           mkdir -p junit
           stestr last --subunit | python tools/subunit_to_junit.py -o junit/test-results.xml
           pushd .stestr

--- a/.azure/tutorials-linux.yml
+++ b/.azure/tutorials-linux.yml
@@ -22,7 +22,7 @@ jobs:
           set -e
           git clone https://github.com/Qiskit/qiskit-tutorials --depth=1
           python -m pip install --upgrade pip setuptools wheel
-          pip install -U \
+          python -m pip install -U \
             -c constraints.txt \
             -r requirements.txt \
             -r requirements-dev.txt \

--- a/.azure/wheels.yml
+++ b/.azure/wheels.yml
@@ -25,8 +25,8 @@ jobs:
       - bash: |
           set -e
           python -m pip install --upgrade pip
-          pip install cibuildwheel==2.11.2
-          pip install -U twine
+          python -m pip install cibuildwheel==2.11.2
+          python -m pip install -U twine
           cibuildwheel --output-dir wheelhouse .
 
       - task: PublishBuildArtifacts@1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,10 +37,10 @@ jobs:
       # Modern pip (23.1+) can error out if it doesn't have `wheel` and we ask for one
       # of these legacy packages.
       - name: Ensure basic build requirements
-        run: pip install --upgrade pip setuptools wheel
+        run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Build and install qiskit-terra
-        run: pip install -e .
+        run: python -m pip install -e .
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-Cinstrument-coverage"
@@ -50,7 +50,7 @@ jobs:
       - name: Generate unittest coverage report
         run: |
           set -e
-          pip install -r requirements-dev.txt qiskit-aer
+          python -m pip install -r requirements-dev.txt qiskit-aer
           stestr run
           # We set the --source-dir to '.' because we want all paths to appear relative to the repo
           # root (we need to combine them with the Python ones), but we only care about `grcov`

--- a/.github/workflows/randomized_tests.yml
+++ b/.github/workflows/randomized_tests.yml
@@ -15,12 +15,12 @@ jobs:
           python-version: '3.8'
       - name: Install dependencies
         run: |
-          pip install -U pip setuptools wheel
-          pip install -U -r requirements.txt -c constraints.txt
-          pip install -U -r requirements-dev.txt coveralls -c constraints.txt
-          pip install -c constraints.txt -e .
-          pip install "qiskit-ibmq-provider" -c constraints.txt
-          pip install "qiskit-aer"
+          python -m pip install -U pip setuptools wheel
+          python -m pip install -U -r requirements.txt -c constraints.txt
+          python -m pip install -U -r requirements-dev.txt coveralls -c constraints.txt
+          python -m pip install -c constraints.txt -e .
+          python -m pip install "qiskit-ibmq-provider" -c constraints.txt
+          python -m pip install "qiskit-aer"
         env:
           SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
       - name: Run randomized tests

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -15,11 +15,11 @@ jobs:
           python-version: '3.10'
       - name: Install dependencies
         run: |
-          pip install -U pip setuptools wheel
-          pip install -U -r requirements.txt -c constraints.txt
-          pip install -U -r requirements-dev.txt -c constraints.txt
-          pip install -c constraints.txt -e .
-          pip install "qiskit-aer" "z3-solver" "cplex" -c constraints.txt
+          python -m pip install -U pip setuptools wheel
+          python -m pip install -U -r requirements.txt -c constraints.txt
+          python -m pip install -U -r requirements-dev.txt -c constraints.txt
+          python -m pip install -c constraints.txt -e .
+          python -m pip install "qiskit-aer" "z3-solver" "cplex" -c constraints.txt
         env:
           SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
       - name: Run all tests including slow


### PR DESCRIPTION
### Summary

On some OSes and configurations (usually Windows), there can be problems when a binary attempts to one that is in use, especially itself.  For this reason, it is more reliable to use `python -m pip install ...` than `pip install`.  We have seen some CI failures on Windows due to `pip` failing to update itself because of the direct-executable `pip install` form.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments


