### PR TITLE
Make DefaultUnitarySynthesis omit decomposers when target is incompat…

### DIFF
--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -675,6 +675,9 @@ class DefaultUnitarySynthesis(plugin.UnitarySynthesisPlugin):
 
         # possible controlled decomposers (i.e. XXDecomposer)
         controlled_basis = {k: v for k, v in available_2q_basis.items() if is_controlled(v)}
+        if len(controlled_basis) == 0:
+            self._decomposer_cache[qubits_tuple] = decomposers
+            return decomposers
         basis_2q_fidelity = {}
         embodiments = {}
         pi2_basis = None

--- a/test/python/transpiler/test_unitary_synthesis_plugin.py
+++ b/test/python/transpiler/test_unitary_synthesis_plugin.py
@@ -308,8 +308,9 @@ class TestUnitarySynthesisPlugin(QiskitTestCase):
         self.assertNotIn("config", call_kwargs)
 
     def test_2q_decomposer_with_no_control_gates(self):
-        """Test that an empty list of decomposers is returned from DefaultUnitarySynthesis._decomposer_2q_from_target when
-        no controlled gates are in the target basis."""
+        """Test that an empty list of decomposers is returned from
+        DefaultUnitarySynthesis._decomposer_2q_from_target when no controlled gates are in the
+        target basis."""
         bad_target = Target()
         theta = 1.0
         rz_props = {
@@ -325,8 +326,8 @@ class TestUnitarySynthesisPlugin(QiskitTestCase):
         cx_props = {
             (0, 1): InstructionProperties(duration=519.11e-9, error=0.01201),
         }
-        bogusCXGate = Gate("cx", num_qubits=2, params=[])
-        bad_target.add_instruction(bogusCXGate, cx_props)
+        bogus_cx_gate = Gate("cx", num_qubits=2, params=[])
+        bad_target.add_instruction(bogus_cx_gate, cx_props)
         measure_props = {
             (0,): InstructionProperties(duration=5.813e-6, error=0.0751),
             (1,): InstructionProperties(duration=5.813e-6, error=0.0225),

--- a/test/python/transpiler/test_unitary_synthesis_plugin.py
+++ b/test/python/transpiler/test_unitary_synthesis_plugin.py
@@ -325,7 +325,7 @@ class TestUnitarySynthesisPlugin(QiskitTestCase):
         cx_props = {
             (0, 1): InstructionProperties(duration=519.11e-9, error=0.01201),
         }
-        bogusCXGate = Gate('cx', num_qubits=2, params=[])
+        bogusCXGate = Gate("cx", num_qubits=2, params=[])
         bad_target.add_instruction(bogusCXGate, cx_props)
         measure_props = {
             (0,): InstructionProperties(duration=5.813e-6, error=0.0751),
@@ -337,6 +337,7 @@ class TestUnitarySynthesisPlugin(QiskitTestCase):
         decomposers = plugin._decomposer_2q_from_target(bad_target, [0, 1], 1.0)
 
         self.assertEqual(decomposers, [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
…ible

#### Problem

The 2q composers require controlled gates (up to local unitaries). Previously, if none were present, the composers were constructed and pushed to a list anyway. The transpiler would try to use these and an error would be raised. 

##### Changes

With this commit, constructing and saving the 2q decomposers is not done if no controlled gates are found in the target gate set.

#### Tests

To test this, a target with a "bogus" cx gate with no method to create a matrix is used (See #9983.) Rather than following all the logic, I cut out qubits and gates from the target in the same test file called `ibm_target`. I used more-or-less the minimum target that would trigger the path that this commit touches. There is no test here that the path is in fact triggered. Something could change in future so that this test no longer tests what was intended. I suppose one could also send a target that is identical to the "bad" one except that the bogus cx is replaced with a real cx. In this case, a non-empty list of decomposers would be returned.

#### Relation to other GH issues

Prior to #9984 --not yet merged-- an inscrutable error would be raised in the heart of the decomposition algorithm for XXDecomposer. With #9984 an error is raised when trying to construct the decomposer with no controlled gates and no alternative source of gates.  See other issues linked in #9984

#### Comments

An alternative would be to raise an error if a basis set with no controlled gates is encountered. However, it is not clear to me that this would be an illegitimate basis.