### PR TITLE
Fix the output macros.measure with backendV2

### DIFF
--- a/qiskit/pulse/macros.py
+++ b/qiskit/pulse/macros.py
@@ -63,16 +63,11 @@ def measure(
 
     # backend is V2.
     if hasattr(backend, "target"):
-        try:
-            meas_map = backend.configuration().meas_map
-        except AttributeError:
-            # TODO add meas_map to Target in 0.25
-            meas_map = [list(range(backend.num_qubits))]
 
         return _measure_v2(
             qubits=qubits,
             target=backend.target,
-            meas_map=meas_map,
+            meas_map=meas_map or getattr(backend, "meas_map", [list(range(backend.num_qubits))]),
             qubit_mem_slots=qubit_mem_slots or dict(zip(qubits, range(len(qubits)))),
             measure_name=measure_name,
         )
@@ -198,12 +193,7 @@ def _measure_v2(
                         channels.AcquireChannel(measure_qubit),
                     ]
                 )
-            else:
-                default_sched = target.get_calibration(measure_name, (measure_qubit,)).filter(
-                    channels=[
-                        channels.AcquireChannel(measure_qubit),
-                    ]
-                )
+                schedule += _schedule_remapping_memory_slot(default_sched, qubit_mem_slots)
         except KeyError as ex:
             raise exceptions.PulseError(
                 "We could not find a default measurement schedule called '{}'. "
@@ -211,7 +201,6 @@ def _measure_v2(
                 "argument. For assistance, the instructions which are defined are: "
                 "{}".format(measure_name, target.instructions)
             ) from ex
-        schedule += _schedule_remapping_memory_slot(default_sched, qubit_mem_slots)
     return schedule
 
 

--- a/test/python/pulse/test_macros.py
+++ b/test/python/pulse/test_macros.py
@@ -24,7 +24,7 @@ from qiskit.pulse import (
 )
 from qiskit.pulse import macros
 from qiskit.pulse.exceptions import PulseError
-from qiskit.providers.fake_provider import FakeOpenPulse2Q, FakeHanoiV2
+from qiskit.providers.fake_provider import FakeOpenPulse2Q, FakeHanoi, FakeHanoiV2
 from qiskit.test import QiskitTestCase
 
 
@@ -95,13 +95,8 @@ class TestMeasure(QiskitTestCase):
         """Test macro - measure with backendV2."""
         sched = macros.measure(qubits=[0], backend=self.backend_v2)
         expected = self.backend_v2.target.get_calibration("measure", (0,)).filter(
-            channels=[
-                MeasureChannel(0),
-            ]
+            channels=[MeasureChannel(0), AcquireChannel(0)]
         )
-        measure_duration = expected.filter(instruction_types=[Play]).duration
-        for qubit in range(self.backend_v2.num_qubits):
-            expected += Acquire(measure_duration, AcquireChannel(qubit), MemorySlot(qubit))
         self.assertEqual(sched.instructions, expected.instructions)
 
     def test_measure_v2_sched_with_qubit_mem_slots(self):
@@ -113,15 +108,7 @@ class TestMeasure(QiskitTestCase):
             ]
         )
         measure_duration = expected.filter(instruction_types=[Play]).duration
-        for qubit in range(self.backend_v2.num_qubits):
-            if qubit == 0:
-                expected += Acquire(measure_duration, AcquireChannel(qubit), MemorySlot(2))
-            elif qubit == 1:
-                expected += Acquire(measure_duration, AcquireChannel(qubit), MemorySlot(0))
-            elif qubit == 2:
-                expected += Acquire(measure_duration, AcquireChannel(qubit), MemorySlot(1))
-            else:
-                expected += Acquire(measure_duration, AcquireChannel(qubit), MemorySlot(qubit))
+        expected += Acquire(measure_duration, AcquireChannel(0), MemorySlot(2))
         self.assertEqual(sched.instructions, expected.instructions)
 
     def test_measure_v2_sched_with_meas_map(self):
@@ -138,8 +125,7 @@ class TestMeasure(QiskitTestCase):
             ]
         )
         measure_duration = expected.filter(instruction_types=[Play]).duration
