### PR TITLE
Add ruff to local tests and CI

### DIFF
--- a/.azure/lint-linux.yml
+++ b/.azure/lint-linux.yml
@@ -43,6 +43,8 @@ jobs:
       - bash: |
           set -e
           source test-job/bin/activate
+          echo "Running ruff"
+          ruff qiskit test tools examples setup.py
           echo "Running pylint"
           pylint -rn qiskit test tools
           echo "Running Cargo Clippy"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -448,10 +448,8 @@ oversights will still be caught by the CI after you open a pull request).
 
 Because they are so fast, it is sometimes convenient to run the tools `black` and `ruff` separately
 rather than via `tox`. If you have installed the development packages in your python environment via
-`pip install -r requirements.dev`, then `ruff` and `black` will be available. Otherwise install them
-with `pip install ruff black`. Running the commands `ruff check qiskit test tools examples setup.py`
-and `black --check qiskit test tools examples setup.py` will run the same tests with these tools
-that are run via `tox` as well as in CI.
+`pip install -r requirements-dev.txt`, then `ruff` and `black` will be available and can be run from
+the command line. See [`tox.ini`](tox.ini) for how `tox` invokes them.
 
 ## Development Cycle
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -446,10 +446,11 @@ this will miss some issues that would have been caught by checking the complete
 source tree, but makes up for this by being much faster (and those rare
 oversights will still be caught by the CI after you open a pull request).
 
-You can also run just `ruff`. If you have installed the development packages in
-your python environment via `pip install -r requirements.dev`, then `ruff` will
-be available. Otherwise install it with `pip install ruff`. Running the command
-`ruff check qiskit test tools examples setup.py` will run the same `ruff` tests
+Because they are so fast, it is sometimes convenient to run the tools `black` and `ruff` separately
+rather than via `tox`. If you have installed the development packages in your python environment via
+`pip install -r requirements.dev`, then `ruff` and `black` will be available. Otherwise install them
+with `pip install ruff black`. Running the commands `ruff check qiskit test tools examples setup.py`
+and `black --check qiskit test tools examples setup.py` will run the same tests with these tools
 that are run via `tox` as well as in CI.
 
 ## Development Cycle

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -422,25 +422,35 @@ Note: If you have run `test/ipynb/mpl_tester.ipynb` locally it is possible some 
 
 ## Style and lint
 
