### PR TITLE
Fix delay padding to respect target's constraints

### DIFF
--- a/qiskit/transpiler/passes/scheduling/alap.py
+++ b/qiskit/transpiler/passes/scheduling/alap.py
@@ -138,7 +138,8 @@ class ALAPSchedule(BaseSchedulerTransform):
             for bit in node.qargs:
                 delta = t0 - idle_before[bit]
                 if delta > 0:
-                    new_dag.apply_operation_front(Delay(delta, time_unit), [bit], [])
+                    if self.target is None or (bit_indices[bit],) in self.target.get("delay", []):
+                        new_dag.apply_operation_front(Delay(delta, time_unit), [bit], [])
                 idle_before[bit] = t1
 
             new_dag.apply_operation_front(node.op, node.qargs, node.cargs)
@@ -148,7 +149,8 @@ class ALAPSchedule(BaseSchedulerTransform):
             delta = circuit_duration - before
             if not (delta > 0 and isinstance(bit, Qubit)):
                 continue
-            new_dag.apply_operation_front(Delay(delta, time_unit), [bit], [])
+            if self.target is None or (bit_indices[bit],) in self.target.get("delay", []):
+                new_dag.apply_operation_front(Delay(delta, time_unit), [bit], [])
 
         new_dag.name = dag.name
         new_dag.metadata = dag.metadata

--- a/qiskit/transpiler/passes/scheduling/alap.py
+++ b/qiskit/transpiler/passes/scheduling/alap.py
@@ -137,11 +137,8 @@ class ALAPSchedule(BaseSchedulerTransform):
 
             for bit in node.qargs:
                 delta = t0 - idle_before[bit]
-                if delta > 0:
-                    if self.target is None or self.target.instruction_supported(
-                        "delay", qargs=(bit_indices[bit],)
-                    ):
-                        new_dag.apply_operation_front(Delay(delta, time_unit), [bit], [])
+                if delta > 0 and self._delay_supported(bit_indices[bit]):
+                    new_dag.apply_operation_front(Delay(delta, time_unit), [bit], [])
                 idle_before[bit] = t1
 
             new_dag.apply_operation_front(node.op, node.qargs, node.cargs)
@@ -151,9 +148,7 @@ class ALAPSchedule(BaseSchedulerTransform):
             delta = circuit_duration - before
             if not (delta > 0 and isinstance(bit, Qubit)):
                 continue
-            if self.target is None or self.target.instruction_supported(
-                "delay", qargs=(bit_indices[bit],)
-            ):
+            if self._delay_supported(bit_indices[bit]):
                 new_dag.apply_operation_front(Delay(delta, time_unit), [bit], [])
 
         new_dag.name = dag.name

--- a/qiskit/transpiler/passes/scheduling/alap.py
+++ b/qiskit/transpiler/passes/scheduling/alap.py
@@ -138,7 +138,9 @@ class ALAPSchedule(BaseSchedulerTransform):
             for bit in node.qargs:
                 delta = t0 - idle_before[bit]
                 if delta > 0:
-                    if self.target is None or (bit_indices[bit],) in self.target.get("delay", []):
+                    if self.target is None or self.target.instruction_supported(
+                        "delay", qargs=(bit_indices[bit],)
+                    ):
                         new_dag.apply_operation_front(Delay(delta, time_unit), [bit], [])
                 idle_before[bit] = t1
 
@@ -149,7 +151,9 @@ class ALAPSchedule(BaseSchedulerTransform):
             delta = circuit_duration - before
             if not (delta > 0 and isinstance(bit, Qubit)):
                 continue
-            if self.target is None or (bit_indices[bit],) in self.target.get("delay", []):
+            if self.target is None or self.target.instruction_supported(
+                "delay", qargs=(bit_indices[bit],)
+            ):
                 new_dag.apply_operation_front(Delay(delta, time_unit), [bit], [])
 
         new_dag.name = dag.name

--- a/qiskit/transpiler/passes/scheduling/asap.py
+++ b/qiskit/transpiler/passes/scheduling/asap.py
@@ -151,7 +151,8 @@ class ASAPSchedule(BaseSchedulerTransform):
             for bit in node.qargs:
                 delta = t0 - idle_after[bit]
                 if delta > 0 and isinstance(bit, Qubit):
