### PR TITLE
[WIP] for-loop optimization pass

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -5032,6 +5032,7 @@ def _bit_argument_conversion(specifier, bit_sequence, bit_set, type_) -> list[Bi
         try:
             return [bit_sequence[specifier]]
         except IndexError as ex:
+            breakpoint()
             raise CircuitError(
                 f"Index {specifier} out of range for size {len(bit_sequence)}."
             ) from ex

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -5032,7 +5032,6 @@ def _bit_argument_conversion(specifier, bit_sequence, bit_set, type_) -> list[Bi
         try:
             return [bit_sequence[specifier]]
         except IndexError as ex:
-            breakpoint()
             raise CircuitError(
                 f"Index {specifier} out of range for size {len(bit_sequence)}."
             ) from ex

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -1850,7 +1850,7 @@ class DAGCircuit:
         }
         return summary
 
-    def draw(self, scale=0.7, filename=None, style="color"):
+    def draw(self, scale=0.7, filename=None, style="color", **kwargs):
         """
         Draws the dag circuit.
 
@@ -1863,11 +1863,11 @@ class DAGCircuit:
             style (str):
                 'plain': B&W graph;
                 'color' (default): color input/output/op nodes
-
+            kwargs (dict): addtional keyword arguments understood by dag_drawer
         Returns:
             Ipython.display.Image: if in Jupyter notebook and not saving to file,
             otherwise None.
         """
         from qiskit.visualization.dag_visualization import dag_drawer
 
-        return dag_drawer(dag=self, scale=scale, filename=filename, style=style)
+        return dag_drawer(dag=self, scale=scale, filename=filename, style=style, **kwargs)

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -1536,23 +1536,20 @@ class DAGCircuit:
         and [DAGNode] is its predecessors in BFS order.
         """
         from collections import deque
+
         queue = deque([(node, None)])
         visited = set()
         children = dict()
         while queue:
-            node, pred = queue.popleft()
-            if node not in visited:
-                visited.add(node)
-                if pred is not None and isinstance(pred, DAGOpNode):
-                    if pred not in children:
-                        children[pred] = []
-                    children[pred].append(node)
-                for child_node in self.predecessors(node):
-                    if child_node not in visited and isinstance(child_node, DAGOpNode):
-                        queue.append((child_node, node))
-        for parent, child_list in children.items():
-            yield parent, child_list
-
+            parent, pred = queue.popleft()
+            if parent not in visited:
+                visited.add(parent)
+                children = [
+                    child for child in self.predecessors(parent) if isinstance(child, DAGOpNode)
+                ]
+                if pred is not None:
+                    yield parent, children
+                queue.extend((child, parent) for child in children if child not in visited)
 
     def bfs_successors(self, node):
         """

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -1530,6 +1530,30 @@ class DAGCircuit:
         """Returns set of the descendants of a node as DAGOpNodes and DAGOutNodes."""
         return {self._multi_graph[x] for x in rx.descendants(self._multi_graph, node._node_id)}
 
+    def bfs_predecessors(self, node):
+        """
+        Returns an iterator of tuples of (DAGNode, [DAGNodes]) where the DAGNode is the current node
+        and [DAGNode] is its predecessors in BFS order.
+        """
+        from collections import deque
+        queue = deque([(node, None)])
+        visited = set()
+        children = dict()
+        while queue:
+            node, pred = queue.popleft()
+            if node not in visited:
+                visited.add(node)
+                if pred is not None and isinstance(pred, DAGOpNode):
+                    if pred not in children:
+                        children[pred] = []
+                    children[pred].append(node)
+                for child_node in self.predecessors(node):
+                    if child_node not in visited and isinstance(child_node, DAGOpNode):
+                        queue.append((child_node, node))
+        for parent, child_list in children.items():
+            yield parent, child_list
+
+
     def bfs_successors(self, node):
         """
         Returns an iterator of tuples of (DAGNode, [DAGNodes]) where the DAGNode is the current node

--- a/qiskit/transpiler/passes/optimization/__init__.py
+++ b/qiskit/transpiler/passes/optimization/__init__.py
@@ -35,3 +35,4 @@ from .collect_linear_functions import CollectLinearFunctions
 from .reset_after_measure_simplification import ResetAfterMeasureSimplification
 from .optimize_cliffords import OptimizeCliffords
 from .collect_cliffords import CollectCliffords
+from .loop_unrolling import UnrollForLoops, ForLoopBodyOptimizer

--- a/qiskit/transpiler/passes/optimization/loop_unrolling.py
+++ b/qiskit/transpiler/passes/optimization/loop_unrolling.py
@@ -1,0 +1,135 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Loop unrolling optimizations"""
+
+import numpy as np
+
+from qiskit.transpiler.basepasses import TransformationPass
+from qiskit.transpiler.passes.utils import control_flow
+from qiskit.transpiler.exceptions import TranspilerError
+from qiskit.circuit import IfElseOp, WhileLoopOp, ForLoopOp, ControlFlowOp, Instruction, Parameter
+from qiskit.converters import dag_to_circuit, circuit_to_dag
+
+
+class UnrollForLoops(TransformationPass):
+    """Unroll for loops."""
+
+    def run(self, dag):
+        for node in dag.op_nodes(op=ForLoopOp):
+            indexset, loop_parameter, body = node.op.params
+            new_circ = body.copy_empty_like()
+            if loop_parameter is None:
+                for _ in range(len(indexset)):
+                    new_circ.compose(body.copy(), inplace=True)
+            elif isinstance(loop_parameter, Parameter):
+                for index in range(len(indexset)):
+                    i_body = body.assign_parameters({loop_parameter: index},
+                                                    inplace=False)
+                    new_circ.compose(i_body, inplace=True)
+            new_dag = circuit_to_dag(new_circ)
+            dag.substitute_node_with_dag(node, new_dag)
+        return dag
+    
+    
+class ForLoopBodyOptimizer(TransformationPass):
+    """Optimize for loop bodies."""
+            
+    def __init__(self, opt_manager=None, pre_opt_cnt=None, inter_opt_cnt=None, post_opt_cnt=None):
+        """
+        Initialize for loop unroller. 
+
+        Args: 
+           opt_manager (None or PassManager): Attempt to optimize loop body across loop
+             boundaries.
+           pre_opt_cnt (None or int): how many operation back to check
+           inter_opt_cnt (None or int): how deep to check from the front and back
+           post_opt_cnt (None or int): how many operations to consider off the back
+        """
+        self._opt = opt_manager
+        self._pre_opt_cnt = pre_opt_cnt
+        self._inter_opt_cnt = inter_opt_cnt
+        self._post_opt_cnt = post_opt_cnt
+        self._global_index_map = None
+
+    def run(self, dag):
+        self._global_index_map = {wire: idx for idx, wire in enumerate(dag.qubits)}
+        for node in dag.op_nodes(op=ForLoopOp):
+            # Optimize order here with pass manager?
+            self._optimize_pre(dag, node)
+            self._optimize_inter(dag, node)
+            self._optimize_post(dag, node)
+        return dag
+
+    def _optimize_pre(self, dag, node):
+        indexset, loop_parameter, body = node.op.params
+        trial_dag_in, block = _get_predecessor_dag(dag, node, self._pre_opt_cnt)
+        #TODO: elliminate this conversion
+        trial_dag_out = circuit_to_dag(self._opt.run([dag_to_circuit(trial_dag_in)]))
+        breakpoint()
+        if sum(trial_dag_out.count_ops().values()) < sum(trial_dag_in.count_ops().values()):
+            _replace_block_with_dag(dag, block, trial_dag_out)
+        breakpoint()
+
+def _get_predecessor_dag(dag, node, cnt):
+    """get the circuit formed from the body of the for-loop node and 
+    previous cnt nodes"""
+    indexset, loop_parameter, body = node.op.params
+
+    # extract body of for_loop into new dag
+    trial_dag.global_phase = 0
+    qubit_map = {body_qubit: dag_qubit for body_qubit, dag_qubit in zip(body.qubits, node.qargs)}
+    clbit_map = {body_qubit: dag_qubit for body_clbit, dag_clbit in zip(body.clbits, node.cargs)}
+    for circ_instr in body.data:
+        qargs = [qubit_map[qubit] for qubit in circ_instr.qubits]
+        cargs = [clbit_map[qubit] for clbit in circ_instr.clbits]        
+        trial_dag.apply_operation_back(circ_instr.operation, qargs=qargs, cargs=cargs)
+
+    # add predecessor nodes from dag
+    pre_iter = dag.predecessors(node)
+    block = [] # tracks the nodes added from _outside_ the loop
+    while cnt > 0:
+        print(f"cnt: {cnt}")
+        try:
+            this_node = next(pre_iter)
+        except StopIteration:
+            break
+        else:
+            cnt -= 1            
+        block.append(this_node)
+        trial_dag.apply_operation_front(this_node.op, qargs=this_node.qargs, cargs=this_node.cargs)
+    return trial_dag, block
+
+def _replace_block_with_dag(dag, block_a, dag_b):
+    """
+    Substitute a block of nodes with a dag
+    There should be 1-to-1 correspondance between qubits in block_a and dag_b.
+    """
+    block_qubit_inds = sorted([dag.qubits.index(bit) for node in block_a for bit in node.qargs])
+    if len(block_qubit_inds) != dag_b.num_qubits:
+        breakpoint()
+        raise TranspilerError(f"Number of qubits in block does not match replacement DAG")
+    block_clbit_inds = sorted([dag.clbits.index(bit) for node in block_a for bit in node.cargs])
+    index_map = {dag.qubits[ind]: ind for ind in block_qubit_inds}
+    wire_map = {dag_b.qubits[index]: dag.qubits[qubit_ind]
+                for index, qubit_ind in enumerate(block_qubit_inds)}
+    placeholder_op = Instruction("placeholder", len(block_qubit_inds), len(block_clbit_inds), params=[])
+    placeholder_node = dag.replace_block_with_op(
+        block_a, placeholder_op, index_map
+    )
+    node_id_map = dag.substitute_node_with_dag(placeholder_node, dag_b)
+    node_map = {node: node_id_map[node._node_id] for node in dag_b.op_nodes()}
+    return node_map
+
+def print_ids(qubits):
+    for bit in qubits:
+        print(hex(id(bit)), repr(bit))

--- a/qiskit/transpiler/passes/optimization/loop_unrolling.py
+++ b/qiskit/transpiler/passes/optimization/loop_unrolling.py
@@ -12,13 +12,9 @@
 
 """Loop unrolling optimizations"""
 
-import numpy as np
-
 from qiskit.transpiler.basepasses import TransformationPass
-from qiskit.transpiler.passes.utils import control_flow
 from qiskit.transpiler.exceptions import TranspilerError
-from qiskit.circuit import IfElseOp, WhileLoopOp, ForLoopOp, ControlFlowOp, Instruction, Parameter
-from qiskit.dagcircuit import DAGInNode, DAGOutNode
+from qiskit.circuit import ForLoopOp, Instruction, Parameter
 from qiskit.converters import dag_to_circuit, circuit_to_dag
 
 
@@ -34,29 +30,28 @@ class UnrollForLoops(TransformationPass):
                     new_circ.compose(body.copy(), inplace=True)
             elif isinstance(loop_parameter, Parameter):
                 for index in range(len(indexset)):
-                    i_body = body.assign_parameters({loop_parameter: index},
-                                                    inplace=False)
+                    i_body = body.assign_parameters({loop_parameter: index}, inplace=False)
                     new_circ.compose(i_body, inplace=True)
             new_dag = circuit_to_dag(new_circ)
             dag.substitute_node_with_dag(node, new_dag)
         return dag
-    
-    
+
+
 class ForLoopBodyOptimizer(TransformationPass):
     """Optimize for loop bodies."""
-            
+
     def __init__(self, opt_manager=None, pre_opt_cnt=0, inter_opt_cnt=0, post_opt_cnt=0):
         """
-        Initialize for loop unroller. 
+        Initialize for loop unroller.
 
-        Args: 
+        Args:
            opt_manager (None or PassManager): Attempt to optimize loop body across loop
              boundaries.
            pre_opt_cnt (None or int): how many operation back to check
            inter_opt_cnt (None or int): how deep to check from the front and back
            post_opt_cnt (None or int): how many operations to consider off the back
         """
-        super().__init__()        
+        super().__init__()
         self._opt = opt_manager
         self._pre_opt_cnt = pre_opt_cnt
         self._inter_opt_cnt = inter_opt_cnt
@@ -76,12 +71,11 @@ class ForLoopBodyOptimizer(TransformationPass):
     def _optimize_pre(self, dag, node):
         indexset, loop_parameter, body = node.op.params
         trial_dag_in, block = _get_predecessor_dag(dag, node, self._pre_opt_cnt)
-        #TODO: elliminate this conversion
+        # TODO: elliminate this conversion
         trial_dag_out = circuit_to_dag(self._opt.run([dag_to_circuit(trial_dag_in)])[0])
         if sum(trial_dag_out.count_ops().values()) < sum(trial_dag_in.count_ops().values()):
             # trim idle qubits so block qubits matches trial_dag_out
             trial_dag_out.remove_qubits(*trial_dag_out.idle_wires())
-            print(dag_to_circuit(trial_dag_out))
             _replace_block_with_dag(dag, block, trial_dag_out)
             if len(indexset) > 1:
                 new_for_loop = node.op.copy()
@@ -93,12 +87,11 @@ class ForLoopBodyOptimizer(TransformationPass):
     def _optimize_post(self, dag, node):
         indexset, loop_parameter, body = node.op.params
         trial_dag_in, block = _get_successor_dag(dag, node, self._post_opt_cnt)
-        #TODO: elliminate this conversion
+        # TODO: elliminate this conversion
         trial_dag_out = circuit_to_dag(self._opt.run([dag_to_circuit(trial_dag_in)])[0])
         if sum(trial_dag_out.count_ops().values()) < sum(trial_dag_in.count_ops().values()):
             # trim idle qubits so block qubits matches trial_dag_out
             trial_dag_out.remove_qubits(*trial_dag_out.idle_wires())
-            print(dag_to_circuit(trial_dag_out))
             _replace_block_with_dag(dag, block, trial_dag_out)
             if len(indexset) > 1:
                 new_for_loop = node.op.copy()
@@ -106,73 +99,69 @@ class ForLoopBodyOptimizer(TransformationPass):
                 dag.substitute_node(node, new_for_loop)
             else:
                 dag.remove_op_node(node)
-                
+
+
 def _get_predecessor_dag(dag, node, cnt):
-    """get the circuit formed from the body of the for-loop node and 
+    """get the circuit formed from the body of the for-loop node and
     previous cnt nodes"""
-    indexset, loop_parameter, body = node.op.params
+    _, _, body = node.op.params
 
     # extract body of for_loop into new dag
     trial_dag = dag.copy_empty_like()
     trial_dag.global_phase = 0
-    qubit_map = {body_qubit: dag_qubit for body_qubit, dag_qubit in zip(body.qubits, node.qargs)}
-    clbit_map = {body_qubit: dag_qubit for body_clbit, dag_clbit in zip(body.clbits, node.cargs)}
+    qubit_map = dict(zip(body.qubits, node.qargs))
+    clbit_map = dict(zip(body.clbits, node.cargs))
     for circ_instr in body.data:
         qargs = [qubit_map[qubit] for qubit in circ_instr.qubits]
-        cargs = [clbit_map[qubit] for clbit in circ_instr.clbits]        
+        cargs = [clbit_map[clbit] for clbit in circ_instr.clbits]
         trial_dag.apply_operation_back(circ_instr.operation, qargs=qargs, cargs=cargs)
     # add predecessor nodes from dag
     pre_iter = dag.bfs_predecessors(node)
-    block = [] # tracks the nodes added from _outside_ the loop
+    block = []  # tracks the nodes added from _outside_ the loop
     while cnt > 0:
-        print(f"cnt: {cnt} {node.name}")
         try:
             node_rec = next(pre_iter)
-            print(node_rec)
         except StopIteration:
-            print('stop iteration')
-            breakpoint()
             break
-        for child_node in node_rec[1]:
-            print(repr(child_node))
-            block.append(child_node)
-            trial_dag.apply_operation_front(child_node.op, qargs=child_node.qargs, cargs=child_node.cargs)
-            cnt -= 1
+        this_node = node_rec[0]
+        trial_dag.apply_operation_front(this_node.op, qargs=this_node.qargs, cargs=this_node.cargs)
+        block.append(this_node)
+        cnt -= 1
     return trial_dag, block
 
+
 def _get_successor_dag(dag, node, cnt):
-    """get the circuit formed from the body of the for-loop node and 
+    """get the circuit formed from the body of the for-loop node and
     subsequent cnt nodes"""
-    indexset, loop_parameter, body = node.op.params
+    _, _, body = node.op.params
 
     # extract body of for_loop into new dag
     trial_dag = dag.copy_empty_like()
     trial_dag.global_phase = 0
-    qubit_map = {body_qubit: dag_qubit for body_qubit, dag_qubit in zip(body.qubits, node.qargs)}
-    clbit_map = {body_qubit: dag_qubit for body_clbit, dag_clbit in zip(body.clbits, node.cargs)}
+    qubit_map = dict(zip(body.qubits, node.qargs))
+    clbit_map = dict(zip(body.clbits, node.cargs))
     for circ_instr in body.data:
         qargs = [qubit_map[qubit] for qubit in circ_instr.qubits]
-        cargs = [clbit_map[qubit] for clbit in circ_instr.clbits]        
+        cargs = [clbit_map[clbit] for clbit in circ_instr.clbits]
         trial_dag.apply_operation_back(circ_instr.operation, qargs=qargs, cargs=cargs)
 
     # add predecessor nodes from dag
     post_iter = dag.bfs_successors(node)
 
-    block = [] # tracks the nodes added from _outside_ the loop
+    block = []  # tracks the nodes added from _outside_ the loop
     while cnt > 0:
-        print(f"cnt: {cnt}")
         try:
             node_rec = next(post_iter)
         except StopIteration:
-            print('stop iteration')
-            breakpoint()
             break
         for child_node in node_rec[1]:
-            print(repr(child_node))
             block.append(child_node)
-            trial_dag.apply_operation_back(child_node.op, qargs=child_node.qargs, cargs=child_node.cargs)
+            trial_dag.apply_operation_back(
+                child_node.op, qargs=child_node.qargs, cargs=child_node.cargs
+            )
             cnt -= 1
     return trial_dag, block
+
 
 def _replace_block_with_dag(dag, block_a, dag_b):
     """
@@ -180,21 +169,18 @@ def _replace_block_with_dag(dag, block_a, dag_b):
     There should be 1-to-1 correspondance between qubits in block_a and dag_b.
     """
     block_qubit_inds = sorted({dag.qubits.index(bit) for node in block_a for bit in node.qargs})
-    if len(block_qubit_inds) != dag_b.num_qubits():
-        breakpoint()
-        raise TranspilerError(f"Number of qubits in block does not match replacement DAG")
+    num_block_qubits = len(block_qubit_inds)
+    if num_block_qubits != dag_b.num_qubits():
+        raise TranspilerError(
+            f"Number of qubits in block ({num_block_qubits}) "
+            f"does not match replacement DAG ({dag_b.num_qubits()})"
+        )
     block_clbit_inds = sorted([dag.clbits.index(bit) for node in block_a for bit in node.cargs])
     index_map = {dag.qubits[ind]: ind for ind in block_qubit_inds}
-    wire_map = {dag_b.qubits[index]: dag.qubits[qubit_ind]
-                for index, qubit_ind in enumerate(block_qubit_inds)}
-    placeholder_op = Instruction("placeholder", len(block_qubit_inds), len(block_clbit_inds), params=[])
-    placeholder_node = dag.replace_block_with_op(
-        block_a, placeholder_op, index_map
+    placeholder_op = Instruction(
+        "placeholder", len(block_qubit_inds), len(block_clbit_inds), params=[]
     )
+    placeholder_node = dag.replace_block_with_op(block_a, placeholder_op, index_map)
     node_id_map = dag.substitute_node_with_dag(placeholder_node, dag_b)
     node_map = {node: node_id_map[node._node_id] for node in dag_b.op_nodes()}
     return node_map
-
-def print_ids(qubits):
-    for bit in qubits:
-        print(hex(id(bit)), repr(bit))

--- a/qiskit/transpiler/passes/optimization/loop_unrolling.py
+++ b/qiskit/transpiler/passes/optimization/loop_unrolling.py
@@ -16,6 +16,7 @@ from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.circuit import ForLoopOp, Instruction, Parameter
 from qiskit.converters import dag_to_circuit, circuit_to_dag
+from qiskit.dagcircuit import DAGCircuit
 
 
 class UnrollForLoops(TransformationPass):
@@ -40,37 +41,49 @@ class UnrollForLoops(TransformationPass):
 class ForLoopBodyOptimizer(TransformationPass):
     """Optimize for loop bodies."""
 
-    def __init__(self, opt_manager=None, pre_opt_cnt=0, inter_opt_cnt=0, post_opt_cnt=0):
+    def __init__(self, opt_manager=None, pre_opt_limit=0, jamming_limit=0, post_opt_limit=0):
         """
         Initialize for loop unroller.
 
         Args:
-           opt_manager (None or PassManager): Attempt to optimize loop body across loop
-             boundaries.
-           pre_opt_cnt (None or int): how many operation back to check
-           inter_opt_cnt (None or int): how deep to check from the front and back
-           post_opt_cnt (None or int): how many operations to consider off the back
+           opt_manager (PassManager): Attempt to optimize loop body across loop
+             boundaries using specified PassManager
+           pre_opt_limit (int): how many operation back to check
+           jamming_cnt (int): how many loops to consider jamming together. This should
+             be an integer greater >= 2.
+           post_opt_limit (int): how many operations to consider off the back
         """
         super().__init__()
         self._opt = opt_manager
-        self._pre_opt_cnt = pre_opt_cnt
-        self._inter_opt_cnt = inter_opt_cnt
-        self._post_opt_cnt = post_opt_cnt
+        self._pre_opt_limit = pre_opt_limit
+        if jamming_limit >= 2 or jamming_limit == 0:
+            self._jamming_limit = jamming_limit
+        else:
+            raise TranspilerError(f"loop jamming limit set too small: {jamming_limit} < 2")
+        self._post_opt_limit = post_opt_limit
         self._global_index_map = None
 
     def run(self, dag):
         self._global_index_map = {wire: idx for idx, wire in enumerate(dag.qubits)}
         for node in dag.op_nodes(op=ForLoopOp):
             # Optimize order here with pass manager?
-            if self._pre_opt_cnt:
+            if self._pre_opt_limit:
                 self._optimize_pre(dag, node)
-            if self._post_opt_cnt:
+            if self._post_opt_limit:
                 self._optimize_post(dag, node)
+            if self._jamming_limit:
+                self._loop_jamming(dag, node)
         return dag
 
     def _optimize_pre(self, dag, node):
+        """optimize body of for-loop with gates before it
+
+        Args:
+            dag (DAGCircuit): circuit to optimize
+            node (DAGNode): for-loop dag node
+        """
         indexset, loop_parameter, body = node.op.params
-        trial_dag_in, block = _get_predecessor_dag(dag, node, self._pre_opt_cnt)
+        trial_dag_in, block = _get_predecessor_dag(dag, node, self._pre_opt_limit)
         # TODO: elliminate this conversion
         trial_dag_out = circuit_to_dag(self._opt.run([dag_to_circuit(trial_dag_in)])[0])
         if sum(trial_dag_out.count_ops().values()) < sum(trial_dag_in.count_ops().values()):
@@ -85,8 +98,14 @@ class ForLoopBodyOptimizer(TransformationPass):
                 dag.remove_op_node(node)
 
     def _optimize_post(self, dag, node):
+        """optimize body of for-loop with gates after it
+
+        Args:
+            dag (DAGCircuit): circuit to optimize
+            node (DAGNode): for-loop dag node
+        """
         indexset, loop_parameter, body = node.op.params
-        trial_dag_in, block = _get_successor_dag(dag, node, self._post_opt_cnt)
+        trial_dag_in, block = _get_successor_dag(dag, node, self._post_opt_limit)
         # TODO: elliminate this conversion
         trial_dag_out = circuit_to_dag(self._opt.run([dag_to_circuit(trial_dag_in)])[0])
         if sum(trial_dag_out.count_ops().values()) < sum(trial_dag_in.count_ops().values()):
@@ -99,6 +118,56 @@ class ForLoopBodyOptimizer(TransformationPass):
                 dag.substitute_node(node, new_for_loop)
             else:
                 dag.remove_op_node(node)
+
+    def _frequency_reduction(self, dag, node):
+        """extract invariant operations outside the loop"""
+        raise NotImplementedError()
+
+    def _loop_jamming(self, dag, node):
+        """fuse two or more loops
+
+        Args:
+            dag (DAGCircuit): circuit to optimize
+            node (DAGOpNode): for-loop dag node
+        """
+        # scale up to limit
+        indexset, loop_parameter, body = node.op.params
+        loop_cnt = len(indexset)
+        base_cost = sum(body.count_ops().values())
+        trial_records = []  # cost for jamming up to self._jamming_limit loops
+        trial_num_loops = list(range(2, min(self._jamming_limit, loop_cnt)))
+        for num_loops in trial_num_loops:
+            quot, rem = divmod(loop_cnt, num_loops)
+            trial_circ_in = body.copy_empty_like()
+            for _ in range(num_loops):
+                trial_circ_in.compose(body, inplace=True)
+            trial_circ_out = self._opt.run([trial_circ_in])[0]
+            new_body_cost = sum(trial_circ_out.count_ops().values())
+            this_cost = quot * new_body_cost
+            if rem:
+                # TODO: decide whether to unroll remainder iteration(s) before or after loop
+                this_cost += rem * base_cost
+            record = {"body": trial_circ_out, "cost": this_cost, "loop_divmod": (quot, rem)}
+            trial_records.append(record)
+        index_jamming_cost = [record["cost"] for record in trial_records]
+        min_trial_cost = min(index_jamming_cost)
+        if min_trial_cost < loop_cnt * base_cost:
+            best_index = index_jamming_cost.index(min_trial_cost)
+            best_record = trial_records[best_index]
+            quot, rem = best_record["loop_divmod"]
+            cf_op = ForLoopOp(range(quot), loop_parameter, best_record["body"])
+            new_dag = DAGCircuit()
+            new_dag.add_qubits(body.qubits)
+            new_dag.add_clbits(body.clbits)
+            new_dag.apply_operation_back(cf_op, qargs=node.qargs, cargs=node.cargs)
+            if rem:
+                # TODO: use _optimize_pre/_optimize_post to decide whether to apply remainder to
+                # front or back
+                for cinstr in body.data:
+                    new_dag.apply_operation_back(
+                        cinstr.operation, qargs=cinstr.qubits, cargs=cinstr.clbits
+                    )
+            dag.substitute_node_with_dag(node, new_dag)
 
 
 def _get_predecessor_dag(dag, node, cnt):

--- a/qiskit/visualization/dag_visualization.py
+++ b/qiskit/visualization/dag_visualization.py
@@ -25,7 +25,7 @@ from .exceptions import VisualizationError
 
 
 @_optionals.HAS_GRAPHVIZ.require_in_call
-def dag_drawer(dag, scale=0.7, filename=None, style="color"):
+def dag_drawer(dag, scale=0.7, filename=None, style="color", show_node_id=False):
     """Plot the directed acyclic graph (dag) to represent operation dependencies
     in a quantum circuit.
 
@@ -38,6 +38,7 @@ def dag_drawer(dag, scale=0.7, filename=None, style="color"):
         filename (str): file path to save image to (format inferred from name)
         style (str): 'plain': B&W graph
                      'color' (default): color input/output/op nodes
+        show_node_id (bool): show the graph node_id for each node
 
     Returns:
         PIL.Image: if in Jupyter notebook and not saving to file,
@@ -143,6 +144,8 @@ def dag_drawer(dag, scale=0.7, filename=None, style="color"):
                     n["color"] = "black"
                     n["style"] = "filled"
                     n["fillcolor"] = "red"
+                if show_node_id:
+                    n["label"] = f"{node._node_id}: {n['label']}"
                 return n
             else:
                 raise VisualizationError("Invalid style %s" % style)

--- a/test/python/transpiler/test_cx_cancellation.py
+++ b/test/python/transpiler/test_cx_cancellation.py
@@ -11,7 +11,6 @@
 # that they have been altered from the originals.
 
 """Tests for pass cancelling 2 consecutive CNOTs on the same qubits."""
-
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.circuit import Clbit, Qubit
 from qiskit.transpiler import PassManager

--- a/test/python/transpiler/test_loop_unrolling.py
+++ b/test/python/transpiler/test_loop_unrolling.py
@@ -1,0 +1,116 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for loop unrolling passes"""
+
+from ddt import ddt, data
+
+from qiskit import QuantumRegister, QuantumCircuit
+from qiskit.circuit import Clbit, Qubit, Parameter
+from qiskit.transpiler import PassManager
+from qiskit.transpiler.passes.optimization import UnrollForLoops, ForLoopBodyOptimizer
+from qiskit.transpiler.passes import Optimize1qGatesDecomposition
+from qiskit.transpiler.passes import CommutativeCancellation
+from qiskit.test import QiskitTestCase
+from qiskit.quantum_info import Operator
+from math import pi
+
+
+@ddt
+class TestUnrollForLoop(QiskitTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._pass = UnrollForLoops()
+
+    @data(1, 2, 3)
+    def test_only_for_loop(self, nloops):
+        body = QuantumCircuit(1)
+        body.rx(0.1, 0)
+        circ = QuantumCircuit(1)
+        circ.for_loop(range(nloops), None, body.copy(), [0], [])
+        ccirc = self._pass(circ)
+        self.assertEqual(Operator(body.repeat(nloops)), Operator(ccirc))
+
+    @data(1, 2, 3)
+    def test_parametrized_for_loop(self, nloops):
+        body = QuantumCircuit(1)
+        θ = Parameter("θ")
+        body.rx(θ + pi / 2, 0)
+        circ = QuantumCircuit(1)
+        circ.for_loop(range(nloops), θ, body.copy(), [0], [])
+        ccirc = self._pass(circ)
+
+        expected = QuantumCircuit(1)
+        for i in range(nloops):
+            expected.rx(i, 0)
+        self.assertEqual(Operator(expected), Operator(ccirc))
+
+    def test_for_loop_compound(self):
+        body = QuantumCircuit(1)
+        body.rx(pi, 0)
+        circ = QuantumCircuit(1)
+        circ.x(0)
+        circ.for_loop(range(2), None, body, [0], [])
+        circ.y(0)
+
+        expected = QuantumCircuit(1)
+        expected.x(0)
+        expected.rx(pi, 0)
+        expected.rx(pi, 0)
+        expected.y(0)
+        self.assertEqual(expected, self._pass(circ))
+
+    @data(1, 2, 3)
+    def test_multiple_loops(self, nloops):
+        body = QuantumCircuit(1)
+        θ = Parameter("θ")
+        body.rx(θ + pi / 2, 0)
+        circ = QuantumCircuit(1)
+        circ.for_loop(range(nloops), θ, body.copy(), [0], [])
+        ccirc = self._pass(circ)
+
+        expected = QuantumCircuit(1)
+        for i in range(nloops):
+            expected.rx(i, 0)
+        self.assertEqual(Operator(expected), Operator(ccirc))
+        
+@ddt
+class TestForLoopBodyOptimizer(QiskitTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._pass = UnrollForLoops()
+
+    def test_pre_opt(self):
+        circ = QuantumCircuit(2)
+        circ.rx(0.1, 0)
+        circ.rx(0.2, 0)        
+        circ.x(0)
+        # define for loop
+        body = QuantumCircuit(1)
+        body.rx(pi/2, 0)
+        circ.for_loop(range(2), None, body, [0], [])
+        basis_gates = ["x", "rx"]
+        _opt = [
+            Optimize1qGatesDecomposition(basis=basis_gates),
+            CommutativeCancellation(basis_gates=basis_gates),
+        ]
+        print('')
+        print(circ)
+        pm_opt = PassManager(_opt)
+        _pass = ForLoopBodyOptimizer(pm_opt, pre_opt_cnt=1)
+        ccirc = _pass(circ)
+        breakpoint()
+        


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This pass attempts to optimize for-loops. Several cases are considered;
1. attempt to optimize for-loop body with what comes before the loop
2. attempt to optimize for-loop body with what comes after the loop
3. attempt to optimize for-loop by loop jamming i.e. combining multiple loops into a single loop


### Details and comments
The first two variants attempt to optimize by checking whether a single loop iteration can be unrolled from the front or back of the circuit to yield a reduced circuit by considering operations which are a set number of operations away from the loop in breadth-first order. The pass takes as argument a PassManager to use when attempting to optimize the candidate circuit. Currently the metric is just whether there is a reduction in number of operations.

