### PR TITLE
Raise error in XXDecomposer if the dict of basis gates => fidelity is empty

### DIFF
--- a/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
+++ b/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
@@ -83,6 +83,10 @@ class XXDecomposer:
         embodiments: dict[float, QuantumCircuit] | None = None,
         backup_optimizer: Callable[..., QuantumCircuit] | None = None,
     ):
+        if isinstance(basis_fidelity, dict) and len(basis_fidelity) == 0:
+            raise (QiskitError("`basis_fidelity` dictionary is empty."))
+        self.basis_fidelity = basis_fidelity
+
         from qiskit.transpiler.passes.optimization.optimize_1q_decomposition import (
             Optimize1qGatesDecomposition,  # pylint: disable=cyclic-import
         )
@@ -90,7 +94,6 @@ class XXDecomposer:
         self._decomposer1q = Optimize1qGatesDecomposition(ONE_QUBIT_EULER_BASIS_GATES[euler_basis])
         self.embodiments = embodiments if embodiments is not None else {}
         self.backup_optimizer = backup_optimizer
-        self.basis_fidelity = basis_fidelity
 
         # expose one of the basis gates so others can know what this decomposer targets
         embodiment_circuit = next(iter(self.embodiments.values()), QuantumCircuit())

--- a/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
+++ b/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
@@ -85,10 +85,11 @@ class XXDecomposer:
         embodiments: dict[float, QuantumCircuit] | None = None,
         backup_optimizer: Callable[..., QuantumCircuit] | None = None,
     ):
-        if isinstance(basis_fidelity, dict) and len(basis_fidelity) == 0:
-            raise QiskitError("`basis_fidelity` dictionary is empty.")
-        if not isinstance(basis_fidelity, float):
-            raise QiskitError("`basis_fidelity` is neither a non-empty `dict` nor a `float`")
+        if isinstance(basis_fidelity, dict):
+            if len(basis_fidelity) == 0:
+                raise QiskitError("`basis_fidelity` dictionary is empty.")
+        elif not isinstance(basis_fidelity, float):
+            raise QiskitError(f"`basis_fidelity` {basis_fidelity} is neither a non-empty `dict` nor a `float`")
         self.basis_fidelity = basis_fidelity
 
         from qiskit.transpiler.passes.optimization.optimize_1q_decomposition import (

--- a/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
+++ b/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
@@ -70,6 +70,8 @@ class XXDecomposer:
             has no efficient decomposition of its own. Useful for special cases involving 2 or 3
             applications of XX(pi/2), in which case standard synthesis methods provide lower
             1Q gate count.
+    Raises:
+        QiskitError: If `basis_fidelity` is neither a non-empty `dict` nor a `float`.
 
     .. note::
         If ``embodiments`` is not passed, or if an entry is missing, it will be populated as needed
@@ -84,7 +86,9 @@ class XXDecomposer:
         backup_optimizer: Callable[..., QuantumCircuit] | None = None,
     ):
         if isinstance(basis_fidelity, dict) and len(basis_fidelity) == 0:
-            raise (QiskitError("`basis_fidelity` dictionary is empty."))
+            raise QiskitError("`basis_fidelity` dictionary is empty.")
+        if not isinstance(basis_fidelity, float):
+            raise QiskitError("`basis_fidelity` is neither a non-empty `dict` nor a `float`")
         self.basis_fidelity = basis_fidelity
 
         from qiskit.transpiler.passes.optimization.optimize_1q_decomposition import (

--- a/test/python/quantum_info/xx_decompose/test_decomposer.py
+++ b/test/python/quantum_info/xx_decompose/test_decomposer.py
@@ -38,11 +38,11 @@ EPSILON = 1e-8
 class TestXXDecomposer(unittest.TestCase):
     """Tests for decomposition of two-qubit unitaries over discrete gates from XX family."""
 
-    def test_valid_basis_fidelity(self):
+    def test_valid_basis_fidelity1(self):
         """Test that error raised if basis_fidelity=={}"""
         self.assertRaises(QiskitError, XXDecomposer, basis_fidelity={})
 
-    def test_valid_basis_fidelity(self):
+    def test_valid_basis_fidelity2(self):
         """Test that error raised if basis_fidelity==None"""
         self.assertRaises(QiskitError, XXDecomposer, basis_fidelity=None)
 

--- a/test/python/quantum_info/xx_decompose/test_decomposer.py
+++ b/test/python/quantum_info/xx_decompose/test_decomposer.py
@@ -22,6 +22,7 @@ import numpy as np
 from scipy.stats import unitary_group
 
 import qiskit
+from qiskit import QiskitError
 from qiskit.quantum_info.operators import Operator
 from qiskit.quantum_info.synthesis.xx_decompose.decomposer import (
     XXDecomposer,
@@ -36,6 +37,14 @@ EPSILON = 1e-8
 @ddt.ddt
 class TestXXDecomposer(unittest.TestCase):
     """Tests for decomposition of two-qubit unitaries over discrete gates from XX family."""
+
+    def test_valid_basis_fidelity(self):
+        """Test that error raised if basis_fidelity=={}"""
+        self.assertRaises(QiskitError, XXDecomposer, basis_fidelity={})
+
+    def test_valid_basis_fidelity(self):
+        """Test that error raised if basis_fidelity==None"""
+        self.assertRaises(QiskitError, XXDecomposer, basis_fidelity=None)
 
     decomposer = XXDecomposer(euler_basis="PSX")
 


### PR DESCRIPTION
An upstream bug can result in an empty `dict` being passed to XXDecomposer as parameter `basis_fidelity`. This class requires that this `dict`, if supplied, be non-empty.

Currently, in case `basis_fidelity={}` is passed an error will be thrown only when the synthesis is run. In particular an out of bounds error is thrown.

This PR instead throws an error on construction. This will make debugging faster and also signals the unstated intent that the dict not be empty.

#### Details

More precisely,  the docstring states that `basis_fidelity` must be either a `dict` mapping gate names to fidelities or a `float`. This PR raises an error if this is not fulfilled.

#### Related GH issues

An empty `dict` is passed in the example in #9935. Debugging would have been much faster with this PR in place.

This fix is also in #9982. But the current PR should be preferred because it self contained, while it is not clear which changes should be made elsewhere in response to the bug.