-                    new_dag.apply_operation_back(Delay(delta, time_unit), [bit], [])
+                    if self.target is None or (bit_indices[bit],) in self.target.get("delay", []):
+                        new_dag.apply_operation_back(Delay(delta, time_unit), [bit], [])
                 idle_after[bit] = t1
 
             new_dag.apply_operation_back(node.op, node.qargs, node.cargs)
@@ -161,7 +162,8 @@ class ASAPSchedule(BaseSchedulerTransform):
             delta = circuit_duration - after
             if not (delta > 0 and isinstance(bit, Qubit)):
                 continue
-            new_dag.apply_operation_back(Delay(delta, time_unit), [bit], [])
+            if self.target is None or (bit_indices[bit],) in self.target.get("delay", []):
+                new_dag.apply_operation_back(Delay(delta, time_unit), [bit], [])
 
         new_dag.name = dag.name
         new_dag.metadata = dag.metadata

--- a/qiskit/transpiler/passes/scheduling/asap.py
+++ b/qiskit/transpiler/passes/scheduling/asap.py
@@ -151,7 +151,9 @@ class ASAPSchedule(BaseSchedulerTransform):
             for bit in node.qargs:
                 delta = t0 - idle_after[bit]
                 if delta > 0 and isinstance(bit, Qubit):
-                    if self.target is None or (bit_indices[bit],) in self.target.get("delay", []):
+                    if self.target is None or self.target.instruction_supported(
+                        "delay", qargs=(bit_indices[bit],)
+                    ):
                         new_dag.apply_operation_back(Delay(delta, time_unit), [bit], [])
                 idle_after[bit] = t1
 
@@ -162,7 +164,9 @@ class ASAPSchedule(BaseSchedulerTransform):
             delta = circuit_duration - after
             if not (delta > 0 and isinstance(bit, Qubit)):
                 continue
-            if self.target is None or (bit_indices[bit],) in self.target.get("delay", []):
+            if self.target is None or self.target.instruction_supported(
+                "delay", qargs=(bit_indices[bit],)
+            ):
                 new_dag.apply_operation_back(Delay(delta, time_unit), [bit], [])
 
         new_dag.name = dag.name

--- a/qiskit/transpiler/passes/scheduling/asap.py
+++ b/qiskit/transpiler/passes/scheduling/asap.py
@@ -150,11 +150,8 @@ class ASAPSchedule(BaseSchedulerTransform):
             # Add delay to qubit wire
             for bit in node.qargs:
                 delta = t0 - idle_after[bit]
-                if delta > 0 and isinstance(bit, Qubit):
-                    if self.target is None or self.target.instruction_supported(
-                        "delay", qargs=(bit_indices[bit],)
-                    ):
-                        new_dag.apply_operation_back(Delay(delta, time_unit), [bit], [])
+                if delta > 0 and isinstance(bit, Qubit) and self._delay_supported(bit_indices[bit]):
+                    new_dag.apply_operation_back(Delay(delta, time_unit), [bit], [])
                 idle_after[bit] = t1
 
             new_dag.apply_operation_back(node.op, node.qargs, node.cargs)
@@ -164,9 +161,7 @@ class ASAPSchedule(BaseSchedulerTransform):
             delta = circuit_duration - after
             if not (delta > 0 and isinstance(bit, Qubit)):
                 continue
-            if self.target is None or self.target.instruction_supported(
-                "delay", qargs=(bit_indices[bit],)
-            ):
+            if self._delay_supported(bit_indices[bit]):
                 new_dag.apply_operation_back(Delay(delta, time_unit), [bit], [])
 
         new_dag.name = dag.name

