### PR TITLE
Address slow test errors

### DIFF
--- a/test/python/algorithms/test_phase_estimator.py
+++ b/test/python/algorithms/test_phase_estimator.py
@@ -66,13 +66,12 @@ class TestHamiltonianPhaseEstimation(QiskitAlgorithmsTestCase):
             phase_est = HamiltonianPhaseEstimation(
                 num_evaluation_qubits=num_evaluation_qubits, quantum_instance=quantum_instance
             )
-        with self.assertWarns(DeprecationWarning):
-            result = phase_est.estimate(
-                hamiltonian=hamiltonian,
-                state_preparation=state_preparation,
-                evolution=evolution,
-                bound=bound,
-            )
+        result = phase_est.estimate(
+            hamiltonian=hamiltonian,
+            state_preparation=state_preparation,
+            evolution=evolution,
+            bound=bound,
+        )
         return result
 
     @data(MatrixEvolution(), PauliTrotterEvolution("suzuki", 4))
@@ -137,8 +136,8 @@ class TestHamiltonianPhaseEstimation(QiskitAlgorithmsTestCase):
             )
             state_preparation = StateFn((I ^ H).to_circuit())
             evo = PauliTrotterEvolution(trotter_mode="suzuki", reps=4)
-
-        result = self.hamiltonian_pe(hamiltonian, state_preparation, evolution=evo)
+        with self.assertWarns(DeprecationWarning):
+            result = self.hamiltonian_pe(hamiltonian, state_preparation, evolution=evo)
         with self.subTest("Most likely eigenvalues"):
             self.assertAlmostEqual(result.most_likely_eigenvalue, -1.855, delta=0.001)
         with self.subTest("Most likely phase"):

--- a/test/python/algorithms/test_phase_estimator.py
+++ b/test/python/algorithms/test_phase_estimator.py
@@ -66,12 +66,13 @@ class TestHamiltonianPhaseEstimation(QiskitAlgorithmsTestCase):
             phase_est = HamiltonianPhaseEstimation(
                 num_evaluation_qubits=num_evaluation_qubits, quantum_instance=quantum_instance
             )
-        result = phase_est.estimate(
-            hamiltonian=hamiltonian,
-            state_preparation=state_preparation,
-            evolution=evolution,
-            bound=bound,
-        )
+        with self.assertWarns(DeprecationWarning):
+            result = phase_est.estimate(
+                hamiltonian=hamiltonian,
+                state_preparation=state_preparation,
+                evolution=evolution,
+                bound=bound,
+            )
         return result
 
     @data(MatrixEvolution(), PauliTrotterEvolution("suzuki", 4))

--- a/test/python/primitives/test_backend_estimator.py
+++ b/test/python/primitives/test_backend_estimator.py
@@ -339,14 +339,14 @@ class TestBackendEstimator(QiskitTestCase):
                 bound_pass = PassManager(dummy_pass)
                 estimator = BackendEstimator(backend=FakeNairobi(), bound_pass_manager=bound_pass)
                 _ = estimator.run(qc, op).result()
-                self.assertTrue(mock_pass.call_count == 1)
+                self.assertEqual(mock_pass.call_count, 1)
 
         with self.subTest("Test circuit batch"):
             with patch.object(DummyTP, "run", wraps=dummy_pass.run) as mock_pass:
                 bound_pass = PassManager(dummy_pass)
                 estimator = BackendEstimator(backend=FakeNairobi(), bound_pass_manager=bound_pass)
                 _ = estimator.run([qc, qc], [op, op]).result()
-                self.assertTrue(mock_pass.call_count == 2)
+                self.assertEqual(mock_pass.call_count, 2)
 
     @combine(backend=BACKENDS)
     def test_layout(self, backend):

--- a/test/python/primitives/test_backend_sampler.py
+++ b/test/python/primitives/test_backend_sampler.py
@@ -392,13 +392,13 @@ class TestBackendSampler(QiskitTestCase):
             bound_pass = PassManager(dummy_pass)
             sampler = BackendSampler(backend=FakeNairobi(), bound_pass_manager=bound_pass)
             _ = sampler.run(self._circuit[0]).result()
