### PR TITLE
Fix interaction graph vf2 scoring to include 1q component

### DIFF
--- a/crates/accelerate/src/vf2_layout.rs
+++ b/crates/accelerate/src/vf2_layout.rs
@@ -73,21 +73,19 @@ pub fn score_layout(
     } else {
         edge_list.par_iter().filter_map(edge_filter_map).product()
     };
-    if strict_direction {
-        fidelity *= if bit_list.len() < PARALLEL_THRESHOLD || !run_in_parallel {
-            bit_counts
-                .iter()
-                .enumerate()
-                .filter_map(bit_filter_map)
-                .product::<f64>()
-        } else {
-            bit_counts
-                .par_iter()
-                .enumerate()
-                .filter_map(bit_filter_map)
-                .product()
-        };
-    }
+    fidelity *= if bit_list.len() < PARALLEL_THRESHOLD || !run_in_parallel {
+        bit_counts
+            .iter()
+            .enumerate()
+            .filter_map(bit_filter_map)
+            .product::<f64>()
+    } else {
+        bit_counts
+            .par_iter()
+            .enumerate()
+            .filter_map(bit_filter_map)
+            .product()
+    };
     Ok(1. - fidelity)
 }
 

--- a/qiskit/transpiler/passes/layout/vf2_utils.py
+++ b/qiskit/transpiler/passes/layout/vf2_utils.py
@@ -111,9 +111,14 @@ def score_layout(
         size = 0
     nlayout = NLayout(layout_mapping, size + 1, size + 1)
     bit_list = np.zeros(len(im_graph), dtype=np.int32)
-    if strict_direction:
-        for node_index in bit_map.values():
+    for node_index in bit_map.values():
+        try:
             bit_list[node_index] = sum(im_graph[node_index].values())
+        # If node_index not in im_graph that means there was a standalone
+        # node we will score/sort separately outside the vf2 mapping, so we
+        # can finish here
+        except IndexError:
+            break
     edge_list = {
         (edge[0], edge[1]): sum(edge[2].values()) for edge in im_graph.edge_index_map().values()
     }

--- a/releasenotes/notes/fix-vf2-scoring-1q-e2ac29075831d64d.yaml
+++ b/releasenotes/notes/fix-vf2-scoring-1q-e2ac29075831d64d.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix a bug in the :class:`~.VF2Layout` and :class:`~.VF2PostLayout` passes
+    where the passes wer failing to account for the 1 qubit error component when
+    evaluating a potential layout.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #9148 a bug was introduced into the vf2 scoring code. In that PR the vf2 passes were changed to treat standalone qubits as a special case to improve the algorithmic efficiency of the pass. However, that PR broke the scoring algorithm so that it was no longer factoring in the 1q component of the interaction graph when scoring a layout. This meant that when scoring a potential layout only the 2q error rates were been factored into the score and the pass was potentially selecting worse performing qubits. This commit fixes this error and ensures the scoring is looking at all the error rates.

### Details and comments