### PR TITLE
providers/backend: define Backend type as union of versioned types

### DIFF
--- a/qiskit/algorithms/amplitude_amplifiers/grover.py
+++ b/qiskit/algorithms/amplitude_amplifiers/grover.py
@@ -24,7 +24,7 @@ import numpy as np
 from qiskit import ClassicalRegister, QuantumCircuit
 from qiskit.algorithms.exceptions import AlgorithmError
 from qiskit.primitives import BaseSampler
-from qiskit.providers import Backend
+from qiskit.providers import Backend, is_backend
 from qiskit.quantum_info import partial_trace, Statevector
 from qiskit.utils import QuantumInstance, algorithm_globals
 from qiskit.utils.deprecation import deprecate_arg, deprecate_func
@@ -221,7 +221,7 @@ class Grover(AmplitudeAmplifier):
         Args:
             quantum_instance: The quantum instance used to run this algorithm.
         """
-        if isinstance(quantum_instance, Backend):
+        if is_backend(quantum_instance):
             quantum_instance = QuantumInstance(quantum_instance)
         self._quantum_instance = quantum_instance
 

--- a/qiskit/algorithms/amplitude_estimators/ae.py
+++ b/qiskit/algorithms/amplitude_estimators/ae.py
@@ -20,7 +20,7 @@ from scipy.stats import chi2, norm
 from scipy.optimize import bisect
 
 from qiskit import QuantumCircuit, ClassicalRegister
-from qiskit.providers import Backend
+from qiskit.providers import Backend, is_backend
 from qiskit.primitives import BaseSampler
 from qiskit.utils import QuantumInstance
 from qiskit.utils.deprecation import deprecate_arg, deprecate_func
@@ -157,7 +157,7 @@ class AmplitudeEstimation(AmplitudeEstimator):
         Args:
             quantum_instance: The quantum instance used to run this algorithm.
         """
-        if isinstance(quantum_instance, Backend):
+        if is_backend(quantum_instance):
             quantum_instance = QuantumInstance(quantum_instance)
         self._quantum_instance = quantum_instance
 

--- a/qiskit/algorithms/amplitude_estimators/fae.py
+++ b/qiskit/algorithms/amplitude_estimators/fae.py
@@ -17,7 +17,7 @@ import warnings
 import numpy as np
 
 from qiskit.circuit import QuantumCircuit, ClassicalRegister
-from qiskit.providers import Backend
+from qiskit.providers import Backend, is_backend
 from qiskit.primitives import BaseSampler
 from qiskit.utils import QuantumInstance
 from qiskit.utils.deprecation import deprecate_arg, deprecate_func
@@ -135,7 +135,7 @@ class FasterAmplitudeEstimation(AmplitudeEstimator):
         Args:
             quantum_instance: The quantum instance used to run this algorithm.
         """
-        if isinstance(quantum_instance, Backend):
+        if is_backend(quantum_instance):
             quantum_instance = QuantumInstance(quantum_instance)
         self._quantum_instance = quantum_instance
 

--- a/qiskit/algorithms/amplitude_estimators/iae.py
+++ b/qiskit/algorithms/amplitude_estimators/iae.py
@@ -19,7 +19,7 @@ import numpy as np
 from scipy.stats import beta
 
 from qiskit import ClassicalRegister, QuantumCircuit
-from qiskit.providers import Backend
+from qiskit.providers import Backend, is_backend
 from qiskit.primitives import BaseSampler
 from qiskit.utils import QuantumInstance
 from qiskit.utils.deprecation import deprecate_arg, deprecate_func
@@ -158,7 +158,7 @@ class IterativeAmplitudeEstimation(AmplitudeEstimator):
         Args:
             quantum_instance: The quantum instance used to run this algorithm.
         """
-        if isinstance(quantum_instance, Backend):
+        if is_backend(quantum_instance):
             quantum_instance = QuantumInstance(quantum_instance)
         self._quantum_instance = quantum_instance
 

