### PR TITLE
Turn off CI for forks

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,6 +10,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   coverage:
+    if: github.repository_owner == 'Qiskit'
     name: Coverage
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/neko.yml
+++ b/.github/workflows/neko.yml
@@ -9,6 +9,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   neko:
+    if: github.repository_owner == 'Qiskit'
     name: Qiskit Neko Integration Tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/randomized_tests.yml
+++ b/.github/workflows/randomized_tests.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   randomized_tests:
+    if: github.repository_owner == 'Qiskit'
     name: Randomized tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   slow-tests:
+    if: github.repository_owner == 'Qiskit'
     name: Full-test-run-with-slow
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Most people agree that GitHub made a mistake by having forks run CI both on the fork and in the upstream repository. It wastes computing resources (which has a real environmental cost!). In this repo in particular, the nightly integration tests have been failing for me.

### Details and comments

If people really want to run CI in their fork, they can always modify their fork's config to revert this change.
