### PR TITLE
Remove recursion from ConstrainedReschedule pass

### DIFF
--- a/qiskit/transpiler/passes/scheduling/alignments/reschedule.py
+++ b/qiskit/transpiler/passes/scheduling/alignments/reschedule.py
@@ -14,6 +14,8 @@
 
 from typing import List
 
+import rustworkx as rx
+
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.measure import Measure
 from qiskit.dagcircuit import DAGCircuit, DAGOpNode, DAGOutNode
@@ -110,37 +112,28 @@ class ConstrainedReschedule(AnalysisPass):
         conditional_latency = self.property_set.get("conditional_latency", 0)
         clbit_write_latency = self.property_set.get("clbit_write_latency", 0)
 
-        nodes_with_overlap = [(node, shift)]
-        visited = set()
-        shift_stack = []
-        while nodes_with_overlap:
-            node, shift = nodes_with_overlap.pop()
-            if node in visited:
-                continue
-            visited.add(node)
-            shift_stack.append((node, shift))
-            # Compute shifted t1 of this node separately for qreg and creg
-            this_t0 = node_start_time[node]
-            new_t1q = this_t0 + node.op.duration + shift
-            this_qubits = set(node.qargs)
-            if isinstance(node.op, Measure):
-                # creg access ends at the end of instruction
-                new_t1c = new_t1q
-                this_clbits = set(node.cargs)
-            else:
-                if node.op.condition_bits:
-                    # conditional access ends at the beginning of node start time
-                    new_t1c = this_t0 + shift
-                    this_clbits = set(node.op.condition_bits)
-                else:
-                    new_t1c = None
-                    this_clbits = set()
+        overlap_dict = {node: shift}
 
-            # Check successors for overlap
-            for next_node in self._get_next_gate(dag, node):
-                # Compute next node start time separately for qreg and creg
+        class PushBackVisitor(rx.visit.DFSVisitor):
+            def __init__(self):
+                super().__init__()
+                self.new_t1c = {}
+                self.new_t1q = {}
+                self.this_qubits = {}
+                self.this_clbits = {}
+
+            def tree_edge(self, edge):
+                node = dag._multi_graph[edge[0]]
+                next_node = dag._multi_graph[edge[1]]
+                if not isinstance(next_node, DAGOpNode):
+                    raise rx.visit.PruneSearch
+                # COmpute next node start time separately for qreg and creg
                 next_t0q = node_start_time[next_node]
                 next_qubits = set(next_node.qargs)
+                new_t1q = self.new_t1q[node]
+                new_t1c = self.new_t1c[node]
+                this_qubits = self.this_qubits[node]
+                this_clbits = self.this_clbits[node]
                 if isinstance(next_node.op, Measure):
                     # creg access starts after write latency
                     next_t0c = next_t0q + clbit_write_latency
@@ -166,11 +159,42 @@ class ConstrainedReschedule(AnalysisPass):
                 # Shift next node if there is finite overlap in either in qubits or clbits
                 overlap = max(qreg_overlap, creg_overlap)
                 if overlap > 0:
