### PR TITLE
FIx 0q operation handling in `Statevector`

### DIFF
--- a/qiskit/quantum_info/operators/op_shape.py
+++ b/qiskit/quantum_info/operators/op_shape.py
@@ -123,6 +123,9 @@ class OpShape:
     @property
     def shape(self):
         """Return a tuple of the matrix shape"""
+        if self._num_qargs_l == self._num_qargs_r == 0:
+            # Scalar shape is op-like
+            return (1, 1)
         if not self._num_qargs_r:
             # Vector shape
             return (self._dim_l,)

--- a/releasenotes/notes/fix-0q-operator-statevector-79199c65c24637c4.yaml
+++ b/releasenotes/notes/fix-0q-operator-statevector-79199c65c24637c4.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Construction of a :class:`~.quantum_info.Statevector` from a :class:`.QuantumCircuit` containing
+    zero-qubit operations will no longer raise an error.  These operations impart a global phase on
+    the resulting statevector.

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -24,7 +24,7 @@ from qiskit.test import QiskitTestCase
 from qiskit import QiskitError
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit import transpile
-from qiskit.circuit.library import HGate, QFT
+from qiskit.circuit.library import HGate, QFT, GlobalPhaseGate
 from qiskit.providers.basicaer import QasmSimulatorPy
 
 from qiskit.quantum_info.random import random_unitary, random_statevector, random_pauli
@@ -183,6 +183,13 @@ class TestStatevector(QiskitTestCase):
         circuit = QuantumCircuit(1)
         circuit.h(0)
         circuit.reset(0)
+        psi = Statevector.from_instruction(circuit)
+        self.assertEqual(psi, target)
+
+        # Test 0q instruction
+        target = Statevector([1j, 0])
+        circuit = QuantumCircuit(1)
+        circuit.append(GlobalPhaseGate(np.pi / 2), [], [])
         psi = Statevector.from_instruction(circuit)
         self.assertEqual(psi, target)
 


### PR DESCRIPTION
### Summary

The root of the problem was the `OpShape` producing a "vector-like" shape if it detected that "input size" was 1.  If both the input and output dimension are 1, it is instead a 0q operator (scalar).

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #10012
