### PR TITLE
Fix tweedledum runtime detection in BooleanExpression.from_dimacs_file

### DIFF
--- a/qiskit/circuit/classicalfunction/boolean_expression.py
+++ b/qiskit/circuit/classicalfunction/boolean_expression.py
@@ -110,6 +110,7 @@ class BooleanExpression(ClassicalElement):
         Raises:
             FileNotFoundError: If filename is not found.
         """
+        HAS_TWEEDLEDUM.require_now("BooleanExpression")
 
         from tweedledum import BoolFunction  # pylint: disable=import-error
 

--- a/releasenotes/notes/fix-exception-from_dimacs_file-b9338f3c913a9bff.yaml
+++ b/releasenotes/notes/fix-exception-from_dimacs_file-b9338f3c913a9bff.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed an issue with the :meth:`.BooleanExpression.from_dimacs_file`
+    constructor method where the exception type raised when tweedledum wasn't
+    installed was not the expected :class:`~.MissingOptionalLibrary`.
+    Fixed `#10079 <https://github.com/Qiskit/qiskit-terra/issues/10079>`__


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an oversight in the 0.24.0 release that caused an accidental change in the exception raised when attempting to use BooleanExpression.from_dimacs_file without having tweedledum installed. In #9754 the detection of tweedledum was updated to avoid import time detection so that the module can be imported even if tweedledum isn't installed. This was done through the use of the optionals decorators so that tweedledum is only attempted to be imported when the classicalfunction modules is used. However, the decorators don't wrap classmethod constructors by default and this caused the incorrect exception type to be raised. This commit fixes this by doing the runtime checking manually inside the from_dimacs_file constructor.

### Details and comments