### PR TITLE
Adding the feature of calculating entanglement measures negativity

### DIFF
--- a/qiskit/quantum_info/__init__.py
+++ b/qiskit/quantum_info/__init__.py
@@ -173,6 +173,7 @@ from .states import (
     purity,
     shannon_entropy,
     state_fidelity,
+    negativity,
 )
 from .synthesis import (
     OneQubitEulerDecomposer,

--- a/qiskit/quantum_info/states/__init__.py
+++ b/qiskit/quantum_info/states/__init__.py
@@ -23,4 +23,5 @@ from .measures import (
     concurrence,
     mutual_information,
     entanglement_of_formation,
+    negativity,
 )

--- a/qiskit/quantum_info/states/measures.py
+++ b/qiskit/quantum_info/states/measures.py
@@ -278,7 +278,7 @@ def negativity(state, qargs):
     # Generating partially transposed state
     state = state.partial_transpose(qargs)
     # Calculating SVD
-    _, singular_values, _ = np.linalg.svd(state.data)
+    singular_values = np.linalg.svd(state.data, compute_uv=False)
     eigvals = np.sum(singular_values)
     # Calculating negativity
     negv = (eigvals - 1) / 2

--- a/qiskit/quantum_info/states/measures.py
+++ b/qiskit/quantum_info/states/measures.py
@@ -254,39 +254,40 @@ def entanglement_of_formation(state):
     return shannon_entropy([val, 1 - val])
 
 
-def negativity(state, qargs, base=2):
-    r"""Calculates the negativity and logarithmic negativity
+def negativity(state, qargs):
+    r"""Calculates the negativity
 
     The mathematical expression for negativity is given by:
     .. math::
+<<<<<<< HEAD
         {\cal{N}}(\rho) = \frac{|| \rho^{T_A}|| - 1 }{2}
 
     The mathematical expression for logarithmic negaitivity is given by:
     .. math::
         {\cal{E}}_N(\rho) = \log_2(|| \rho^{T_A}||)
+=======
+        {\cal{N}}(\rho) = \frac{|| \rho^{T_A} || - 1 }{2}
+>>>>>>> 221a3c02e (Modified the negativity function, where we have removed log negativity)
 
     Args:
         state (Statevector or DensityMatrix): a quantum state.
         qargs (list): The subsystems to be transposed.
-        base (float): the base of the logarithm [Default: 2].
 
     Returns:
         negv (float): Negativity value of the quantum state
-        log_negv (float): Logarithmic Negativity value of the quantum state
 
     Raises:
         QiskitError: if the input state is not a valid QuantumState.
     """
-    import math
 
     if isinstance(state, Statevector):
         # If input is statevector then converting it into density matrix
         state = DensityMatrix(state)
     # Generating partially transposed state
     state = state.partial_transpose(qargs)
-    eigvals, _ = np.linalg.eig(np.matmul(np.transpose(np.conjugate(state.data)), state.data))
-    eigvals = np.sum(np.sqrt(np.maximum(np.real(eigvals), 0.0)))
-
+    # Calculating SVD
+    _, singular_values, _ = np.linalg.svd(state.data)
+    eigvals = np.sum(singular_values)
+    # Calculating negativity
     negv = (eigvals - 1) / 2
-    log_negv = math.log(eigvals, base)
-    return negv, log_negv
+    return negv

--- a/qiskit/quantum_info/states/measures.py
+++ b/qiskit/quantum_info/states/measures.py
@@ -252,3 +252,41 @@ def entanglement_of_formation(state):
     conc = concurrence(state)
     val = (1 + np.sqrt(1 - (conc**2))) / 2
     return shannon_entropy([val, 1 - val])
+
+
+def negativity(state, qargs, base=2):
+    r"""Calculates the negativity and logarithmic negativity
+
+    The mathematical expression for negativity is given by:
+    .. math::
+        {\cal{N}}(\rho) = \frac{|| \rho^{T_A} - 1 ||}{2}
+
+    The mathematical expression for logarithmic negaitivity is given by:
+    .. math::
+        {\cal{E}}_N(\rho) = \log_2(|| \rho^{T_A}||)
+
+    Args:
+        state (Statevector or DensityMatrix): a quantum state.
+        qargs (list): The subsystems to be transposed.
+        base (float): the base of the logarithm [Default: 2].
+
+    Returns:
+        negv (float): Negativity value of the quantum state
+        log_negv (float): Logarithmic Negativity value of the quantum state
+
+    Raises:
+        QiskitError: if the input state is not a valid QuantumState.
+    """
+    import math
+
+    if isinstance(state, Statevector):
+        # If input is statevector then converting it into density matrix
+        state = DensityMatrix(state)
+    # Generating partially transposed state
+    state = state.partial_transpose(qargs)
+    eigvals, _ = np.linalg.eig(np.matmul(np.transpose(np.conjugate(state.data)), state.data))
+    eigvals = np.sum(np.sqrt(np.maximum(np.real(eigvals), 0.0)))
+
+    negv = (eigvals - 1) / 2
+    log_negv = math.log(eigvals, base)
+    return negv, log_negv

--- a/qiskit/quantum_info/states/measures.py
+++ b/qiskit/quantum_info/states/measures.py
@@ -259,7 +259,7 @@ def negativity(state, qargs, base=2):
 
     The mathematical expression for negativity is given by:
     .. math::
-        {\cal{N}}(\rho) = \frac{|| \rho^{T_A} - 1 ||}{2}
+        {\cal{N}}(\rho) = \frac{|| \rho^{T_A}|| - 1 }{2}
 
     The mathematical expression for logarithmic negaitivity is given by:
     .. math::

--- a/qiskit/quantum_info/states/measures.py
+++ b/qiskit/quantum_info/states/measures.py
@@ -259,15 +259,7 @@ def negativity(state, qargs):
 
     The mathematical expression for negativity is given by:
     .. math::
-<<<<<<< HEAD
         {\cal{N}}(\rho) = \frac{|| \rho^{T_A}|| - 1 }{2}
-
-    The mathematical expression for logarithmic negaitivity is given by:
-    .. math::
-        {\cal{E}}_N(\rho) = \log_2(|| \rho^{T_A}||)
-=======
-        {\cal{N}}(\rho) = \frac{|| \rho^{T_A} || - 1 }{2}
->>>>>>> 221a3c02e (Modified the negativity function, where we have removed log negativity)
 
     Args:
         state (Statevector or DensityMatrix): a quantum state.

--- a/releasenotes/notes/add-feature-negativity-logarithmic-negativity-fce5d8392460a0e9.yaml
+++ b/releasenotes/notes/add-feature-negativity-logarithmic-negativity-fce5d8392460a0e9.yaml
@@ -1,0 +1,24 @@
+---
+features:
+  - |
+    Added a new function , :func:`negativity` that adds support for calculating
+    entanglement measures negativity and logarithmic negativity of an quantum state.
+    An illustrative example for using the above function is given below:
+
+    .. code-block:
+      from qiskit.quantum_info.states.densitymatrix import DensityMatrix
+      from qiskit.quantum_info.states.statevector import Statevector
+      from qiskit.quantum_info import negativity
+      import numpy as np
+
+      # Constructing a two-qubit bell state vector
+      state = np.array([0, 1/np.sqrt(2), -1/np.sqrt(2), 0])
+      # Calculating negativity and logarithmic negativity of statevector
+      negv, lognegv = negativity(Statevector(state), [1])
+
+      # Creating the Density Matrix (DM)
+      rho = DensityMatrix.from_label("10+")
+      # Calculating negativity and logarithmic negativity of DM
+      negv2, lognegv2 = negativity(rho, [0, 1])
+
+

--- a/releasenotes/notes/add-feature-negativity-logarithmic-negativity-fce5d8392460a0e9.yaml
+++ b/releasenotes/notes/add-feature-negativity-logarithmic-negativity-fce5d8392460a0e9.yaml
@@ -2,7 +2,7 @@
 features:
   - |
     Added a new function , :func:`negativity` that adds support for calculating
-    entanglement measures negativity and logarithmic negativity of an quantum state.
+    entanglement measures negativity of an quantum state.
     An illustrative example for using the above function is given below:
 
     .. code-block:
@@ -13,12 +13,12 @@ features:
 
       # Constructing a two-qubit bell state vector
       state = np.array([0, 1/np.sqrt(2), -1/np.sqrt(2), 0])
-      # Calculating negativity and logarithmic negativity of statevector
-      negv, lognegv = negativity(Statevector(state), [1])
+      # Calculating negativity of statevector
+      negv = negativity(Statevector(state), [1])
 
       # Creating the Density Matrix (DM)
       rho = DensityMatrix.from_label("10+")
-      # Calculating negativity and logarithmic negativity of DM
-      negv2, lognegv2 = negativity(rho, [0, 1])
+      # Calculating negativity of DM
+      negv2 = negativity(rho, [0, 1])
 
 

--- a/test/python/quantum_info/states/test_measures.py
+++ b/test/python/quantum_info/states/test_measures.py
@@ -346,33 +346,27 @@ class TestStateMeasures(QiskitTestCase):
         """Test negativity function on statevector inputs"""
         # Constructing separable quantum statevector
         state = Statevector([1 / np.sqrt(2), 1 / np.sqrt(2), 0, 0])
-        negv, log_negv = negativity(state, [0])
+        negv = negativity(state, [0])
         self.assertAlmostEqual(negv, 0, places=7)
-        self.assertAlmostEqual(log_negv, 0, places=7)
         # Constructing entangled quantum statevector
         state = Statevector([0, 1 / np.sqrt(2), -1 / np.sqrt(2), 0])
-        negv, log_negv = negativity(state, [1])
+        negv = negativity(state, [1])
         self.assertAlmostEqual(negv, 0.5, places=7)
-        self.assertAlmostEqual(log_negv, 1, places=7)
 
     def test_negativity_density_matrix(self):
         """Test negativity function on density matrix inputs"""
         # Constructing separable quantum state
         rho = DensityMatrix.from_label("10+")
-        negv, log_negv = negativity(rho, [0, 1])
+        negv = negativity(rho, [0, 1])
         self.assertAlmostEqual(negv, 0, places=7)
-        self.assertAlmostEqual(log_negv, 0, places=7)
-        negv, log_negv = negativity(rho, [0, 2])
+        negv = negativity(rho, [0, 2])
         self.assertAlmostEqual(negv, 0, places=7)
-        self.assertAlmostEqual(log_negv, 0, places=7)
         # Constructing entangled quantum state
         rho = DensityMatrix([[0, 0, 0, 0], [0, 0.5, -0.5, 0], [0, -0.5, 0.5, 0], [0, 0, 0, 0]])
-        negv, log_negv = negativity(rho, [0])
+        negv = negativity(rho, [0])
         self.assertAlmostEqual(negv, 0.5, places=7)
-        self.assertAlmostEqual(log_negv, 1, places=7)
-        negv, log_negv = negativity(rho, [1])
+        negv = negativity(rho, [1])
         self.assertAlmostEqual(negv, 0.5, places=7)
-        self.assertAlmostEqual(log_negv, 1, places=7)
 
 
 if __name__ == "__main__":

--- a/test/python/quantum_info/states/test_measures.py
+++ b/test/python/quantum_info/states/test_measures.py
@@ -25,6 +25,7 @@ from qiskit.quantum_info import concurrence
 from qiskit.quantum_info import entanglement_of_formation
 from qiskit.quantum_info import mutual_information
 from qiskit.quantum_info.states import shannon_entropy
+from qiskit.quantum_info import negativity
 
 
 class TestStateMeasures(QiskitTestCase):
@@ -340,6 +341,38 @@ class TestStateMeasures(QiskitTestCase):
             psi = Statevector([alpha, beta, 0, 1j * np.sqrt(1 - alpha**2 - beta**2)])
             rho = DensityMatrix(psi)
             self.assertAlmostEqual(mutual_information(psi), mutual_information(rho))
+
+    def test_negativity_statevector(self):
+        """Test negativity function on statevector inputs"""
+        # Constructing separable quantum statevector
+        state = Statevector([1 / np.sqrt(2), 1 / np.sqrt(2), 0, 0])
+        negv, log_negv = negativity(state, [0])
+        self.assertAlmostEqual(negv, 0, places=7)
+        self.assertAlmostEqual(log_negv, 0, places=7)
+        # Constructing entangled quantum statevector
+        state = Statevector([0, 1 / np.sqrt(2), -1 / np.sqrt(2), 0])
+        negv, log_negv = negativity(state, [1])
+        self.assertAlmostEqual(negv, 0.5, places=7)
+        self.assertAlmostEqual(log_negv, 1, places=7)
+
+    def test_negativity_density_matrix(self):
+        """Test negativity function on density matrix inputs"""
+        # Constructing separable quantum state
+        rho = DensityMatrix.from_label("10+")
+        negv, log_negv = negativity(rho, [0, 1])
+        self.assertAlmostEqual(negv, 0, places=7)
+        self.assertAlmostEqual(log_negv, 0, places=7)
+        negv, log_negv = negativity(rho, [0, 2])
+        self.assertAlmostEqual(negv, 0, places=7)
+        self.assertAlmostEqual(log_negv, 0, places=7)
+        # Constructing entangled quantum state
+        rho = DensityMatrix([[0, 0, 0, 0], [0, 0.5, -0.5, 0], [0, -0.5, 0.5, 0], [0, 0, 0, 0]])
+        negv, log_negv = negativity(rho, [0])
+        self.assertAlmostEqual(negv, 0.5, places=7)
+        self.assertAlmostEqual(log_negv, 1, places=7)
+        negv, log_negv = negativity(rho, [1])
+        self.assertAlmostEqual(negv, 0.5, places=7)
+        self.assertAlmostEqual(log_negv, 1, places=7)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I and @PayalSolanki2906 are adding the feature which can be used to calculate the entanglement measures negativity and logarithmic negativity. To this end, we have created a function: `negativity` inside `qiskit.quantum_info.states.measures` module.