### PR TITLE
Replace `assert` in tests with unittest methods

### DIFF
--- a/test/python/algorithms/optimizers/test_umda.py
+++ b/test/python/algorithms/optimizers/test_umda.py
@@ -15,8 +15,10 @@
 from test.python.algorithms import QiskitAlgorithmsTestCase
 
 import numpy as np
+from scipy.optimize import rosen
 
 from qiskit.algorithms.optimizers.umda import UMDA
+from qiskit.utils import algorithm_globals
 
 
 class TestUMDA(QiskitAlgorithmsTestCase):
@@ -30,10 +32,10 @@ class TestUMDA(QiskitAlgorithmsTestCase):
         umda.alpha = 0.6
         umda.maxiter = 100
 
-        assert umda.disp is True
-        assert umda.size_gen == 30
-        assert umda.alpha == 0.6
-        assert umda.maxiter == 100
+        self.assertTrue(umda.disp)
+        self.assertEqual(umda.size_gen, 30)
+        self.assertAlmostEqual(umda.alpha, 0.6)
+        self.assertEqual(umda.maxiter, 100)
 
     def test_settings(self):
         """Test if the settings display works well"""
@@ -50,13 +52,10 @@ class TestUMDA(QiskitAlgorithmsTestCase):
             "callback": None,
         }
 
-        assert umda.settings == set_
+        self.assertEqual(umda.settings, set_)
 
     def test_minimize(self):
         """optimize function test"""
-        from scipy.optimize import rosen
-        from qiskit.utils import algorithm_globals
-
         # UMDA is volatile so we need to set the seeds for the execution
         algorithm_globals.random_seed = 52
 
@@ -64,9 +63,8 @@ class TestUMDA(QiskitAlgorithmsTestCase):
         x_0 = [1.3, 0.7, 1.5]
         res = optimizer.minimize(rosen, x_0)
 
-        assert res.fun is not None
-        assert len(res.x) == len(x_0)
-
+        self.assertIsNotNone(res.fun)
+        self.assertEqual(len(res.x), len(x_0))
         np.testing.assert_array_almost_equal(res.x, [1.0] * len(x_0), decimal=2)
 
     def test_callback(self):

--- a/test/python/algorithms/optimizers/test_umda.py
+++ b/test/python/algorithms/optimizers/test_umda.py
@@ -34,7 +34,7 @@ class TestUMDA(QiskitAlgorithmsTestCase):
 
         self.assertTrue(umda.disp)
         self.assertEqual(umda.size_gen, 30)
-        self.assertAlmostEqual(umda.alpha, 0.6)
+        self.assertEqual(umda.alpha, 0.6)
         self.assertEqual(umda.maxiter, 100)
 
     def test_settings(self):

--- a/test/python/circuit/library/test_nlocal.py
+++ b/test/python/circuit/library/test_nlocal.py
@@ -913,7 +913,8 @@ class TestTwoLocal(QiskitTestCase):
         reverse = RealAmplitudes(num_qubits=num_qubits, entanglement="reverse_linear", reps=reps)
         full.assign_parameters(params, inplace=True)
         reverse.assign_parameters(params, inplace=True)
-        assert Operator(full) == Operator(reverse)
+
+        self.assertEqual(Operator(full), Operator(reverse))
 
 
 if __name__ == "__main__":

--- a/test/python/quantum_info/operators/symplectic/test_pauli_list.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli_list.py
@@ -2106,8 +2106,8 @@ class TestPauliListMethods(QiskitTestCase):
 
         # checking that every input Pauli in pauli_list is in a group in the ouput
         output_labels = [pauli.to_label() for group in groups for pauli in group]
-        #     assert sorted(output_labels) == sorted(input_labels)
         self.assertListEqual(sorted(output_labels), sorted(input_labels))
+
         # Within each group, every operator qubit-wise commutes with every other operator.
         for group in groups:
             self.assertTrue(

--- a/test/python/result/test_quasi.py
+++ b/test/python/result/test_quasi.py
@@ -191,9 +191,10 @@ class TestQuasi(QiskitTestCase):
         ans = {0: 9 / 20, 1: 7 / 20, 2: 1 / 5}
         # Check probs are correct
         for key, val in closest.items():
-            assert abs(ans[key] - val) < 1e-14
+            self.assertAlmostEqual(ans[key], val, places=14)
+
         # Check if distance calculation is correct
-        assert abs(dist - sqrt(0.38)) < 1e-14
+        self.assertAlmostEqual(dist, sqrt(0.38), places=14)
 
     def test_marginal_distribution(self):
         """Test marginal_distribution with float value."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Mainly a follow-up to #8695, where we noticed some plain `assert` statements used instead of the appropriate `unittest` methods. Also replaces those in some other tests and removes a dangling commented `assert` line.

### Details and comments


