### PR TITLE
Replace deprecated function call

### DIFF
--- a/qiskit/pulse/library/waveform.py
+++ b/qiskit/pulse/library/waveform.py
@@ -121,7 +121,7 @@ class Waveform(Pulse):
         )
 
     def __hash__(self) -> int:
-        return hash(self.samples.tostring())
+        return hash(self.samples.tobytes())
 
     def __repr__(self) -> str:
         opt = np.get_printoptions()

--- a/test/python/pulse/test_pulse_lib.py
+++ b/test/python/pulse/test_pulse_lib.py
@@ -64,6 +64,16 @@ class TestWaveform(QiskitTestCase):
         self.assertEqual(sample_pulse.duration, n_samples)
         self.assertEqual(sample_pulse.name, name)
 
+    def test_waveform_hashing(self):
+        """Test waveform hashing."""
+        n_samples = 100
+        samples = np.linspace(0, 1.0, n_samples, dtype=np.complex128)
+        name = "test"
+        sample_pulse = Waveform(samples, name=name)
+        sample_pulse2 = Waveform(samples, name="test2")
+
+        self.assertEqual({sample_pulse, sample_pulse2}, {sample_pulse})
+
     def test_type_casting(self):
         """Test casting of input samples to numpy array."""
         n_samples = 100


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

`tostring` has been deprecated since numpy 1.17. 