-Qiskit Terra uses 2 tools for verify code formatting and lint checking. The
+Qiskit Terra uses three tools for verify code formatting and lint checking. The
 first tool is [black](https://github.com/psf/black) which is a code formatting
 tool that will automatically update the code formatting to a consistent style.
 The second tool is [pylint](https://www.pylint.org/) which is a code linter
 which does a deeper analysis of the Python code to find both style issues and
-potential bugs and other common issues in Python.
+potential bugs and other common issues in Python. The third tool is the linter
+[ruff](https://github.com/charliermarsh/ruff), which has been recently
+introduced into Qiskit Terra on an experimental basis. Only a very small number
+of rules are enabled.
 
-You can check that your local modifications conform to the style rules
-by running `tox -elint` which will run `black` and `pylint` to check the local
-code formatting and lint. If black returns a code formatting error you can
-run `tox -eblack` to automatically update the code formatting to conform to
-the style. However, if `pylint` returns any error you will have to fix these
-issues by manually updating your code.
+You can check that your local modifications conform to the style rules by
+running `tox -elint` which will run `black`, `ruff`, and `pylint` to check the
+local code formatting and lint. If black returns a code formatting error you can
+run `tox -eblack` to automatically update the code formatting to conform to the
+style. However, if `ruff` or `pylint` return any error you will have to fix
+these issues by manually updating your code.
 
-Because `pylint` analysis can be slow, there is also a `tox -elint-incr` target, which only applies
-`pylint` to files which have changed from the source github. On rare occasions this will miss some
-issues that would have been caught by checking the complete source tree, but makes up for this by
-being much faster (and those rare oversights will still be caught by the CI after you open a pull
-request).
+Because `pylint` analysis can be slow, there is also a `tox -elint-incr` target,
+which runs `black` and `ruff` just as `tox -elint` does, but only applies
+`pylint` to files which have changed from the source github. On rare occasions
+this will miss some issues that would have been caught by checking the complete
+source tree, but makes up for this by being much faster (and those rare
+oversights will still be caught by the CI after you open a pull request).
+
+You can also run just `ruff`. If you have installed the development packages in
+your python environment via `pip install -r requirements.dev`, then `ruff` will
+be available. Otherwise install it with `pip install ruff`. Running the command
+`ruff check qiskit test tools examples setup.py` will run the same `ruff` tests
+that are run via `tox` as well as in CI.
 
 ## Development Cycle
 

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@
 
 OS := $(shell uname -s)
 
-.PHONY: default env lint lint-incr style black test test_randomized pytest pytest_randomized test_ci coverage coverage_erase clean
+.PHONY: default ruff env lint lint-incr style black test test_randomized pytest pytest_randomized test_ci coverage coverage_erase clean
 
-default: style lint-incr test ;
+default: ruff style lint-incr test ;
 
 # Dependencies need to be installed on the Anaconda virtual environment.
 env:
@@ -40,6 +40,9 @@ lint-incr:
 	tools/pylint_incr.py -j4 -rn -sn --disable='invalid-name, missing-module-docstring, redefined-outer-name' --paths ':(glob,top)examples/python/*.py'
 	tools/verify_headers.py qiskit test tools examples
 	tools/find_optional_imports.py
+
+ruff:
+	ruff qiskit test tools examples setup.py
 
 style:
 	black --check qiskit test tools examples setup.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,14 @@ environment = 'RUSTUP_TOOLCHAIN="stable"'
 before-all = "yum install -y wget && {package}/tools/install_rust.sh"
 environment = 'PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true" RUSTUP_TOOLCHAIN="stable"'
 
+[tool.ruff]
+select = [
+       "F631",
+       "F632",
+       "F634",
+       "F823",
+]
+
 [tool.pylint.main]
 extension-pkg-allow-list = [
     "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,10 @@ environment = 'PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true"
 
 [tool.ruff]
 select = [
-       "F631",
-       "F632",
-       "F634",
-       "F823",
+  "F631",
+  "F632",
+  "F634",
+  "F823",
 ]
 
 [tool.pylint.main]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@ black[jupyter]~=22.0
 pydot
 astroid==2.14.2
 pylint==2.16.2
+ruff==0.0.267
 stestr>=2.0.0,!=4.0.0
 pylatexenc>=1.4
 ddt>=1.2.0,!=1.4.0,!=1.4.3

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ commands =
 [testenv:lint]
 basepython = python3
 commands =
+  ruff check qiskit test tools examples setup.py
   black --check {posargs} qiskit test tools examples setup.py
   pylint -rn qiskit test tools
   # This line is commented out until #6649 merges. We can't run this currently
@@ -38,6 +39,7 @@ commands =
 basepython = python3
 allowlist_externals = git
 commands =
+  ruff check qiskit test tools examples setup.py
   black --check {posargs} qiskit test tools examples setup.py
   -git fetch -q https://github.com/Qiskit/qiskit-terra.git :lint_incr_latest
   python {toxinidir}/tools/pylint_incr.py -rn -j4 -sn --paths :/qiskit/*.py :/test/*.py :/tools/*.py


### PR DESCRIPTION
This adds linting using `ruff` to the relevant configuration files. Only a few rules are enabled and none of them trigger an error in the current state of 	qiskit-terra.

The immediate goal of this PR is to test integrating `ruff` into local workflows as well as CI.  This is the reason why only very few rules are enabled, and none necessitated code changes.

If this PR is successful, more `ruff` rules will be added in subsequent PRs.