-            self.assertTrue(mock_pass.call_count == 1)
+            self.assertEqual(mock_pass.call_count, 1)
 
         with patch.object(DummyTP, "run", wraps=dummy_pass.run) as mock_pass:
             bound_pass = PassManager(dummy_pass)
             sampler = BackendSampler(backend=FakeNairobi(), bound_pass_manager=bound_pass)
             _ = sampler.run([self._circuit[0], self._circuit[0]]).result()
-            self.assertTrue(mock_pass.call_count == 2)
+            self.assertEqual(mock_pass.call_count, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Addresses the slow test errors https://github.com/Qiskit/qiskit-terra/actions/runs/4848239802/jobs/8639178931
This fixes the first error and revises the other tests to be more informative when error.
I could not reproduce the bound_pass_manager errors on my local environment.

#7864 

```
==============================
Failed 3 tests - output below:
==============================

test.python.algorithms.test_phase_estimator.TestHamiltonianPhaseEstimation.test_H2_hamiltonian
----------------------------------------------------------------------------------------------

Captured traceback:
~~~~~~~~~~~~~~~~~~~
    Traceback (most recent call last):

      File "/home/runner/work/qiskit-terra/qiskit-terra/qiskit/test/decorators.py", line 98, in _wrapper
    return func(*args, **kwargs)

      File "/home/runner/work/qiskit-terra/qiskit-terra/test/python/algorithms/test_phase_estimator.py", line 140, in test_H2_hamiltonian
    result = self.hamiltonian_pe(hamiltonian, state_preparation, evolution=evo)

      File "/home/runner/work/qiskit-terra/qiskit-terra/test/python/algorithms/test_phase_estimator.py", line 69, in hamiltonian_pe
    result = phase_est.estimate(

      File "/home/runner/work/qiskit-terra/qiskit-terra/qiskit/algorithms/phase_estimators/hamiltonian_phase_estimation.py", line 228, in estimate
    hamiltonian = hamiltonian.to_pauli_op()

      File "/home/runner/work/qiskit-terra/qiskit-terra/qiskit/opflow/primitive_ops/pauli_sum_op.py", line 378, in to_pauli_op
    [

      File "/home/runner/work/qiskit-terra/qiskit-terra/qiskit/opflow/primitive_ops/pauli_sum_op.py", line 379, in <listcomp>
    PauliOp(pauli, to_native(coeff))

      File "/home/runner/work/qiskit-terra/qiskit-terra/qiskit/utils/deprecation.py", line 91, in wrapper
    warnings.warn(msg, category=category, stacklevel=2)

    DeprecationWarning: The class ``qiskit.opflow.primitive_ops.pauli_op.PauliOp`` is deprecated as of qiskit-terra 0.24.0. It will be removed no earlier than 3 months after the release date. For code migration guidelines, visit https://qisk.it/opflow_migration.


test.python.primitives.test_backend_sampler.TestBackendSampler.test_bound_pass_manager
--------------------------------------------------------------------------------------

Captured traceback:
~~~~~~~~~~~~~~~~~~~
    Traceback (most recent call last):

      File "/home/runner/work/qiskit-terra/qiskit-terra/test/python/primitives/test_backend_sampler.py", line 401, in test_bound_pass_manager
    self.assertTrue(mock_pass.call_count == 2)

      File "/opt/hostedtoolcache/Python/3.10.11/x64/lib/python3.10/unittest/case.py", line 687, in assertTrue
    raise self.failureException(msg)

    AssertionError: False is not true


test.python.primitives.test_backend_estimator.TestBackendEstimator.test_bound_pass_manager
------------------------------------------------------------------------------------------

Captured traceback:
~~~~~~~~~~~~~~~~~~~
    Traceback (most recent call last):

      File "/home/runner/work/qiskit-terra/qiskit-terra/test/python/primitives/test_backend_estimator.py", line 349, in test_bound_pass_manager
    self.assertTrue(mock_pass.call_count == 2)

      File "/opt/hostedtoolcache/Python/3.10.11/x64/lib/python3.10/unittest/case.py", line 687, in assertTrue
    raise self.failureException(msg)

    AssertionError: False is not true
```

### Details and comments


