### PR TITLE
CITATION.bib from metapackage

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,6 @@
+@misc{Qiskit,
+    author = {{Qiskit contributors}},
+    title = {Qiskit: An Open-source Framework for Quantum Computing},
+    year = {2023},
+    doi = {10.5281/zenodo.2573505}
+}

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Now you're set up and ready to check out some of the other examples from our
 ## Authors and Citation
 
 Qiskit Terra is the work of [many people](https://github.com/Qiskit/qiskit-terra/graphs/contributors) who contribute
-to the project at different levels. If you use Qiskit, please cite as per the included [BibTeX file](https://github.com/Qiskit/qiskit/blob/master/Qiskit.bib).
+to the project at different levels. If you use Qiskit, please cite as per the included [BibTeX file](CITATION.bib).
 
 ## Changelog and Release Notes
 


### PR DESCRIPTION
_Originally posted by @garrison in https://github.com/Qiskit/qiskit-metapackage/issues/1722#issuecomment-1545938188_

> Just noticed that `CITATION.bib` needs to move as well.  Otherwise, the link from the Terra README will be broken after `qiskit-terra` -> `qiskit`.

This is related with [`RFC 0011`](https://github.com/Qiskit/RFCs/blob/master/0011-repo-rename.md )