--- a/qiskit/transpiler/passes/scheduling/base_scheduler.py
+++ b/qiskit/transpiler/passes/scheduling/base_scheduler.py
@@ -245,15 +245,16 @@ class BaseSchedulerTransform(TransformationPass):
         """
         super().__init__()
         self.durations = durations
+        # Ensure op node durations are attached and in consistent unit
+        if target is not None:
+            self.durations = target.durations()
+        self.requires.append(TimeUnitConversion(self.durations))
 
         # Control flow constraints.
         self.clbit_write_latency = clbit_write_latency
         self.conditional_latency = conditional_latency
 
-        # Ensure op node durations are attached and in consistent unit
-        self.requires.append(TimeUnitConversion(durations))
-        if target is not None:
-            self.durations = target.durations()
+        self.target = target
 
     @staticmethod
     def _get_node_duration(

--- a/qiskit/transpiler/passes/scheduling/base_scheduler.py
+++ b/qiskit/transpiler/passes/scheduling/base_scheduler.py
@@ -282,5 +282,11 @@ class BaseSchedulerTransform(TransformationPass):
 
         return duration
 
+    def _delay_supported(self, qarg: int) -> bool:
+        """Delay operation is supported on the qubit (qarg) or not."""
+        if self.target is None or self.target.instruction_supported("delay", qargs=(qarg,)):
+            return True
+        return False
+
     def run(self, dag: DAGCircuit):
         raise NotImplementedError

--- a/qiskit/transpiler/passes/scheduling/padding/base_padding.py
+++ b/qiskit/transpiler/passes/scheduling/padding/base_padding.py
@@ -123,8 +123,8 @@ class BasePadding(TransformationPass):
 
                     # Fill idle time with some sequence
                     if t0 - idle_after[bit] > 0:
-                        if self.target is None or (bit_indices[bit],) in self.target.get(
-                            "delay", []
+                        if self.target is None or self.target.instruction_supported(
+                            "delay", qargs=(bit_indices[bit],)
                         ):
                             # Find previous node on the wire, i.e. always the latest node on the wire
                             prev_node = next(new_dag.predecessors(new_dag.output_map[bit]))
@@ -149,7 +149,9 @@ class BasePadding(TransformationPass):
         # Add delays until the end of circuit.
         for bit in new_dag.qubits:
             if circuit_duration - idle_after[bit] > 0:
-                if self.target is None or (bit_indices[bit],) in self.target.get("delay", []):
+                if self.target is None or self.target.instruction_supported(
+                    "delay", qargs=(bit_indices[bit],)
+                ):
                     node = new_dag.output_map[bit]
                     prev_node = next(new_dag.predecessors(node))
                     self._pad(

--- a/qiskit/transpiler/passes/scheduling/padding/base_padding.py
+++ b/qiskit/transpiler/passes/scheduling/padding/base_padding.py
@@ -12,6 +12,7 @@
 
 """Padding pass to fill empty timeslot."""
 
+import logging
 from typing import List, Optional, Union
 
 from qiskit.circuit import Qubit, Clbit, Instruction
@@ -20,6 +21,8 @@ from qiskit.dagcircuit import DAGCircuit, DAGNode
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.target import Target
+
+logger = logging.getLogger(__name__)
 
 
 class BasePadding(TransformationPass):
@@ -180,6 +183,13 @@ class BasePadding(TransformationPass):
                 f"The input circuit {dag.name} is not scheduled. Call one of scheduling passes "
                 f"before running the {self.__class__.__name__} pass."
             )
+        for qarg, _ in enumerate(dag.qubits):
+            if not self.__delay_supported(qarg):
+                logger.debug(
+                    "Idle time may not be padded for qubit %d as the target does not support "
+                    "delay instruction on the qubit",
+                    qarg,
+                )
 
     def _apply_scheduled_op(
         self,

--- a/qiskit/transpiler/passes/scheduling/padding/base_padding.py
+++ b/qiskit/transpiler/passes/scheduling/padding/base_padding.py
@@ -186,8 +186,7 @@ class BasePadding(TransformationPass):
         for qarg, _ in enumerate(dag.qubits):
             if not self.__delay_supported(qarg):
                 logger.debug(
-                    "Idle time may not be padded for qubit %d as the target does not support "
-                    "delay instruction on the qubit",
+                    "No padding on qubit %d as delay is not supported on it",
                     qarg,
                 )
 

--- a/qiskit/transpiler/passes/scheduling/padding/dynamical_decoupling.py
+++ b/qiskit/transpiler/passes/scheduling/padding/dynamical_decoupling.py
@@ -212,6 +212,10 @@ class PadDynamicalDecoupling(BasePadding):
 
             sequence_lengths = []
             for gate in self._dd_sequence:
+                if not self.__gate_supported(gate, physical_index):
+                    raise TranspilerError(
+                        f"Gate {gate.name} in dd_sequence is not supported on qubit {physical_index}"
+                    )
                 try:
                     # Check calibration.
                     gate_length = dag.calibrations[gate.name][(physical_index, gate.params)]
@@ -234,6 +238,12 @@ class PadDynamicalDecoupling(BasePadding):
                 # Update gate duration. This is necessary for current timeline drawer, i.e. scheduled.
                 gate.duration = gate_length
             self._dd_sequence_lengths[qubit] = sequence_lengths
+
+    def __gate_supported(self, gate: Gate, qarg: int) -> bool:
+        """A gate is supported on the qubit (qarg) or not."""
+        if self.target is None or self.target.instruction_supported(gate.name, qargs=(qarg,)):
+            return True
+        return False
 
     def _pad(
         self,

--- a/qiskit/transpiler/passes/scheduling/padding/dynamical_decoupling.py
+++ b/qiskit/transpiler/passes/scheduling/padding/dynamical_decoupling.py
@@ -172,7 +172,7 @@ class PadDynamicalDecoupling(BasePadding):
         if target is not None:
             self._durations = target.durations()
             for gate in dd_sequence:
-                if gate.name not in self.target.operation_names:
+                if gate.name not in target.operation_names:
                     raise TranspilerError(
                         f"{gate.name} in dd_sequence is not supported in the target"
                     )

--- a/qiskit/transpiler/passes/scheduling/padding/dynamical_decoupling.py
+++ b/qiskit/transpiler/passes/scheduling/padding/dynamical_decoupling.py
@@ -167,6 +167,11 @@ class PadDynamicalDecoupling(BasePadding):
         self._sequence_phase = 0
         if target is not None:
             self._durations = target.durations()
+            for gate in dd_sequence:
+                if gate.name not in self.target.operation_names:
+                    raise TranspilerError(
+                        f"{gate.name} in dd_sequence is not supported in the target"
+                    )
 
     def _pre_runhook(self, dag: DAGCircuit):
         super()._pre_runhook(dag)
@@ -201,8 +206,7 @@ class PadDynamicalDecoupling(BasePadding):
             self._sequence_phase = np.angle(noop[0][0])
 
         # Precompute qubit-wise DD sequence length for performance
-        for qubit in dag.qubits:
-            physical_index = dag.qubits.index(qubit)
+        for physical_index, qubit in enumerate(dag.qubits):
             if self._qubits and physical_index not in self._qubits:
                 continue
 

--- a/qiskit/transpiler/passes/scheduling/padding/dynamical_decoupling.py
+++ b/qiskit/transpiler/passes/scheduling/padding/dynamical_decoupling.py
@@ -152,7 +152,7 @@ class PadDynamicalDecoupling(BasePadding):
                 non-multiple of the alignment constraint value is found.
             TypeError: If ``dd_sequence`` is not specified
         """