--- a/qiskit/algorithms/amplitude_estimators/mlae.py
+++ b/qiskit/algorithms/amplitude_estimators/mlae.py
@@ -21,7 +21,7 @@ import numpy as np
 from scipy.optimize import brute
 from scipy.stats import norm, chi2
 
-from qiskit.providers import Backend
+from qiskit.providers import Backend, is_backend
 from qiskit import ClassicalRegister, QuantumRegister, QuantumCircuit
 from qiskit.utils import QuantumInstance
 from qiskit.primitives import BaseSampler
@@ -162,7 +162,7 @@ class MaximumLikelihoodAmplitudeEstimation(AmplitudeEstimator):
         Args:
             quantum_instance: The quantum instance used to run this algorithm.
         """
-        if isinstance(quantum_instance, Backend):
+        if is_backend(quantum_instance):
             quantum_instance = QuantumInstance(quantum_instance)
         self._quantum_instance = quantum_instance
 

--- a/qiskit/algorithms/evolvers/trotterization/trotter_qrte.py
+++ b/qiskit/algorithms/evolvers/trotterization/trotter_qrte.py
@@ -31,7 +31,7 @@ from qiskit.opflow import (
     OperatorBase,
 )
 from qiskit.circuit.library import PauliEvolutionGate
-from qiskit.providers import Backend
+from qiskit.providers import Backend, is_backend
 from qiskit.synthesis import ProductFormula, LieTrotter
 from qiskit.utils import QuantumInstance
 from qiskit.utils.deprecation import deprecate_func
@@ -125,7 +125,7 @@ class TrotterQRTE(RealEvolver):
         Args:
             quantum_instance: The quantum instance used to run this algorithm.
         """
-        if isinstance(quantum_instance, Backend):
+        if is_backend(quantum_instance):
             quantum_instance = QuantumInstance(quantum_instance)
 
         self._circuit_sampler = None

--- a/qiskit/algorithms/phase_estimators/ipe.py
+++ b/qiskit/algorithms/phase_estimators/ipe.py
@@ -20,7 +20,7 @@ import numpy
 import qiskit
 from qiskit.circuit import QuantumCircuit, QuantumRegister
 from qiskit.circuit.classicalregister import ClassicalRegister
-from qiskit.providers import Backend
+from qiskit.providers import Backend, is_backend
 from qiskit.utils import QuantumInstance
 from qiskit.utils.deprecation import deprecate_arg
 from qiskit.algorithms.exceptions import AlgorithmError
@@ -68,7 +68,7 @@ class IterativePhaseEstimation(PhaseEstimator):
             raise AlgorithmError(
                 "Neither a sampler nor a quantum instance was provided. Please provide one of them."
             )
-        if isinstance(quantum_instance, Backend):
+        if is_backend(quantum_instance):
             quantum_instance = QuantumInstance(quantum_instance)
         self._quantum_instance = quantum_instance
         if num_iterations <= 0:

--- a/qiskit/algorithms/phase_estimators/phase_estimation.py
+++ b/qiskit/algorithms/phase_estimators/phase_estimation.py
@@ -21,7 +21,7 @@ from qiskit.circuit import QuantumCircuit
 import qiskit
 from qiskit import circuit
 from qiskit.circuit.classicalregister import ClassicalRegister
-from qiskit.providers import Backend
+from qiskit.providers import Backend, is_backend
 from qiskit.utils import QuantumInstance
 from qiskit.utils.deprecation import deprecate_arg
 from qiskit.result import Result
@@ -114,7 +114,7 @@ class PhaseEstimation(PhaseEstimator):
         if num_evaluation_qubits is not None:
             self._num_evaluation_qubits = num_evaluation_qubits
 
-        if isinstance(quantum_instance, Backend):
+        if is_backend(quantum_instance):
             quantum_instance = QuantumInstance(quantum_instance)
         self._quantum_instance = quantum_instance
         self._sampler = sampler

