### PR TITLE
Fix handling of numpy integers in marginal_distribution()

### DIFF
--- a/qiskit/result/utils.py
+++ b/qiskit/result/utils.py
@@ -231,7 +231,7 @@ def marginal_distribution(
         res = results_rs.marginal_distribution(counts, indices)
     else:
         first_value = next(iter(counts.values()))
-        if isinstance(first_value, int):
+        if isinstance(first_value, (int, np.integer)):
             res = results_rs.marginal_counts(counts, indices)
         elif isinstance(first_value, float):
             res = results_rs.marginal_distribution(counts, indices)

--- a/qiskit/result/utils.py
+++ b/qiskit/result/utils.py
@@ -233,7 +233,7 @@ def marginal_distribution(
         first_value = next(iter(counts.values()))
         if isinstance(first_value, (int, np.integer)):
             res = results_rs.marginal_counts(counts, indices)
-        elif isinstance(first_value, float):
+        elif isinstance(first_value, (float, np.floating)):
             res = results_rs.marginal_distribution(counts, indices)
         else:
             raise QiskitError("Values of counts must be an int or float")

--- a/releasenotes/notes/fix-marginal-distribution-np-ints-ee78859bfda79b60.yaml
+++ b/releasenotes/notes/fix-marginal-distribution-np-ints-ee78859bfda79b60.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed an issue with the :func:`~.marginal_distribution` function where it
+    would incorrectly raise an error when an input counts dictionary was using
+    a numpy integer type instead of the Python int type. The underlying function
+    always would handle the different types correctly, but the input type
+    checking was previously incorrectly raising a ``TypeError`` in this case.

--- a/test/python/result/test_counts.py
+++ b/test/python/result/test_counts.py
@@ -114,6 +114,37 @@ class TestCounts(unittest.TestCase):
         result = utils.marginal_distribution(counts_obj, [0, 1])
         self.assertEqual(expected, result)
 
+    def test_marginal_distribution_int_counts_numpy_64_bit(self):
+        raw_counts = {
+            0: np.int64(4),
+            1: np.int64(7),
+            2: np.int64(10),
+            6: np.int64(5),
+            9: np.int64(11),
+            13: np.int64(9),
+            14: np.int64(8),
+        }
+        expected = {"00": 4, "01": 27, "10": 23}
+        counts_obj = counts.Counts(raw_counts, creg_sizes=[["c0", 4]], memory_slots=4)
+        result = utils.marginal_distribution(counts_obj, [0, 1])
+        self.assertEqual(expected, result)
+
+    def test_marginal_distribution_int_counts_numpy_8_bit(self):
+        raw_counts = {
+            0: np.int8(4),
+            1: np.int8(7),
+            2: np.int8(10),
+            6: np.int8(5),
+            9: np.int8(11),
+            13: np.int8(9),
+            14: np.int8(8),
+        }
+        expected = {"00": 4, "01": 27, "10": 23}
+        counts_obj = counts.Counts(raw_counts, creg_sizes=[["c0", 4]], memory_slots=4)
+        result = utils.marginal_distribution(counts_obj, [0, 1])
+        self.assertEqual(expected, result)
+
+
     def test_int_outcomes_with_int_counts(self):
         raw_counts = {0: 21, 2: 12, 3: 5, 46: 265}
         counts_obj = counts.Counts(raw_counts)

--- a/test/python/result/test_counts.py
+++ b/test/python/result/test_counts.py
@@ -144,7 +144,6 @@ class TestCounts(unittest.TestCase):
         result = utils.marginal_distribution(counts_obj, [0, 1])
         self.assertEqual(expected, result)
 
-
     def test_int_outcomes_with_int_counts(self):
         raw_counts = {0: 21, 2: 12, 3: 5, 46: 265}
         counts_obj = counts.Counts(raw_counts)

--- a/test/python/result/test_quasi.py
+++ b/test/python/result/test_quasi.py
@@ -13,8 +13,10 @@
 """Test conversion to probability distribution"""
 from math import sqrt
 
+import numpy as np
+
 from qiskit.test import QiskitTestCase
-from qiskit.result import QuasiDistribution
+from qiskit.result import QuasiDistribution, marginal_distribution
 
 
 class TestQuasi(QiskitTestCase):
@@ -192,3 +194,38 @@ class TestQuasi(QiskitTestCase):
             assert abs(ans[key] - val) < 1e-14
         # Check if distance calculation is correct
         assert abs(dist - sqrt(0.38)) < 1e-14
+
+    def test_marginal_distribution(self):
+        """Test marginal_distribution with float value."""
+        qprobs = {0: 3 / 5, 1: 1 / 2, 2: 7 / 20, 3: 1 / 10, 4: -11 / 20}
+        dist = QuasiDistribution(qprobs)
+        res = marginal_distribution(dist.binary_probabilities(), [0])
+        expected = {"0": 0.4, "1": 0.6}
+        self.assertDictAlmostEqual(expected, res, delta=0.0001)
+
+    def test_marginal_distribution_np_double(self):
+        """Test marginal_distribution with np double float value."""
+        qprobs = {0: 3 / 5, 1: 1 / 2, 2: 7 / 20, 3: 1 / 10, 4: -11 / 20}
+        qprobs = {k: np.float64(v) for k, v in qprobs.items()}
+        dist = QuasiDistribution(qprobs)
+        res = marginal_distribution(dist.binary_probabilities(), [0])
+        expected = {"0": 0.4, "1": 0.6}
+        self.assertDictAlmostEqual(expected, res, delta=0.0001)
+
+    def test_marginal_distribution_np_single(self):
+        """test marginal_distribution with np single float value."""
+        qprobs = {0: 3 / 5, 1: 1 / 2, 2: 7 / 20, 3: 1 / 10, 4: -11 / 20}
+        qprobs = {k: np.float32(v) for k, v in qprobs.items()}
+        dist = QuasiDistribution(qprobs)
+        res = marginal_distribution(dist.binary_probabilities(), [0])
+        expected = {"0": 0.4, "1": 0.6}
+        self.assertDictAlmostEqual(expected, res, delta=0.0001)
+
+    def test_marginal_distribution_np_half(self):
+        """test marginal_distribution with np half float value."""
+        qprobs = {0: 3 / 5, 1: 1 / 2, 2: 7 / 20, 3: 1 / 10, 4: -11 / 20}
+        qprobs = {k: np.float16(v) for k, v in qprobs.items()}
+        dist = QuasiDistribution(qprobs)
+        res = marginal_distribution(dist.binary_probabilities(), [0])
+        expected = {"0": 0.4, "1": 0.6}
+        self.assertDictAlmostEqual(expected, res, delta=0.001)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an oversight in the input type checking for the marginal_distribution() function. The function which is primarily written in rust has some quick input type checking to raise a more descriptive TypeError if the input distribution/counts object isn't of a known type (and also to dispatch to the correct rust function). This type checking was overly restrictive and would cause an error to be raised if an input counts dictionary was using numpy integer types as a value instead of a python int. This commit updates the type check to treat numpy ints as valid too.

### Details and comments