### PR TITLE
Don't run both ZSX and ZSXX basis in Optimize1qGatesDecomposition

### DIFF
--- a/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
@@ -243,6 +243,16 @@ def _possible_decomposers(basis_set):
         for euler_basis_name, gates in euler_basis_gates.items():
             if set(gates).issubset(basis_set):
                 decomposers.append(euler_basis_name)
+        # If both U3 and U321 are in decomposer list only run U321 because
+        # in worst case it will produce the same U3 output, but in the general
+        # case it will use U2 and U1 which will be more efficient.
         if "U3" in decomposers and "U321" in decomposers:
             decomposers.remove("U3")
+        # If both ZSX and ZSXX are in decomposer list only run ZSXX because
+        # in the worst case it will produce the same output, but in the general
+        # case it will simplify X rotations to use X gate instead of multiple
+        # SX gates and be more efficient. Running multiple decomposers in this
+        # case will just waste time.
+        if "ZSX" in decomposers and "ZSXX" in decomposers:
+            decomposers.remove("ZSX")
     return decomposers


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Currently in the Optimize1qGatesDecomposition transpielr pass we build a list of valid bases for the decomposer to synthesize the 1q unitary for. However, in the case of the overlapping bases ZSX and ZSXX if ZSXX is valid we end up doing the same work twice for no reason. ZSX and ZSXX produce the same basic output except ZSXX will always be the same or more efficient if multiple sx gates can be simplified to an x gate. So there is no need for us to run 2 decomposers in that case. This commit updates the pass to only run ZSXX if both ZSX and ZSXX are valid bases to use.

### Details and comments