### PR TITLE
Mark `mcsu2_real_diagonal` utility function as private

### DIFF
--- a/qiskit/circuit/library/standard_gates/multi_control_rotation_gates.py
+++ b/qiskit/circuit/library/standard_gates/multi_control_rotation_gates.py
@@ -83,7 +83,7 @@ def _apply_mcu_graycode(circuit, theta, phi, lam, ctls, tgt, use_basis_gates):
         last_pattern = pattern
 
 
-def mcsu2_real_diagonal(
+def _mcsu2_real_diagonal(
     circuit,
     unitary: np.ndarray,
     controls: Union[QuantumRegister, List[Qubit]],
@@ -232,7 +232,7 @@ def mcrx(
             use_basis_gates=use_basis_gates,
         )
     else:
-        mcsu2_real_diagonal(self, RXGate(theta).to_matrix(), control_qubits, target_qubit)
+        _mcsu2_real_diagonal(self, RXGate(theta).to_matrix(), control_qubits, target_qubit)
 
 
 def mcry(
@@ -302,7 +302,7 @@ def mcry(
                 use_basis_gates=use_basis_gates,
             )
         else:
-            mcsu2_real_diagonal(self, RYGate(theta).to_matrix(), control_qubits, target_qubit)
+            _mcsu2_real_diagonal(self, RYGate(theta).to_matrix(), control_qubits, target_qubit)
     else:
         raise QiskitError(f"Unrecognized mode for building MCRY circuit: {mode}.")
 

--- a/releasenotes/notes/0.24/su2-synthesis-295ebf03d9033263.yaml
+++ b/releasenotes/notes/0.24/su2-synthesis-295ebf03d9033263.yaml
@@ -1,7 +1,6 @@
 ---
 features:
   - |
-    The new function `mcsu2_real_diagonal(circuit, unitary, controls, target, ctrl_state)` 
-    applies a multi-controlled SU(2) gate unitary with one real diagonal. With n-1 controls, 
-    the decomposition requires approximately 16n cx gates. Synthesis of mcrx and mcry without 
-    auxiliary qubits now uses the `mcsu2_real_diagonal` decomposition.
+    Improve the decomposition of multi-controlled Pauli-X and Pauli-Y rotations on :math:`n`
+    controls to :math:`16n - 40` CX gates, for :math:`n \geq 4`. This improvement is based
+    on `arXiv:2302.06377 <https://arxiv.org/abs/2302.06377>`__.

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -77,7 +77,7 @@ from qiskit.circuit.library import (
 from qiskit.circuit._utils import _compute_control_matrix
 import qiskit.circuit.library.standard_gates as allGates
 from qiskit.extensions import UnitaryGate
-from qiskit.circuit.library.standard_gates.multi_control_rotation_gates import mcsu2_real_diagonal
+from qiskit.circuit.library.standard_gates.multi_control_rotation_gates import _mcsu2_real_diagonal
 
 from .gate_utils import _get_free_params
 
@@ -612,7 +612,7 @@ class TestControlledGate(QiskitTestCase):
         theta = 0.3
         qc = QuantumCircuit(num_ctrls + 1)
         ry_matrix = RYGate(theta).to_matrix()
-        mcsu2_real_diagonal(qc, ry_matrix, list(range(num_ctrls)), num_ctrls)
+        _mcsu2_real_diagonal(qc, ry_matrix, list(range(num_ctrls)), num_ctrls)
 
         mcry_matrix = _compute_control_matrix(ry_matrix, 6)
         self.assertTrue(np.allclose(mcry_matrix, Operator(qc).to_matrix()))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This utility function is used to construct multi-controlled Pauli rotations, but since it's a utility only used internally and we might need to move/adjust it, it would be better if it's a private function -- we can still turn it into a public one if we decide to.


