### PR TITLE
Upgrade straggler GitHub Actions to Node 16

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,11 +20,8 @@ jobs:
           python-version: '3.8'
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
-          profile: default
           components: llvm-tools-preview
 
       - name: Install dependencies

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,10 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
+    env:
+      # Override the `rust-toolchain.toml` file because `grcov` has greater requirements.
+      RUSTUP_TOOLCHAIN: stable
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -18,9 +18,7 @@ jobs:
         name: Install Python
         with:
           python-version: '3.7'
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
@@ -53,9 +51,7 @@ jobs:
         name: Install Python
         with:
           python-version: '3.7'
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
@@ -88,9 +84,7 @@ jobs:
         name: Install Python
         with:
           python-version: '3.7'
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:


### PR DESCRIPTION
### Summary

The Node 12 runners are due to be removed from GitHub Actions this summer.  We updated most of them in 5d977fbf (gh-8856), but a couple remained un-updated.

The `actions-rs/toolchain` action is unmaintained.  The replacement used in this commit is actively updated, and has mostly the same interface, although the Rust version is typically specified using the action version.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

The alternative to this is just installing calling `rustup` manually.