### PR TITLE
Undo breaking API change in unitary synthesis plugin interface

### DIFF
--- a/qiskit/transpiler/passes/synthesis/plugin.py
+++ b/qiskit/transpiler/passes/synthesis/plugin.py
@@ -85,6 +85,14 @@ something like::
             return False
 
         @property
+        def supports_gate_lengths_by_qubit(self):
+            return False
+
+        @property
+        def supports_gate_errors_by_qubit(self):
+            return False
+
+        @property
         def min_qubits(self):
             return None
 
@@ -341,8 +349,7 @@ class UnitarySynthesisPlugin(abc.ABC):
         pass
 
     @property
-    @abc.abstractmethod
-    def supports_gate_lengths(self):
+    def supports_gate_lengths_by_qubit(self):
         """Return whether the plugin supports taking ``gate_lengths``
 
         ``gate_lengths`` will be a dictionary in the form of
@@ -359,11 +366,10 @@ class UnitarySynthesisPlugin(abc.ABC):
         as it depends on the target backend reporting gate lengths on every
         gate for each qubit.
         """
-        pass
+        return False
 
     @property
-    @abc.abstractmethod
-    def supports_gate_errors(self):
+    def supports_gate_errors_by_qubit(self):
         """Return whether the plugin supports taking ``gate_errors``
 
         ``gate_errors`` will be a dictionary in the form of
@@ -372,6 +378,48 @@ class UnitarySynthesisPlugin(abc.ABC):
             {
             (0,): [SXGate(): 0.0006149355812506126, RZGate(): 0.0],
             (0, 1): [CXGate(): 0.012012477900732316]
+            }
+
+        Do note that this dictionary might not be complete or could be empty
+        as it depends on the target backend reporting gate errors on every
+        gate for each qubit. The gate error rates reported in ``gate_errors``
+        are provided by the target device ``Backend`` object and the exact
+        meaning might be different depending on the backend.
+        """
+        return False
+
+    @property
+    @abc.abstractmethod
+    def supports_gate_lengths(self):
+        """Return whether the plugin supports taking ``gate_lengths``
+
+        ``gate_lengths`` will be a dictionary in the form of
+        ``{gate_name: {(qubit_1, qubit_2): length}}``. For example::
+
+            {
+            'sx': {(0,): 0.0006149355812506126, (1,): 0.0006149355812506126},
+            'cx': {(0, 1): 0.012012477900732316, (1, 0): 5.191111111111111e-07}
+            }
+
+        where the ``length`` value is in units of seconds.
+
+        Do note that this dictionary might not be complete or could be empty
+        as it depends on the target backend reporting gate lengths on every
+        gate for each qubit.
+        """
+        pass
+
+    @property
+    @abc.abstractmethod
+    def supports_gate_errors(self):
+        """Return whether the plugin supports taking ``gate_errors``
+
+        ``gate_errors`` will be a dictionary in the form of
+        ``{gate_name: {(qubit_1, qubit_2): error}}``. For example::
+
+            {
+            'sx': {(0,): 0.0006149355812506126, (1,): 0.0006149355812506126},
+            'cx': {(0, 1): 0.012012477900732316, (1, 0): 5.191111111111111e-07}
             }
 
         Do note that this dictionary might not be complete or could be empty

--- a/qiskit/transpiler/passes/synthesis/plugin.py
+++ b/qiskit/transpiler/passes/synthesis/plugin.py
@@ -350,9 +350,13 @@ class UnitarySynthesisPlugin(abc.ABC):
 
     @property
     def supports_gate_lengths_by_qubit(self):
-        """Return whether the plugin supports taking ``gate_lengths``
+        """Return whether the plugin supports taking ``gate_lengths_by_qubit``
 
-        ``gate_lengths`` will be a dictionary in the form of
+        This differs from ``supports_gate_lengths``/``gate_lengths`` by using a different
+        view of the same data. Instead of being keyed by gate name this is keyed by qubit
+        and uses :class:`~.Gate` instances to represent gates (instead of gate names)
+
+        ``gate_lengths_by_qubit`` will be a dictionary in the form of
         ``{(qubits,): [Gate, length]}``. For example::
 
             {
@@ -365,14 +369,20 @@ class UnitarySynthesisPlugin(abc.ABC):
         Do note that this dictionary might not be complete or could be empty
         as it depends on the target backend reporting gate lengths on every
         gate for each qubit.
+
+        This defaults to False
         """
         return False
 
     @property
     def supports_gate_errors_by_qubit(self):
-        """Return whether the plugin supports taking ``gate_errors``
+        """Return whether the plugin supports taking ``gate_errors_by_qubit``
 