-        for qubit in range(self.backend_v2.num_qubits):
-            expected += Acquire(measure_duration, AcquireChannel(qubit), MemorySlot(qubit))
+        expected += Acquire(measure_duration, AcquireChannel(0), MemorySlot(0))
         self.assertEqual(sched_with_meas_map_list.instructions, expected.instructions)
         self.assertEqual(sched_with_meas_map_dict.instructions, expected.instructions)
 
@@ -159,9 +145,57 @@ class TestMeasure(QiskitTestCase):
         measure_duration = expected.filter(instruction_types=[Play]).duration
         expected += Acquire(measure_duration, AcquireChannel(0), MemorySlot(0))
         expected += Acquire(measure_duration, AcquireChannel(1), MemorySlot(1))
-        for qubit in range(2, self.backend_v2.num_qubits):
-            expected += Acquire(measure_duration, AcquireChannel(qubit), MemorySlot(qubit))
         self.assertEqual(sched.instructions, expected.instructions)
+
+    def test_output_with_measure_v1_and_measure_v2(self):
+        """Test make outputs of measure_v1 and measure_v2 consistent."""
+        sched_measure_v1 = macros.measure(qubits=[0, 1], backend=FakeHanoi())
+        sched_measure_v2 = macros.measure(qubits=[0, 1], backend=self.backend_v2)
+        self.assertEqual(sched_measure_v1.instructions, sched_measure_v2.instructions)
+
+    def test_output_with_measure_v1_and_measure_v2_sched_with_qubit_mem_slots(self):
+        """Test make outputs of measure_v1 and measure_v2 with custom qubit_mem_slots consistent."""
+        sched_measure_v1 = macros.measure(qubits=[0], backend=FakeHanoi(), qubit_mem_slots={0: 2})
+        sched_measure_v2 = macros.measure(
+            qubits=[0], backend=self.backend_v2, qubit_mem_slots={0: 2}
+        )
+        self.assertEqual(sched_measure_v1.instructions, sched_measure_v2.instructions)
+
+    def test_output_with_measure_v1_and_measure_v2_sched_with_meas_map(self):
+        """Test make outputs of measure_v1 and measure_v2
+        with custom meas_map as list and dict consistent."""
+        num_qubits_list_measure_v1 = list(range(FakeHanoi().configuration().num_qubits))
+        num_qubits_list_measure_v2 = list(range(self.backend_v2.num_qubits))
+        sched_with_meas_map_list_v1 = macros.measure(
+            qubits=[0], backend=FakeHanoi(), meas_map=[num_qubits_list_measure_v1]
+        )
+        sched_with_meas_map_dict_v1 = macros.measure(
+            qubits=[0],
+            backend=FakeHanoi(),
+            meas_map={0: num_qubits_list_measure_v1, 1: num_qubits_list_measure_v1},
+        )
+        sched_with_meas_map_list_v2 = macros.measure(
+            qubits=[0], backend=self.backend_v2, meas_map=[num_qubits_list_measure_v2]
+        )
+        sched_with_meas_map_dict_v2 = macros.measure(
+            qubits=[0],
+            backend=self.backend_v2,
+            meas_map={0: num_qubits_list_measure_v2, 1: num_qubits_list_measure_v2},
+        )
+        self.assertEqual(
+            sched_with_meas_map_list_v1.instructions,
+            sched_with_meas_map_list_v2.instructions,
+        )
+        self.assertEqual(
+            sched_with_meas_map_dict_v1.instructions,
+            sched_with_meas_map_dict_v2.instructions,
+        )
+
+    def test_output_with_multiple_measure_v1_and_measure_v2(self):
+        """Test macro - consistent output of multiple qubit measure with backendV1 and backendV2."""
+        sched_measure_v1 = macros.measure(qubits=[0, 1], backend=FakeHanoi())
+        sched_measure_v2 = macros.measure(qubits=[0, 1], backend=self.backend_v2)
+        self.assertEqual(sched_measure_v1.instructions, sched_measure_v2.instructions)
 
 
 class TestMeasureAll(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
In the process of working on https://github.com/Qiskit/qiskit-terra/pull/9501, the output of measure_v1 and measure_v2 don't match.
This is the PR for this fix.


### Details and comments
- modify some codes about _measure_v2
- add some test codes that confirms the consistency of outputs between measure_v1 and measure_v2