--- a/qiskit/execute_function.py
+++ b/qiskit/execute_function.py
@@ -23,7 +23,7 @@ import logging
 from time import time
 
 from qiskit.compiler import transpile, schedule
-from qiskit.providers.backend import Backend
+from qiskit.providers.backend import is_backend
 from qiskit.pulse import Schedule, ScheduleBlock
 from qiskit.exceptions import QiskitError
 from qiskit.utils.deprecation import deprecate_arg
@@ -319,7 +319,7 @@ def execute(
             method=scheduling_method,
         )
 
-    if isinstance(backend, Backend):
+    if is_backend(backend):
         start_time = time()
         run_kwargs = {
             "shots": shots,

--- a/qiskit/opflow/converters/circuit_sampler.py
+++ b/qiskit/opflow/converters/circuit_sampler.py
@@ -29,7 +29,7 @@ from qiskit.opflow.operator_base import OperatorBase
 from qiskit.opflow.state_fns.circuit_state_fn import CircuitStateFn
 from qiskit.opflow.state_fns.dict_state_fn import DictStateFn
 from qiskit.opflow.state_fns.state_fn import StateFn
-from qiskit.providers import Backend
+from qiskit.providers import Backend, is_backend
 from qiskit.utils.backend_utils import is_aer_provider, is_statevector_backend
 from qiskit.utils.quantum_instance import QuantumInstance
 from qiskit.utils.deprecation import deprecate_func
@@ -140,7 +140,7 @@ class CircuitSampler(ConverterBase):
         Raises:
             ValueError: statevector or param_qobj are True when not supported by backend.
         """
-        if isinstance(quantum_instance, Backend):
+        if is_backend(quantum_instance):
             quantum_instance = QuantumInstance(quantum_instance)
         self._quantum_instance = quantum_instance
         self._check_quantum_instance_and_modes_consistent()

--- a/qiskit/providers/__init__.py
+++ b/qiskit/providers/__init__.py
@@ -760,6 +760,7 @@ from qiskit.providers.provider import ProviderV1
 from qiskit.providers.backend import Backend
 from qiskit.providers.backend import BackendV1
 from qiskit.providers.backend import BackendV2
+from qiskit.providers.backend import is_backend_v1, is_backend_v2, is_backend
 from qiskit.providers.backend import QubitProperties
 from qiskit.providers.backend_compat import BackendV2Converter
 from qiskit.providers.backend_compat import convert_to_target

--- a/qiskit/providers/backend.py
+++ b/qiskit/providers/backend.py
@@ -15,29 +15,19 @@
 """Backend abstract interface for providers."""
 
 
-from abc import ABC
-from abc import abstractmethod
 import datetime
-from typing import List, Union, Iterable, Tuple
+import typing
+from abc import ABC, abstractmethod
+from typing import Any, Iterable, List, Tuple, Union
 
-from qiskit.providers.provider import Provider
-from qiskit.providers.models.backendstatus import BackendStatus
+from typing_extensions import TypeAlias, TypeGuard
+
 from qiskit.circuit.gate import Instruction
+from qiskit.providers.models.backendstatus import BackendStatus
+from qiskit.providers.provider import Provider
 
 
-class Backend:
-    """Base common type for all versioned Backend abstract classes.
-
-    Note this class should not be inherited from directly, it is intended
-    to be used for type checking. When implementing a provider you should use
-    the versioned abstract classes as the parent class and not this class
-    directly.
-    """
-
-    version = 0
-
-
-class BackendV1(Backend, ABC):
+class BackendV1(ABC):
     """Abstract class for Backends
 
     This abstract class is to be used for all Backend objects created by a
@@ -265,7 +255,7 @@ class QubitProperties:
         return f"QubitProperties(t1={self.t1}, t2={self.t2}, " f"frequency={self.frequency})"
 
 
-class BackendV2(Backend, ABC):
+class BackendV2(ABC):
     """Abstract class for Backends
 
     This abstract class is to be used for all Backend objects created by a
@@ -635,3 +625,27 @@ class BackendV2(Backend, ABC):
             Job: The job object for the run
         """
         pass
+
+
+Backend: TypeAlias = Union[BackendV1, BackendV2]
+"""Type that represents any backend type version.
+
+Use this type for functions that take a backend in any version.
+The :func:`is_backend_v1` and :func:`is_backend_v2` functions can
+be used to narrow the type appropriately.
+"""
+
+
+def is_backend(obj: Any) -> TypeGuard[Backend]:
+    """Type guard that narrows an object to the Backend union type."""
+    return isinstance(obj, typing.get_args(Backend))
+
+
+def is_backend_v1(obj: Backend) -> TypeGuard[BackendV1]:
+    """Type guard that narrows a backend instance to the BackendV1 type."""
+    return isinstance(obj, BackendV1)
+
+
+def is_backend_v2(obj: Backend) -> TypeGuard[BackendV2]:
+    """Type guard that narrows a backend instance to the BackendV2 type."""
+    return isinstance(obj, BackendV2)

--- a/qiskit/utils/quantum_instance.py
+++ b/qiskit/utils/quantum_instance.py
@@ -247,9 +247,9 @@ class QuantumInstance:
 
         # if the shots are none, try to get them from the backend
         if shots is None:
-            from qiskit.providers.backend import Backend  # pylint: disable=cyclic-import
+            from qiskit.providers.backend import is_backend  # pylint: disable=cyclic-import
 
-            if isinstance(backend, Backend):
+            if is_backend(backend):
                 if hasattr(backend, "options"):  # should always be true for V1
                     backend_shots = backend.options.get("shots", 1024)
                     if shots != backend_shots:

--- a/releasenotes/notes/backend-base-as-type-union-7a88be041b7fd628.yaml
+++ b/releasenotes/notes/backend-base-as-type-union-7a88be041b7fd628.yaml
@@ -1,0 +1,21 @@
+---
+features:
+  - |
+    Define the :class:`qiskit.providers.Backend` type as a union of all
+    existing backend versions types instead of an empty base class.
+    Functions that take a backend can handle the corresponding argument in a
+    uniform and typed manner as:
+
+      ```python
+      from qiskit.providers import Backend, BackendV2, BackendV2Converter, is_backend_v2
+      from typing_extensions import backend_v2
+
+      def func(backend: Backend) -> None:
+          if is_backend_v1(backend):
+              backend_v2 = BackendV2Converter(backend)
+          else:
+              backend_v2 = backend
+
+          assert_type(backend_v2, BackendV2)
+          print(backend_v2.name)
+      ```


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This patch is a proposal for redefining the `qiskit.providers.Backend` type as a union of the versioned types instead of as an empty base class.

The empty base class is unfortunately not very useful in a typed context because having an instance of the `Backend` type doesn't allow calling any methods / accessing any attributes other than `version` on it.

With the proposed approach, a pre-processor could be defined:

```python
def as_backend_v2(backend: Backend) -> BackendV2:
    if is_backend_v1(backend):
        return BackendV2Converter(backend)

    return backend
```

such that functions consuming backends can access backend attributes in a typesafe manner:

```python
def print_backend_name(backend: Backend) -> None:
    backend_ = as_backend_v2(backend)
    print(backend.name)  # should have been backend.name() for BackendV1
```

Since both variants of the new `Backend` type have a `version` attribute, the proposed modification is fully backwards compatible. Manualy narrowing using the `version` attribute is still supported (see below).

### Details and comments

- the [PEP 647](https://peps.python.org/pep-0647/) type guards could also be implemented as 

```python
def is_backend_v1(obj: Backend) -> TypeGuard[BackendV1]:
    return obj.version == 1
```
