### PR TITLE
Prevent DefaultUnitarySynthesis from calling synth with bad args

### DIFF
--- a/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
+++ b/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
@@ -83,10 +83,6 @@ class XXDecomposer:
         embodiments: dict[float, QuantumCircuit] | None = None,
         backup_optimizer: Callable[..., QuantumCircuit] | None = None,
     ):
-        if isinstance(basis_fidelity, dict) and len(basis_fidelity) == 0:
-            raise(QiskitError("`basis_fidelity` dictionary is empty."))
-        self.basis_fidelity = basis_fidelity
-
         from qiskit.transpiler.passes.optimization.optimize_1q_decomposition import (
             Optimize1qGatesDecomposition,  # pylint: disable=cyclic-import
         )
@@ -94,6 +90,7 @@ class XXDecomposer:
         self._decomposer1q = Optimize1qGatesDecomposition(ONE_QUBIT_EULER_BASIS_GATES[euler_basis])
         self.embodiments = embodiments if embodiments is not None else {}
         self.backup_optimizer = backup_optimizer
+        self.basis_fidelity = basis_fidelity
 
         # expose one of the basis gates so others can know what this decomposer targets
         embodiment_circuit = next(iter(self.embodiments.values()), QuantumCircuit())

--- a/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
+++ b/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
@@ -83,6 +83,10 @@ class XXDecomposer:
         embodiments: dict[float, QuantumCircuit] | None = None,
         backup_optimizer: Callable[..., QuantumCircuit] | None = None,
     ):
+        if isinstance(basis_fidelity, dict) and len(basis_fidelity) == 0:
+            raise(QiskitError("Basis_fidelity dictionary is empty."))
+        self.basis_fidelity = basis_fidelity
+
         from qiskit.transpiler.passes.optimization.optimize_1q_decomposition import (
             Optimize1qGatesDecomposition,  # pylint: disable=cyclic-import
         )
@@ -90,7 +94,6 @@ class XXDecomposer:
         self._decomposer1q = Optimize1qGatesDecomposition(ONE_QUBIT_EULER_BASIS_GATES[euler_basis])
         self.embodiments = embodiments if embodiments is not None else {}
         self.backup_optimizer = backup_optimizer
-        self.basis_fidelity = basis_fidelity
 
         # expose one of the basis gates so others can know what this decomposer targets
         embodiment_circuit = next(iter(self.embodiments.values()), QuantumCircuit())

--- a/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
+++ b/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
@@ -84,7 +84,7 @@ class XXDecomposer:
         backup_optimizer: Callable[..., QuantumCircuit] | None = None,
     ):
         if isinstance(basis_fidelity, dict) and len(basis_fidelity) == 0:
-            raise(QiskitError("Basis_fidelity dictionary is empty."))
+            raise(QiskitError("`basis_fidelity` dictionary is empty."))
         self.basis_fidelity = basis_fidelity
 
         from qiskit.transpiler.passes.optimization.optimize_1q_decomposition import (

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -675,6 +675,9 @@ class DefaultUnitarySynthesis(plugin.UnitarySynthesisPlugin):
 
         # possible controlled decomposers (i.e. XXDecomposer)
         controlled_basis = {k: v for k, v in available_2q_basis.items() if is_controlled(v)}
+        if len(controlled_basis) == 0:
+            self._decomposer_cache[qubits_tuple] = decomposers
+            return decomposers
         basis_2q_fidelity = {}
         embodiments = {}
         pi2_basis = None


### PR DESCRIPTION
#### Problem
`DefaultUnitarySynthesis` tries to determine which basis gates are controlled gates and then calls a synthesizer with just the "controlled basis".  If the latter is emtpy, the synthesizers will fail by throwing an index-out-of-bounds error. This PR does two things.

[EDIT]  The approach in this PR is probably wrong. The bug that found this was triggered by faulty input data. See #9983.
If we at least one controlled gate should be in the list of supported operations when running `DefaultUnitarySynthesis`, then we should instead raise an error on finding no controlled gates.

If review of this PR determines that this is the correct approach, I will finish items in the TODO list below. (Add tests).

#### Changes

First if an attempt is made to construct a synthesizer of type `XXDecomposer` with an empty basis and an empty backup synthesizer, an error is now raised during construction.

Second, if the controlled basis is empty, `DefaultUnitarySynthesis` doesn't try construct the synthesizer and push it onto the list of synthesizers to use since this will fail.

#### Related GH Issues
See #9935 #9937

#### Potential problems with this PR

I did not check the possibility that the determination of whether a gate is controlled is not always accurate:
https://github.com/Qiskit/qiskit-terra/blob/c4f1b0bd0b3873bcc5807a3c55b7eeceedd18193/qiskit/transpiler/passes/synthesis/unitary_synthesis.py#L646-L652

#### TODO

- [ ] Tests