### PR TITLE
Detect attempted synth of entangling gate with empty basis

### DIFF
--- a/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
+++ b/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
@@ -153,9 +153,13 @@ class XXDecomposer:
         while True:
             if len(priority_queue) == 0:
                 if len(available_strengths) == 0:
-                    raise QiskitError("Attempting to synthesize entangling gate with no controlled gates in basis set.")
+                    raise QiskitError(
+                        "Attempting to synthesize entangling gate with no controlled gates in basis set."
+                    )
                 else:
-                    raise QiskitError("Unable to synthesize a 2q unitary with the supplied basis set.")
+                    raise QiskitError(
+                        "Unable to synthesize a 2q unitary with the supplied basis set."
+                    )
 
             sequence_cost, sequence = heapq.heappop(priority_queue)
 

--- a/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
+++ b/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
@@ -151,6 +151,8 @@ class XXDecomposer:
         canonical_coordinate = np.array(canonical_coordinate)
 
         while True:
+            if len(priority_queue) == 0:
+                raise QiskitError("Attempting to synthesize entangling gate with no controlled gates in basis set")
             sequence_cost, sequence = heapq.heappop(priority_queue)
 
             strength_polytope = XXPolytope.from_strengths(*[x / 2 for x in sequence])

--- a/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
+++ b/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
@@ -156,10 +156,7 @@ class XXDecomposer:
                     raise QiskitError(
                         "Attempting to synthesize entangling gate with no controlled gates in basis set."
                     )
-                else:
-                    raise QiskitError(
-                        "Unable to synthesize a 2q unitary with the supplied basis set."
-                    )
+                raise QiskitError("Unable to synthesize a 2q unitary with the supplied basis set.")
 
             sequence_cost, sequence = heapq.heappop(priority_queue)
 

--- a/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
+++ b/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
@@ -152,7 +152,11 @@ class XXDecomposer:
 
         while True:
             if len(priority_queue) == 0:
-                raise QiskitError("Attempting to synthesize entangling gate with no controlled gates in basis set")
+                if len(available_strengths) == 0:
+                    raise QiskitError("Attempting to synthesize entangling gate with no controlled gates in basis set.")
+                else:
+                    raise QiskitError("Unable to synthesize a 2q unitary with the supplied basis set.")
+
             sequence_cost, sequence = heapq.heappop(priority_queue)
 
             strength_polytope = XXPolytope.from_strengths(*[x / 2 for x in sequence])

--- a/test/python/transpiler/test_unitary_synthesis.py
+++ b/test/python/transpiler/test_unitary_synthesis.py
@@ -836,7 +836,7 @@ class TestUnitarySynthesis(QiskitTestCase):
         result_qc = dag_to_circuit(result_dag)
         self.assertEqual(result_qc, QuantumCircuit(2))
 
-    def test_unitary_synthesis_custom_gate_target(self):
+    def test_nonentangling_unitary_synthesis_custom_gate_target(self):
         qc = QuantumCircuit(2)
         qc.unitary(np.eye(4), [0, 1])
         dag = circuit_to_dag(qc)
@@ -856,6 +856,28 @@ class TestUnitarySynthesis(QiskitTestCase):
         result_dag = unitary_synth_pass.run(dag)
         result_qc = dag_to_circuit(result_dag)
         self.assertEqual(result_qc, QuantumCircuit(2))
+
+
+    def test_entangling_unitary_synthesis_custom_gate_target(self):
+        qc = QuantumCircuit(2)
+        cx_matrix = Operator(CXGate()).to_matrix()
+        qc.unitary(cx_matrix, [0, 1])
+        dag = circuit_to_dag(qc)
+
+        class CustomGate(Gate):
+            """Custom Opaque Gate"""
+
+            def __init__(self):
+                super().__init__("custom", 2, [])
+
+        target = Target(num_qubits=2)
+        target.add_instruction(
+            UGate(Parameter("t"), Parameter("p"), Parameter("l")), {(0,): None, (1,): None}
+        )
+        target.add_instruction(CustomGate(), {(0, 1): None, (1, 0): None})
+        unitary_synth_pass = UnitarySynthesis(target=target)
+        with self.assertRaises(QiskitError):
+            unitary_synth_pass.run(dag)
 
     def test_default_does_not_fail_on_no_syntheses(self):
         qc = QuantumCircuit(1)

--- a/test/python/transpiler/test_unitary_synthesis.py
+++ b/test/python/transpiler/test_unitary_synthesis.py
@@ -875,7 +875,10 @@ class TestUnitarySynthesis(QiskitTestCase):
         )
         target.add_instruction(CustomGate(), {(0, 1): None, (1, 0): None})
         unitary_synth_pass = UnitarySynthesis(target=target)
-        with self.assertRaises(QiskitError):
+        with self.assertRaisesRegex(
+            QiskitError,
+            "Attempting to synthesize entangling gate with no controlled gates in basis set.",
+        ):
             unitary_synth_pass.run(dag)
 
     def test_default_does_not_fail_on_no_syntheses(self):

--- a/test/python/transpiler/test_unitary_synthesis.py
+++ b/test/python/transpiler/test_unitary_synthesis.py
@@ -857,7 +857,6 @@ class TestUnitarySynthesis(QiskitTestCase):
         result_qc = dag_to_circuit(result_dag)
         self.assertEqual(result_qc, QuantumCircuit(2))
 
-
     def test_entangling_unitary_synthesis_custom_gate_target(self):
         qc = QuantumCircuit(2)
         cx_matrix = Operator(CXGate()).to_matrix()


### PR DESCRIPTION
If the optimization loop in `XXDecomposer` runs out of options and the supplied basis set of 2q controlled gates is empty, this implies that the unitary to synthesize is entangling, and can't be synthesized.

This PR adds a test to detect this and raise an error.

This PR replaces the (unmerged) PRs #9982 #9984 #9986

See https://github.com/Qiskit/qiskit-terra/issues/9935#issuecomment-1515500629 for a detailed discussion.

*EDIT* this is still not quite right although it passes all existing tests and another one added in this PR. There is another situation that we currently do not  test for that this PR also can't handle correctly. That will go in another issue.