-        super().__init__()
+        super().__init__(target=target)
         self._durations = durations
         if dd_sequence is None:
             raise TypeError("required argument 'dd_sequence' is not specified")

--- a/qiskit/transpiler/passes/scheduling/padding/pad_delay.py
+++ b/qiskit/transpiler/passes/scheduling/padding/pad_delay.py
@@ -15,6 +15,7 @@
 from qiskit.circuit import Qubit
 from qiskit.circuit.delay import Delay
 from qiskit.dagcircuit import DAGCircuit, DAGNode, DAGOutNode
+from qiskit.transpiler.target import Target
 
 from .base_padding import BasePadding
 
@@ -50,13 +51,16 @@ class PadDelay(BasePadding):
     See :class:`BasePadding` pass for details.
     """
 
-    def __init__(self, fill_very_end: bool = True):
+    def __init__(self, fill_very_end: bool = True, target: Target = None):
         """Create new padding delay pass.
 
         Args:
             fill_very_end: Set ``True`` to fill the end of circuit with delay.
+            target: The :class:`~.Target` representing the target backend.
+                If it supplied and it does not support delay instruction on a qubit,
+                padding passes do not pad any idle time of the qubit.
         """
-        super().__init__()
+        super().__init__(target=target)
         self.fill_very_end = fill_very_end
 
     def _pad(

--- a/qiskit/transpiler/preset_passmanagers/common.py
+++ b/qiskit/transpiler/preset_passmanagers/common.py
@@ -534,7 +534,7 @@ def generate_scheduling(
         )
     if scheduling_method:
         # Call padding pass if circuit is scheduled
-        scheduling.append(PadDelay())
+        scheduling.append(PadDelay(target=target))
 
     return scheduling
 

--- a/releasenotes/notes/fix-delay-padding-75937bda37ebc3fd.yaml
+++ b/releasenotes/notes/fix-delay-padding-75937bda37ebc3fd.yaml
@@ -1,8 +1,8 @@
 ---
 fixes:
   - |
-    Fixed an issue with tranpiler passes for padding delays, which did not respect target's
-    constraints and inserted delays even for qubits not supporting :class:`~.Delay` instruction.
+    Fixed an issue in tranpiler passes for padding delays, which did not respect target's constraints
+    and inserted delays even for qubits not supporting :class:`~.circuit.Delay` instruction.
     :class:`~.PadDelay` and :class:`~.PadDynamicalDecoupling` are fixed
     so that they do not pad any idle time of qubits such that the target does not support
     ``Delay`` instructions for the qubits.

--- a/releasenotes/notes/fix-delay-padding-75937bda37ebc3fd.yaml
+++ b/releasenotes/notes/fix-delay-padding-75937bda37ebc3fd.yaml
@@ -1,0 +1,13 @@
+---
+fixes:
+  - |
+    Fixed an issue with tranpiler passes for padding delays, which did not respect target's
+    constraints and inserted delays even for qubits not supporting :class:`~.Delay` instruction.
+    :class:`~.PadDelay` and :class:`~.PadDynamicalDecoupling` are fixed
+    so that they do not pad any idle time of qubits such that the target does not support
+    ``Delay`` instructions for the qubits.
+    Also legacy scheduling passes ``ASAPSchedule`` and ``ALAPSchedule``,
+    which pad delays internally, are fixed in the same way.
+    In addition, :func:`transpile` is fixed to call ``PadDelay`` with a ``target`` object
+    so that it works correctly when called with ``scheduling_method`` option.
+    Fixed `#9993 <https://github.com/Qiskit/qiskit-terra/issues/9993>`__

--- a/test/python/transpiler/legacy_scheduling/test_scheduling_pass.py
+++ b/test/python/transpiler/legacy_scheduling/test_scheduling_pass.py
@@ -15,11 +15,14 @@
 import unittest
 
 from ddt import ddt, data, unpack
+
 from qiskit import QuantumCircuit
+from qiskit.circuit import Delay, Parameter
+from qiskit.circuit.library.standard_gates import XGate, YGate, CXGate
 from qiskit.test import QiskitTestCase
-from qiskit.circuit.library.standard_gates import XGate
+from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.instruction_durations import InstructionDurations
-from qiskit.transpiler.passes import ASAPSchedule, ALAPSchedule
+from qiskit.transpiler.passes import ASAPSchedule, ALAPSchedule, DynamicalDecoupling
 from qiskit.transpiler.passmanager import PassManager
 from qiskit.transpiler.target import Target, InstructionProperties
 
@@ -739,6 +742,68 @@ class TestSchedulingPass(QiskitTestCase):
         expected.x(1)
         # no delay on qubit 0
 
+        self.assertEqual(expected, scheduled)
+
+    def test_dd_respect_target_instruction_constraints(self):
+        """Test if DD pass does not pad delays for qubits that do not support delay instructions
+        and does not insert DD gates for qubits that do not support necessary gates.
+        See: https://github.com/Qiskit/qiskit-terra/issues/9993
+        """
+        qc = QuantumCircuit(3)
+        qc.cx(0, 1)
+        qc.cx(1, 2)
+
+        target = Target(dt=1)
+        # Y is partially supported (not supported on qubit 2)
+        target.add_instruction(
+            XGate(), {(q,): InstructionProperties(duration=100) for q in range(2)}
+        )
+        target.add_instruction(
+            CXGate(),
+            {
+                (0, 1): InstructionProperties(duration=1000),
+                (1, 2): InstructionProperties(duration=1000),
+            },
+        )
+        # delays are not supported
+
+        # No DD instructions nor delays are padded due to no delay support in the target
+        pm_xx = PassManager(
+            [
+                ALAPSchedule(target=target),
+                DynamicalDecoupling(durations=None, dd_sequence=[XGate(), XGate()], target=target),
+            ]
+        )
+        scheduled = pm_xx.run(qc)
+        self.assertEqual(qc, scheduled)
+
+        # Fails since Y is not supported in the target
+        with self.assertRaises(TranspilerError):
+            PassManager(
+                [
+                    ALAPSchedule(target=target),
+                    DynamicalDecoupling(
+                        durations=None,
+                        dd_sequence=[XGate(), YGate(), XGate(), YGate()],
+                        target=target,
+                    ),
+                ]
+            )
+
+        # Add delay support to the target
+        target.add_instruction(Delay(Parameter("t")), {(q,): None for q in range(3)})
+        # No error but no DD on qubit 2 (just delay is padded) since X is not supported on it
+        scheduled = pm_xx.run(qc)
+
+        expected = QuantumCircuit(3)
+        expected.delay(1000, [2])
+        expected.cx(0, 1)
+        expected.cx(1, 2)
+        expected.delay(200, [0])
+        expected.x([0])
+        expected.delay(400, [0])
+        expected.x([0])
+        expected.delay(200, [0])
         self.assertEqual(expected, scheduled)
 
 

--- a/test/python/transpiler/test_dynamical_decoupling.py
+++ b/test/python/transpiler/test_dynamical_decoupling.py
@@ -824,7 +824,8 @@ class TestPadDynamicalDecoupling(QiskitTestCase):
         self.assertEqual(circ1, circ2)
 
     def test_respect_target_instruction_constraints(self):
-        """Test if DD pass does not pad delays for qubits that do not support delay instructions.
+        """Test if DD pass does not pad delays for qubits that do not support delay instructions
+        and does not insert DD gates for qubits that do not support necessary gates.
         See: https://github.com/Qiskit/qiskit-terra/issues/9993
         """
         qc = QuantumCircuit(3)