-        ``gate_errors`` will be a dictionary in the form of
+        This differs from ``supports_gate_errors``/``gate_errors`` by using a different
+        view of the same data. Instead of being keyed by gate name this is keyed by qubit
+        and uses :class:`~.Gate` instances to represent gates (instead of gate names).
+
+        ``gate_errors_by_qubit`` will be a dictionary in the form of
         ``{(qubits,): [Gate, error]}``. For example::
 
             {
@@ -385,6 +395,8 @@ class UnitarySynthesisPlugin(abc.ABC):
         gate for each qubit. The gate error rates reported in ``gate_errors``
         are provided by the target device ``Backend`` object and the exact
         meaning might be different depending on the backend.
+
+        This defaults to False
         """
         return False
 

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -490,6 +490,15 @@ class UnitarySynthesis(TransformationPass):
 
 
 def _build_gate_lengths(props=None, target=None):
+    """Builds a ``gate_lengths`` dictionary from either ``props`` (BackendV1)
+    or ``target`` (BackendV2).
+
+    The dictionary has the form:
+    {gate_name: {(qubits,): duration}}
+    """
+
+
+    This method differs from
     gate_lengths = {}
     if target is not None:
         for gate, prop_dict in target.items():
@@ -510,6 +519,12 @@ def _build_gate_lengths(props=None, target=None):
 
 
 def _build_gate_errors(props=None, target=None):
+    """Builds a ``gate_error`` dictionary from either ``props`` (BackendV1)
+    or ``target`` (BackendV2).
+
+    The dictionary has the form:
+    {gate_name: {(qubits,): error_rate}}
+    """
     gate_errors = {}
     if target is not None:
         for gate, prop_dict in target.items():

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -496,9 +496,6 @@ def _build_gate_lengths(props=None, target=None):
     The dictionary has the form:
     {gate_name: {(qubits,): duration}}
     """
-
-
-    This method differs from
     gate_lengths = {}
     if target is not None:
         for gate, prop_dict in target.items():

--- a/releasenotes/notes/0.24/unitary-synthesis-based-on-errors-8041fcc9584f5db2.yaml
+++ b/releasenotes/notes/0.24/unitary-synthesis-based-on-errors-8041fcc9584f5db2.yaml
@@ -9,11 +9,17 @@ features:
     (e.g. RZ-RX-RZ or RZ-RY-RZ), generic unitary basis (e.g. U), and a
     few others.
     For a two-qubit decomposition, it can target any supercontrolled basis
-    (e.g. CNOT, iSWAP, B) or multiple controlled basis 
+    (e.g. CNOT, iSWAP, B) or multiple controlled basis
     (e.g. CZ, CH, ZZ^.5, ZX^.2, etc.).
-upgrade:
   - |
-    The interface for :class:`~.UnitarySynthesisPlugin` has been changed so
-    now `gate_lengths` and `gate_errors` have the form
-    ``{(qubits,): [Gate, length]}``. This allows gates that have the same
-    name but different parameters to be represented separately.
+    The interface for :class:`~.UnitarySynthesisPlugin` has two new
+    optional properties ``supports_gate_lengths_by_qubit`` and
+    ``supports_gate_errors_by_qubit`` which when set will add the
+    fields ``gate_lengths_by_qubit`` and ``gate_errors_by_qubit``
+    respectively to the input options to the plugin's ``run()`` method.
+    These new fields are an alternative view of the data provided by
+    ``gate_lengths`` and ``gate_errors`` but instead have the form:
+    ``{(qubits,): [Gate, length]}`` (where ``Gate`` is the instance
+    of :class:`~.Gate` for that definition). This allows plugins to
+    reason about working with gates of the same type but but that
+    have different parameters set.

--- a/test/python/transpiler/test_unitary_synthesis_plugin.py
+++ b/test/python/transpiler/test_unitary_synthesis_plugin.py
@@ -226,8 +226,8 @@ class TestUnitarySynthesisPlugin(QiskitTestCase):
         expected_kwargs = [
             "basis_gates",
             "coupling_map",
-            "gate_errors",
-            "gate_lengths",
+            "gate_errors_by_qubit",
+            "gate_lengths_by_qubit",
             "natural_direction",
             "pulse_optimize",
         ]
@@ -294,8 +294,8 @@ class TestUnitarySynthesisPlugin(QiskitTestCase):
         expected_kwargs = [
             "basis_gates",
             "coupling_map",
-            "gate_errors",
-            "gate_lengths",
+            "gate_errors_by_qubit",
+            "gate_lengths_by_qubit",
             "natural_direction",
             "pulse_optimize",
         ]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit reverts an unecessary breaking API change that was introduced in #9175. In that PR the data type for two arguments, gate_lengths and gate_errors, that was potentially passed to plugins was changed. This change was well intentioned as it was used by the default plugin as part of the changes to the default plugin made in that PR. But this neglected the downstream effects for any existing plugin interface users relying on the input to those fields. Making this change to existing fields would break any plugins that were using the old data format and is a violation of the Qiskit stability and deprecation policy. This commit reverts that change so that gate_lengths and gate_errors contain the same data format as in previous releases. Instead to facilitate the new workflow a new fields, gate_lengths_by_qubit and gate_errors_by_qubit, were added that leverage the new format introduced by #9175. By adding this as new optional fields existing users can continue to work as before, but the default plugin which requires the different data format can use the new data type.

### Details and comments


