### PR TITLE
Use backend_compat module's convert to target

### DIFF
--- a/qiskit/providers/backend_compat.py
+++ b/qiskit/providers/backend_compat.py
@@ -104,9 +104,17 @@ def convert_to_target(
             if filter_faulty:
                 if not properties.is_qubit_operational(qubit):
                     continue
+            try:
+                duration = properties.readout_length(qubit)
+            except BackendPropertyError:
+                duration = None
+            try:
+                error = properties.readout_error(qubit)
+            except BackendPropertyError:
+                error = None
             measure_props[(qubit,)] = InstructionProperties(
-                duration=properties.readout_length(qubit),
-                error=properties.readout_error(qubit),
+                duration=duration,
+                error=error,
             )
         target.add_instruction(Measure(), measure_props)
     # Parse from configuration because properties doesn't exist

--- a/qiskit/providers/fake_provider/fake_backend.py
+++ b/qiskit/providers/fake_provider/fake_backend.py
@@ -25,20 +25,20 @@ import re
 from typing import List, Iterable
 
 from qiskit import circuit
-from qiskit.providers.models import BackendProperties
+from qiskit.providers.models import BackendProperties, BackendConfiguration, PulseDefaults
 from qiskit.providers import BackendV2, BackendV1
 from qiskit import pulse
 from qiskit.exceptions import QiskitError
 from qiskit.utils import optionals as _optionals
 from qiskit.providers import basicaer
 from qiskit.transpiler import Target
+from qiskit.providers.backend_compat import convert_to_target
 
 from .utils.json_decoder import (
     decode_backend_configuration,
     decode_backend_properties,
     decode_pulse_defaults,
 )
-from .utils.backend_converter import convert_to_target
 
 
 class _Credentials:
@@ -168,10 +168,16 @@ class FakeBackendV2(BackendV2):
                 self._set_props_dict_from_json()
             if self._defs_dict is None:
                 self._set_defs_dict_from_json()
+            conf = BackendConfiguration.from_dict(self._conf_dict)
+            props = None
+            if self._props_dict is not None:
+                props = BackendProperties.from_dict(self._props_dict)
+            defaults = None
+            if self._defs_dict is not None:
+                defaults = PulseDefaults.from_dict(self._defs_dict)
+
             self._target = convert_to_target(
-                conf_dict=self._conf_dict,
-                props_dict=self._props_dict,
-                defs_dict=self._defs_dict,
+                conf, props, defaults, add_delay=True, filter_faulty=True
             )
 
         return self._target

--- a/test/python/providers/test_fake_backends.py
+++ b/test/python/providers/test_fake_backends.py
@@ -34,6 +34,8 @@ from qiskit.providers.fake_provider import (
     FakeYorktown,
     FakeMumbai,
     FakeWashington,
+    FakeSherbrooke,
+    FakePrague,
 )
 from qiskit.providers.backend_compat import BackendV2Converter
 from qiskit.providers.models.backendproperties import BackendProperties
@@ -55,6 +57,8 @@ from qiskit.circuit.library import (
     RGate,
     MCXGrayCode,
     RYGate,
+    CZGate,
+    ECRGate,
 )
 from qiskit.circuit import ControlledGate, Parameter
 from qiskit.quantum_info.operators.channel.quantum_channel import QuantumChannel
@@ -229,6 +233,12 @@ class TestFakeBackends(QiskitTestCase):
         qc.measure_all()
         res = transpile(qc, backend_v2)
         self.assertIn("delay", res.count_ops())
+
+    def test_non_cx_tests(self):
+        backend = FakePrague()
+        self.assertIsInstance(backend.target.operation_from_name("cz"), CZGate)
+        backend = FakeSherbrooke()
+        self.assertIsInstance(backend.target.operation_from_name("ecr"), ECRGate)
 
     @unittest.skipUnless(optionals.HAS_AER, "Aer required for this test")
     def test_converter_simulator(self):


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue with the fake backend classes built on the BackendV2 that used ECR or CZ (or any 2q gate besides CX) as gates. The fundamental issue was the fake backend class had a hardcoded dict mapping gate names to classes to use for generating a target. This prevents the correct gate class from being reported when a backend uses gates outside of that dict. To fix this issue this commit switches the fake backends to use the convert_to_target function which is part of the BackendConverterV2 class. That function provides the same functionality as the one used internally by the fake provider except it is more general as its designed to work with any backend. At the time of its introduction this unification wasn't done because the fake backend's version would be more efficient because it doesn't generate unused intermediate object forms. But, a small loading time performance regression against correct operation and de-duplicating code paths using the more general function is a better choice. In a future commit we can deprecate and remove the fake backend version of convert_to_target.

### Details and comments

Fixes #10004
Fixes #9983