-                    nodes_with_overlap.append((next_node, overlap))
-        # Update start time of this node after all overlaps are resolved
-        while shift_stack:
-            node, shift = shift_stack.pop()
-            node_start_time[node] += shift
+                    overlap_dict[next_node] = overlap
+                else:
+                    raise rx.visit.PruneSearch
+
+            def discover_vertex(self, node_id, _t):
+                node = dag._multi_graph[node_id]
+
+                if not isinstance(node, DAGOpNode):
+                    raise rx.visit.PruneSearch
+                shift = overlap_dict[node]
+                # Compute shifted t1 of this node separately for qreg and creg
+                this_t0 = node_start_time[node]
+                new_t1q = this_t0 + node.op.duration + shift
+                this_qubits = set(node.qargs)
+                if isinstance(node.op, Measure):
+                    # creg access ends at the end of instruction
+                    new_t1c = new_t1q
+                    this_clbits = set(node.cargs)
+                else:
+                    if node.op.condition_bits:
+                        # conditional access ends at the beginning of node start time
+                        new_t1c = this_t0 + shift
+                        this_clbits = set(node.op.condition_bits)
+                    else:
+                        new_t1c = None
+                        this_clbits = set()
+                self.new_t1q[node] = new_t1q
+                self.new_t1c[node] = new_t1c
+                self.this_qubits[node] = this_qubits
+                self.this_clbits[node] = this_clbits
+
+            def finish_vertex(self, node_id, _t):
+                node = dag._multi_graph[node_id]
+                node_start_time[node] += overlap_dict[node]
+
+        rx.dfs_search(dag._multi_graph, [node._node_id], PushBackVisitor())
 
     def run(self, dag: DAGCircuit):
         """Run rescheduler.

--- a/qiskit/transpiler/passes/scheduling/alignments/reschedule.py
+++ b/qiskit/transpiler/passes/scheduling/alignments/reschedule.py
@@ -111,13 +111,9 @@ class ConstrainedReschedule(AnalysisPass):
         clbit_write_latency = self.property_set.get("clbit_write_latency", 0)
 
         nodes_with_overlap = [(node, shift)]
-        visited = set()
         shift_stack = []
         while nodes_with_overlap:
             node, shift = nodes_with_overlap.pop()
-            if node in visited:
-                continue
-            visited.add(node)
             shift_stack.append((node, shift))
             # Compute shifted t1 of this node separately for qreg and creg
             this_t0 = node_start_time[node]

--- a/qiskit/transpiler/passes/scheduling/alignments/reschedule.py
+++ b/qiskit/transpiler/passes/scheduling/alignments/reschedule.py
@@ -88,13 +88,9 @@ class ConstrainedReschedule(AnalysisPass):
         Returns:
             A list of non-delay successors.
         """
-        op_nodes = []
         for next_node in dag.successors(node):
