### PR TITLE
Give ownership of output from `Target.build_coupling_map`

### DIFF
--- a/qiskit/providers/backend.py
+++ b/qiskit/providers/backend.py
@@ -354,6 +354,7 @@ class BackendV2(Backend, ABC):
         self.description = description
         self.online_date = online_date
         self.backend_version = backend_version
+        self._coupling_map = None
 
     @property
     def instructions(self) -> List[Tuple[Instruction, Tuple[int]]]:
@@ -387,7 +388,9 @@ class BackendV2(Backend, ABC):
     @property
     def coupling_map(self):
         """Return the :class:`~qiskit.transpiler.CouplingMap` object"""
-        return self.target.build_coupling_map()
+        if self._coupling_map is None:
+            self._coupling_map = self.target.build_coupling_map()
+        return self._coupling_map
 
     @property
     def instruction_durations(self):

--- a/qiskit/transpiler/passes/layout/sabre_layout.py
+++ b/qiskit/transpiler/passes/layout/sabre_layout.py
@@ -36,6 +36,7 @@ from qiskit._accelerate.sabre_swap import (
 )
 from qiskit.transpiler.passes.routing.sabre_swap import process_swaps, apply_gate
 from qiskit.transpiler.target import Target
+from qiskit.transpiler.coupling import CouplingMap
 from qiskit.tools.parallel import CPU_COUNT
 
 logger = logging.getLogger(__name__)
@@ -150,10 +151,11 @@ class SabreLayout(TransformationPass):
         self.skip_routing = skip_routing
         if self.coupling_map is not None:
             if not self.coupling_map.is_symmetric:
-                # deepcopy is needed here to avoid modifications updating
-                # shared references in passes which require directional
-                # constraints
-                self.coupling_map = copy.deepcopy(self.coupling_map)
+                # deepcopy is needed here if we don't own the coupling map (i.e. we were passed it
+                # directly) to avoid modifications updating shared references in passes which
+                # require directional constraints
+                if isinstance(coupling_map, CouplingMap):
+                    self.coupling_map = copy.deepcopy(self.coupling_map)
                 self.coupling_map.make_symmetric()
             self._neighbor_table = NeighborTable(rx.adjacency_matrix(self.coupling_map.graph))
 

--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -19,6 +19,7 @@ import rustworkx
 
 from qiskit.circuit.library.standard_gates import SwapGate
 from qiskit.transpiler.basepasses import TransformationPass
+from qiskit.transpiler.coupling import CouplingMap
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.target import Target
@@ -151,7 +152,7 @@ class SabreSwap(TransformationPass):
             # A deepcopy is needed here if we don't own the coupling map (i.e. we were given it,
             # rather than calculated it from the Target), to avoid modifications updating shared
             # references in passes which require directional constraints.
-            if self.target is None:
+            if isinstance(coupling_map, CouplingMap):
                 self.coupling_map = deepcopy(self.coupling_map)
             self.coupling_map.make_symmetric()
         self._neighbor_table = None

--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -148,10 +148,11 @@ class SabreSwap(TransformationPass):
             self.coupling_map = coupling_map
             self.target = None
         if self.coupling_map is not None and not self.coupling_map.is_symmetric:
-            # A deepcopy is needed here to avoid modifications updating
-            # shared references in passes which require directional
-            # constraints
-            self.coupling_map = deepcopy(self.coupling_map)
+            # A deepcopy is needed here if we don't own the coupling map (i.e. we were given it,
+            # rather than calculated it from the Target), to avoid modifications updating shared
+            # references in passes which require directional constraints.
+            if self.target is None:
+                self.coupling_map = deepcopy(self.coupling_map)
             self.coupling_map.make_symmetric()
         self._neighbor_table = None
         if self.coupling_map is not None:

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -1001,7 +1001,7 @@ class Target(Mapping):
 
         If there is a mix of two qubit operations that have a connectivity
         constraint and those that are globally defined this will also return
-        ``None`` because the globally connectivity means there is no contstraint
+        ``None`` because the globally connectivity means there is no constraint
         on the target. If you wish to see the constraints of the two qubit
         operations that have constraints you should use the ``two_q_gate``
         argument to limit the output to the gates which have a constraint.
@@ -1059,17 +1059,16 @@ class Target(Mapping):
             if filter_idle_qubits:
                 cmap.graph = self._filter_coupling_graph()
             else:
-                cmap.graph = self._coupling_graph
+                cmap.graph = self._coupling_graph.copy()
             return cmap
         else:
             return None
 
     def _filter_coupling_graph(self):
         has_operations = set(itertools.chain.from_iterable(self.qargs))
-        graph = self._coupling_graph
+        graph = self._coupling_graph.copy()
         to_remove = set(graph.node_indices()).difference(has_operations)
         if to_remove:
-            graph = graph.copy()
             graph.remove_nodes_from(list(to_remove))
         return graph
 

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -12,10 +12,12 @@
 
 """Tests basic functionality of the transpile function"""
 
+import copy
 import io
 import os
 import sys
 import math
+import unittest
 
 from logging import StreamHandler, getLogger
 from unittest.mock import patch
@@ -57,6 +59,7 @@ from qiskit.providers.fake_provider import (
     FakeBoeblingen,
     FakeMumbaiV2,
     FakeNairobiV2,
+    FakeSherbrooke,
 )
 from qiskit.transpiler import Layout, CouplingMap
 from qiskit.transpiler import PassManager, TransformationPass
@@ -2838,3 +2841,17 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
         qc.x(4)
         with self.assertRaises(TranspilerError):
             transpile(qc, target=target, optimization_level=opt_level)
+
+    @data(0, 1, 2, 3)
+    def test_transpile_does_not_affect_backend_coupling(self, opt_level):
+        """Test that transpiliation of a circuit does not mutate the `CouplingMap` stored by a V2
+        backend.  Regression test of gh-9997."""
+        if opt_level == 3:
+            raise unittest.SkipTest("unitary resynthesis fails due to gh-10004")
+        qc = QuantumCircuit(127)
+        for i in range(1, 127):
+            qc.ecr(0, i)
+        backend = FakeSherbrooke()
+        original_map = copy.deepcopy(backend.coupling_map)
+        transpile(qc, backend, optimization_level=opt_level)
+        self.assertEqual(original_map, backend.coupling_map)


### PR DESCRIPTION
### Summary

Previously, the return value from `Target.build_coupling_map` could contain a shared reference to the underlying `PyDiGraph`, which subsequent calls to `make_symmetric` could mutate, affecting the backing `Target` and consequently backend.  This now always causes `build_coupling_map` to return a value that is fully owned by the caller, removes some now-redundant copies in other parts of the stack, and adds a manual cache into the `BackendV2.coupling_map` property to avoid performance surprises there.  `BackendV2.coupling_map` was previously relying on `build_coupling_map` being cached for its performance, so this makes it more explicit.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Fix #9997 

This is something we probably ought to logically do to avoid other surprises later down the line, and it immediately fixes the issue.  However, we also most likely want to inline the handling of directional coupling maps within Sabre anyway.  That can be done separately.