### PR TITLE
Remove concurrency handling from Makefile stestr usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,26 +12,6 @@
 
 OS := $(shell uname -s)
 
-ifeq ($(OS), Linux)
-  NPROCS := $(shell grep -c ^processor /proc/cpuinfo)
-else ifeq ($(OS), Darwin)
-  NPROCS := 2
-else
-  NPROCS := 0
-endif # $(OS)
-
-ifeq ($(NPROCS), 2)
-	CONCURRENCY := 2
-else ifeq ($(NPROCS), 1)
-	CONCURRENCY := 1
-else ifeq ($(NPROCS), 3)
-	CONCURRENCY := 3
-else ifeq ($(NPROCS), 0)
-	CONCURRENCY := 0
-else
-	CONCURRENCY := $(shell echo "$(NPROCS) 2" | awk '{printf "%.0f", $$1 / $$2}')
-endif
-
 .PHONY: default env lint lint-incr style black test test_randomized pytest pytest_randomized test_ci coverage coverage_erase clean
 
 default: style lint-incr test ;
@@ -87,8 +67,7 @@ pytest_randomized:
 	pytest test/randomized
 
 test_ci:
-	@echo Detected $(NPROCS) CPUs running with $(CONCURRENCY) workers
-	QISKIT_TEST_CAPTURE_STREAMS=1 stestr run --concurrency $(CONCURRENCY)
+	QISKIT_TEST_CAPTURE_STREAMS=1 stestr run
 
 test_randomized:
 	python3 -m unittest discover -s test/randomized -t . -v


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #1973 the Makefile was updated to add manual concurrency handling to the invocation of stestr. At the time (> 4 yrs ag) our CI setup looked very different, everything was run in TravisCI which had much smaller memory quotas in the worker VMs and we also were actively using the Makefile to run tests. Since that time though CI and our development workflow have changed. At the time running multiple tests in parallel was causing us to exhaust the available RAM in the CI workers for MacOS and Windows so we set concurrency limits to prevent this. However, we no longer use travis, and the use of the makefile has long since been replaced by using tox as it provides a unified interface that manges venvs along with running tests in a consistent way across systems (including locally and CI). This commit reverts that change and lets stestr run with it's default concurrency when people use the Makefile. While the Makefile isn't widely used and has been largely superseded by tox, there are still some people using it and of those using MacOS or Windows this should improve local test throughput.

### Details and comments