-            if isinstance(next_node, DAGOutNode):
-                continue
-            op_nodes.append(next_node)
-
-        return op_nodes
+            if not isinstance(next_node, DAGOutNode):
+                yield next_node
 
     def _push_node_back(self, dag: DAGCircuit, node: DAGOpNode, shift: int):
         """Update start time of current node. Successors are also shifted to avoid overlap.
@@ -114,57 +110,67 @@ class ConstrainedReschedule(AnalysisPass):
         conditional_latency = self.property_set.get("conditional_latency", 0)
         clbit_write_latency = self.property_set.get("clbit_write_latency", 0)
 
-        # Compute shifted t1 of this node separately for qreg and creg
-        this_t0 = node_start_time[node]
-        new_t1q = this_t0 + node.op.duration + shift
-        this_qubits = set(node.qargs)
-        if isinstance(node.op, Measure):
-            # creg access ends at the end of instruction
-            new_t1c = new_t1q
-            this_clbits = set(node.cargs)
-        else:
-            if node.op.condition_bits:
-                # conditional access ends at the beginning of node start time
-                new_t1c = this_t0 + shift
-                this_clbits = set(node.op.condition_bits)
+        nodes_with_overlap = [(node, shift)]
+        visited = set()
+        shift_stack = []
+        while nodes_with_overlap:
+            node, shift = nodes_with_overlap.pop()
+            if node in visited:
+                continue
+            visited.add(node)
+            shift_stack.append((node, shift))
+            # Compute shifted t1 of this node separately for qreg and creg
+            this_t0 = node_start_time[node]
+            new_t1q = this_t0 + node.op.duration + shift
+            this_qubits = set(node.qargs)
+            if isinstance(node.op, Measure):
+                # creg access ends at the end of instruction
+                new_t1c = new_t1q
+                this_clbits = set(node.cargs)
             else:
-                new_t1c = None
-                this_clbits = set()
-
-        # Check successors for overlap
-        for next_node in self._get_next_gate(dag, node):
-            # Compute next node start time separately for qreg and creg
-            next_t0q = node_start_time[next_node]
-            next_qubits = set(next_node.qargs)
-            if isinstance(next_node.op, Measure):
-                # creg access starts after write latency
-                next_t0c = next_t0q + clbit_write_latency
-                next_clbits = set(next_node.cargs)
-            else:
-                if next_node.op.condition_bits:
-                    # conditional access starts before node start time
-                    next_t0c = next_t0q - conditional_latency
-                    next_clbits = set(next_node.op.condition_bits)
+                if node.op.condition_bits:
+                    # conditional access ends at the beginning of node start time
+                    new_t1c = this_t0 + shift
+                    this_clbits = set(node.op.condition_bits)
                 else:
-                    next_t0c = None
-                    next_clbits = set()
-            # Compute overlap if there is qubits overlap
-            if any(this_qubits & next_qubits):
-                qreg_overlap = new_t1q - next_t0q
-            else:
-                qreg_overlap = 0
-            # Compute overlap if there is clbits overlap
-            if any(this_clbits & next_clbits):
-                creg_overlap = new_t1c - next_t0c
-            else:
-                creg_overlap = 0
-            # Shift next node if there is finite overlap in either in qubits or clbits
-            overlap = max(qreg_overlap, creg_overlap)
-            if overlap > 0:
-                self._push_node_back(dag, next_node, overlap)
+                    new_t1c = None
+                    this_clbits = set()
 
+            # Check successors for overlap
+            for next_node in self._get_next_gate(dag, node):
+                # Compute next node start time separately for qreg and creg
+                next_t0q = node_start_time[next_node]
+                next_qubits = set(next_node.qargs)
+                if isinstance(next_node.op, Measure):
+                    # creg access starts after write latency
+                    next_t0c = next_t0q + clbit_write_latency
+                    next_clbits = set(next_node.cargs)
+                else:
+                    if next_node.op.condition_bits:
+                        # conditional access starts before node start time
+                        next_t0c = next_t0q - conditional_latency
+                        next_clbits = set(next_node.op.condition_bits)
+                    else:
+                        next_t0c = None
+                        next_clbits = set()
+                # Compute overlap if there is qubits overlap
+                if any(this_qubits & next_qubits):
+                    qreg_overlap = new_t1q - next_t0q
+                else:
+                    qreg_overlap = 0
+                # Compute overlap if there is clbits overlap
+                if any(this_clbits & next_clbits):
+                    creg_overlap = new_t1c - next_t0c
+                else:
+                    creg_overlap = 0
+                # Shift next node if there is finite overlap in either in qubits or clbits
+                overlap = max(qreg_overlap, creg_overlap)
+                if overlap > 0:
+                    nodes_with_overlap.append((next_node, overlap))
         # Update start time of this node after all overlaps are resolved
-        node_start_time[node] += shift
+        while shift_stack:
+            node, shift = shift_stack.pop()
+            node_start_time[node] += shift
 
     def run(self, dag: DAGCircuit):
         """Run rescheduler.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The ConstrainedReschedule pass previosuly was using a recursive depth first traversal to push back overlapping gates after aligning operations. This however would cause a failure for a sufficiently large circuit when the recursion depth could potentially exceed the maximum stack depth allowed in python. To address this, this commit rewrites the depth first traversal to be iterative instead of recursive. This removes the stack depth limitation and should let the pass run with any size circuit.

~However, the performance of this pass is poor for large circuits. One thing we can look at using to try and speed it up is~ ~rustworkx's dfs_search() function which will let us shift the traversal to rust and call back to python to do the timing~ ~offsets.~ I tried this in https://github.com/Qiskit/qiskit-terra/pull/10051/commits/bd3cbb271030b3d88c1ee36691b623a1714348c1 and it was significantly slower. We'll have to investigate a different algorithmic approach for adjusting the time that doesn't require multiple iterations like the current approach.

### Details and comments

Fixes #10049