--- a/test/python/transpiler/test_scheduling_padding_pass.py
+++ b/test/python/transpiler/test_scheduling_padding_pass.py
@@ -851,6 +851,23 @@ class TestSchedulingAndPaddingPass(QiskitTestCase):
 
         self.assertEqual(scheduled, qc)
 
+    @data(ALAPScheduleAnalysis, ASAPScheduleAnalysis)
+    def test_respect_target_instruction_constraints(self, schedule_pass):
+        """Test if DD pass does not pad delays for qubits that do not support delay instructions.
+        See: https://github.com/Qiskit/qiskit-terra/issues/9993
+        """
+        qc = QuantumCircuit(3)
+        qc.cx(1, 2)
+
+        target = Target(dt=1)
+        target.add_instruction(CXGate(), {(1, 2): InstructionProperties(duration=1000)})
+        # delays are not supported
+
+        pm = PassManager([schedule_pass(target=target), PadDelay(target=target)])
+        scheduled = pm.run(qc)
+
+        self.assertEqual(qc, scheduled)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes delay padding in `transpile()` function and tranpiler passes to respect target's constraints.

### Details and comments
`PadDelay` and `PadDynamicalDecoupling` are fixed so that they do not pad any idle time of qubits for which the `target` does not support `Delay` instruction. For that, the parent `BasePadding` as well as `PadDelay` is updated so that it optionally takes `target` argument. Legacy scheduling passes `ASAPSchedule` and `ALAPSchedule`, which pad delays internally, are also fixed in the same way. In addition, `transpile()` is fixed to call `PadDelay` with a `target` object so that it works correctly when called with `scheduling_method` option.

Fixes #9993 