### PR TITLE
Fix qubit filtering in BackendV2Converter with add_delay

### DIFF
--- a/qiskit/providers/backend_compat.py
+++ b/qiskit/providers/backend_compat.py
@@ -64,8 +64,11 @@ def convert_to_target(
     target = None
     if custom_name_mapping is not None:
         name_mapping.update(custom_name_mapping)
+    faulty_qubits = set()
     # Parse from properties if it exsits
     if properties is not None:
+        if filter_faulty:
+            faulty_qubits = set(properties.faulty_qubits())
         qubit_properties = qubit_props_list_from_props(properties=properties)
         target = Target(num_qubits=configuration.n_qubits, qubit_properties=qubit_properties)
         # Parse instructions
@@ -137,9 +140,6 @@ def convert_to_target(
         target.acquire_alignment = configuration.timing_constraints.get("acquire_alignment")
     # If a pulse defaults exists use that as the source of truth
     if defaults is not None:
-        faulty_qubits = set()
-        if filter_faulty and properties is not None:
-            faulty_qubits = set(properties.faulty_qubits())
         inst_map = defaults.instruction_schedule_map
         for inst in inst_map.instructions:
             for qarg in inst_map.qubits_with_instruction(inst):
@@ -174,7 +174,8 @@ def convert_to_target(
                 )
     if add_delay and "delay" not in target:
         target.add_instruction(
-            name_mapping["delay"], {(bit,): None for bit in range(target.num_qubits)}
+            name_mapping["delay"],
+            {(bit,): None for bit in range(target.num_qubits) if bit not in faulty_qubits},
         )
     return target
 

--- a/test/python/providers/test_fake_backends.py
+++ b/test/python/providers/test_fake_backends.py
@@ -494,6 +494,27 @@ class TestFakeBackends(QiskitTestCase):
             for qarg in v2_backend.target.qargs:
                 self.assertNotIn(i, qarg)
 
+    def test_filter_faulty_qubits_backend_v2_converter_with_delay(self):
+        """Test faulty qubits in v2 conversion."""
+        backend = FakeWashington()
+        # Get properties dict to make it easier to work with the properties API
+        # is difficult to edit because of the multiple layers of nesting and
+        # different object types
+        props_dict = backend.properties().to_dict()
+        for i in range(62, 67):
+            non_operational = {
+                "date": datetime.datetime.utcnow(),
+                "name": "operational",
+                "unit": "",
+                "value": 0,
+            }
+            props_dict["qubits"][i].append(non_operational)
+        backend._properties = BackendProperties.from_dict(props_dict)
+        v2_backend = BackendV2Converter(backend, filter_faulty=True, add_delay=True)
+        for i in range(62, 67):
+            for qarg in v2_backend.target.qargs:
+                self.assertNotIn(i, qarg)
+
     def test_filter_faulty_qubits_and_gates_backend_v2_converter(self):
         """Test faulty gates and qubits."""
         backend = FakeWashington()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue with the filter_faulty and add_delay flag were both set on the BackendV2Converter and convert_to_target flag. In these cases the function would incorrectly add delay operations to the faulty qubits even though they should have no operations preset on them. This commit fixes the oversight to ensure that no operations are present on a qubit if it's listed as non-operational in an input BackendProperties.

### Details and comments