### PR TITLE
Set `max_trials` for `VF2Layout` in preset pass managers.

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -133,6 +133,7 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
             call_limit=int(5e4),  # Set call limit to ~100ms with rustworkx 0.10.2
             properties=backend_properties,
             target=target,
+            max_trials=int(2500),  # Limits layout scoring to < 600ms on ~400 qubit devices
         )
     )
 

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -118,6 +118,7 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
             call_limit=int(5e6),  # Set call limit to ~10 sec with rustworkx 0.10.2
             properties=backend_properties,
             target=target,
+            max_trials=int(25000),  # Limits layout scoring to < 6 sec on ~400 qubit devices
         )
     )
 

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -124,6 +124,7 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
             call_limit=int(3e7),  # Set call limit to ~60 sec with rustworkx 0.10.2
             properties=backend_properties,
             target=target,
+            max_trials=int(250000),  # Limits layout scoring to < 60 sec on ~400 qubit devices
         )
     )
 

--- a/releasenotes/notes/preset-pm-vf2-max-trials-958bb8a36fff472f.yaml
+++ b/releasenotes/notes/preset-pm-vf2-max-trials-958bb8a36fff472f.yaml
@@ -1,0 +1,18 @@
+---
+upgrade:
+  - |
+    The maximum number of trials evaluated when searching for the best
+    layout using :class:`.VF2Layout` is now limited in
+    :func:`qiskit.transpiler.preset_passmanagers.level_1_pass_manager`,
+    :func:`qiskit.transpiler.preset_passmanagers.level_2_pass_manager`,
+    and
+    :func:`qiskit.transpiler.preset_passmanagers.level_3_pass_manager`
+    to ``2,500``, ``25,000``, and ``250,000``, respectively. Previously,
+    all possible layouts were evaluated. To perform a full search as
+    before, manually run :class:`.VF2PostLayout` over the transpiled circuit,
+    in strict mode, specifying ``0`` for ``max_trials``.
+fixes:
+  - |
+    Fixed a potential performance scaling issue with layout scoring in preset
+    pass managers, which could occur when transpiling circuits with many
+    connected components on large devices.


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
By setting ``max_trials``, we limit the number of layouts enumerated and scored when iterating through ``vf2_mapping()``.

This is necessary for scoring to complete in a reasonable amount of time for circuits with many connected components on larger (e.g. 400 qubit) devices.

### Details and comments
These limits were chosen using a fake 400 qubit device, using 200 connected components, where each component is a single CX gate.

Because layout scoring scales linearly with the number of qubits in the circuit, 250,000 (O3) takes abount a minute, 25,000 (O2) takes about 6 seconds, and 2,500 (O1) takes less than a second.

By adding these limits, we may miss out on better layouts beyond the options we evaluate. To mitigate this, a separate PR will follow that introduces presorting of the interaction graph and the coupling map graph which coerces VF2 to place the heaviest / most error inducing portions of the interaction graph onto the best quality qubits, leading to better layouts being found with fewer trials.

Related to #9834, which can be resolved once the follow-on PR lands.