### PR TITLE
circuit: narrow the return type of QuantumCircuit.assign_parameters

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -15,6 +15,7 @@
 """Quantum circuit object."""
 
 from __future__ import annotations
+import sys
 import collections.abc
 import copy
 import itertools
@@ -37,7 +38,6 @@ from typing import (
     Iterable,
     Any,
     DefaultDict,
-    Literal,
     overload,
 )
 import numpy as np
@@ -72,6 +72,11 @@ try:
     HAS_PYGMENTS = True
 except Exception:  # pylint: disable=broad-except
     HAS_PYGMENTS = False
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 if typing.TYPE_CHECKING:
     import qiskit  # pylint: disable=cyclic-import

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -37,6 +37,8 @@ from typing import (
     Iterable,
     Any,
     DefaultDict,
+    Literal,
+    overload,
 )
 import numpy as np
 from qiskit.exceptions import QiskitError, MissingOptionalLibraryError
@@ -2607,6 +2609,22 @@ class QuantumCircuit:
             parameters.update(self.global_phase.parameters)
 
         return parameters
+
+    @overload
+    def assign_parameters(
+        self,
+        parameters: Union[Mapping[Parameter, ParameterValueType], Sequence[ParameterValueType]],
+        inplace: Literal[False] = ...,
+    ) -> "QuantumCircuit":
+        ...
+
+    @overload
+    def assign_parameters(
+        self,
+        parameters: Union[Mapping[Parameter, ParameterValueType], Sequence[ParameterValueType]],
+        inplace: Literal[True] = ...,
+    ) -> None:
+        ...
 
     def assign_parameters(
         self,

--- a/releasenotes/notes/improve-quantum-circuit-assign-parameters-typing-70c9623405cbd420.yaml
+++ b/releasenotes/notes/improve-quantum-circuit-assign-parameters-typing-70c9623405cbd420.yaml
@@ -2,6 +2,6 @@
 fixes:
   - |
     Improve the type annotations on the
-    :meth:`qiskit.circuit.quantumcircuit.QuantumCircuit.assign_parameters`
-    method to reflect the change in return type depending on the `inplace`
+    :meth:`.QuantumCircuit.assign_parameters`
+    method to reflect the change in return type depending on the ``inplace``
     argument.

--- a/releasenotes/notes/improve-quantum-circuit-assign-parameters-typing-70c9623405cbd420.yaml
+++ b/releasenotes/notes/improve-quantum-circuit-assign-parameters-typing-70c9623405cbd420.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Improve the type annotations on the
+    :meth:`qiskit.circuit.quantumcircuit.QuantumCircuit.assign_parameters`
+    method to reflect the change in return type depending on the `inplace`
+    argument.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This patch improves on the type annotations of the `qiskit.circuit.quantumcircuit.QuantumCircuit.assign_parameters` method.

The return type is now correctly narrowed depending on the `inplace` argument:

```python
qc = QuantumCircuit(...)

a = qc.assign_parameters(..., inplace=False)  # default
reveal_type(a)  # type: QuantumCircuit

b = qc.assign_parameters(..., inplace=True)
reveal_type(b)  # type: None
```

### Details and comments

As an alternative to the verbose type overload, one could always return the bound circuit (as a reference to `self` when `inplace=True`). This should be backwards compatible since users of `inplace=True` should not be using the return value.
