### PR TITLE
Attempt to fix backend primitives unittest failure on slow tests

### DIFF
--- a/test/python/primitives/test_backend_estimator.py
+++ b/test/python/primitives/test_backend_estimator.py
@@ -332,31 +332,25 @@ class TestBackendEstimator(QiskitTestCase):
         qc = QuantumCircuit(2)
         op = SparsePauliOp.from_list([("II", 1)])
 
-        with self.subTest(msg="one circuit"):
+        with self.subTest("Test single circuit"):
 
             dummy_pass = DummyTP()
 
-            with self.subTest("Test single circuit"):
-                with patch.object(DummyTP, "run", wraps=dummy_pass.run) as mock_pass:
-                    bound_pass = PassManager(dummy_pass)
-                    estimator = BackendEstimator(
-                        backend=FakeNairobi(), bound_pass_manager=bound_pass
-                    )
-                    _ = estimator.run(qc, op).result()
-                    self.assertEqual(mock_pass.call_count, 1)
+            with patch.object(DummyTP, "run", wraps=dummy_pass.run) as mock_pass:
+                bound_pass = PassManager(dummy_pass)
+                estimator = BackendEstimator(backend=FakeNairobi(), bound_pass_manager=bound_pass)
+                _ = estimator.run(qc, op).result()
+                self.assertEqual(mock_pass.call_count, 1)
 
-        with self.subTest(msg="multiple circuits"):
+        with self.subTest("Test circuit batch"):
 
             dummy_pass = DummyTP()
 
-            with self.subTest("Test circuit batch"):
-                with patch.object(DummyTP, "run", wraps=dummy_pass.run) as mock_pass:
-                    bound_pass = PassManager(dummy_pass)
-                    estimator = BackendEstimator(
-                        backend=FakeNairobi(), bound_pass_manager=bound_pass
-                    )
-                    _ = estimator.run([qc, qc], [op, op]).result()
-                    self.assertEqual(mock_pass.call_count, 2)
+            with patch.object(DummyTP, "run", wraps=dummy_pass.run) as mock_pass:
+                bound_pass = PassManager(dummy_pass)
+                estimator = BackendEstimator(backend=FakeNairobi(), bound_pass_manager=bound_pass)
+                _ = estimator.run([qc, qc], [op, op]).result()
+                self.assertEqual(mock_pass.call_count, 2)
 
     @combine(backend=BACKENDS)
     def test_layout(self, backend):

--- a/test/python/primitives/test_backend_estimator.py
+++ b/test/python/primitives/test_backend_estimator.py
@@ -329,24 +329,34 @@ class TestBackendEstimator(QiskitTestCase):
     def test_bound_pass_manager(self):
         """Test bound pass manager."""
 
-        dummy_pass = DummyTP()
-
         qc = QuantumCircuit(2)
         op = SparsePauliOp.from_list([("II", 1)])
 
-        with self.subTest("Test single circuit"):
-            with patch.object(DummyTP, "run", wraps=dummy_pass.run) as mock_pass:
-                bound_pass = PassManager(dummy_pass)
-                estimator = BackendEstimator(backend=FakeNairobi(), bound_pass_manager=bound_pass)
-                _ = estimator.run(qc, op).result()
-                self.assertEqual(mock_pass.call_count, 1)
+        with self.subTest(msg="one circuit"):
 
-        with self.subTest("Test circuit batch"):
-            with patch.object(DummyTP, "run", wraps=dummy_pass.run) as mock_pass:
-                bound_pass = PassManager(dummy_pass)
-                estimator = BackendEstimator(backend=FakeNairobi(), bound_pass_manager=bound_pass)
-                _ = estimator.run([qc, qc], [op, op]).result()
-                self.assertEqual(mock_pass.call_count, 2)
+            dummy_pass = DummyTP()
+
+            with self.subTest("Test single circuit"):
+                with patch.object(DummyTP, "run", wraps=dummy_pass.run) as mock_pass:
+                    bound_pass = PassManager(dummy_pass)
+                    estimator = BackendEstimator(
+                        backend=FakeNairobi(), bound_pass_manager=bound_pass
+                    )
+                    _ = estimator.run(qc, op).result()
+                    self.assertEqual(mock_pass.call_count, 1)
+
+        with self.subTest(msg="multiple circuits"):
+
+            dummy_pass = DummyTP()
+
+            with self.subTest("Test circuit batch"):
+                with patch.object(DummyTP, "run", wraps=dummy_pass.run) as mock_pass:
+                    bound_pass = PassManager(dummy_pass)
+                    estimator = BackendEstimator(
+                        backend=FakeNairobi(), bound_pass_manager=bound_pass
+                    )
+                    _ = estimator.run([qc, qc], [op, op]).result()
+                    self.assertEqual(mock_pass.call_count, 2)
 
     @combine(backend=BACKENDS)
     def test_layout(self, backend):

--- a/test/python/primitives/test_backend_sampler.py
+++ b/test/python/primitives/test_backend_sampler.py
@@ -386,7 +386,7 @@ class TestBackendSampler(QiskitTestCase):
     def test_bound_pass_manager(self):
         """Test bound pass manager."""
 
-        with self.subTest(msg="one circuit"):
+        with self.subTest("Test single circuit"):
 
             dummy_pass = DummyTP()
 
@@ -396,7 +396,7 @@ class TestBackendSampler(QiskitTestCase):
                 _ = sampler.run(self._circuit[0]).result()
                 self.assertEqual(mock_pass.call_count, 1)
 
-        with self.subTest(msg="multiple circuits"):
+        with self.subTest("Test circuit batch"):
 
             dummy_pass = DummyTP()
 

--- a/test/python/primitives/test_backend_sampler.py
+++ b/test/python/primitives/test_backend_sampler.py
@@ -386,19 +386,25 @@ class TestBackendSampler(QiskitTestCase):
     def test_bound_pass_manager(self):
         """Test bound pass manager."""
 
-        dummy_pass = DummyTP()
+        with self.subTest(msg="one circuit"):
 
-        with patch.object(DummyTP, "run", wraps=dummy_pass.run) as mock_pass:
-            bound_pass = PassManager(dummy_pass)
-            sampler = BackendSampler(backend=FakeNairobi(), bound_pass_manager=bound_pass)
-            _ = sampler.run(self._circuit[0]).result()
-            self.assertEqual(mock_pass.call_count, 1)
+            dummy_pass = DummyTP()
 
-        with patch.object(DummyTP, "run", wraps=dummy_pass.run) as mock_pass:
-            bound_pass = PassManager(dummy_pass)
-            sampler = BackendSampler(backend=FakeNairobi(), bound_pass_manager=bound_pass)
-            _ = sampler.run([self._circuit[0], self._circuit[0]]).result()
-            self.assertEqual(mock_pass.call_count, 2)
+            with patch.object(DummyTP, "run", wraps=dummy_pass.run) as mock_pass:
+                bound_pass = PassManager(dummy_pass)
+                sampler = BackendSampler(backend=FakeNairobi(), bound_pass_manager=bound_pass)
+                _ = sampler.run(self._circuit[0]).result()
+                self.assertEqual(mock_pass.call_count, 1)
+
+        with self.subTest(msg="multiple circuits"):
+
+            dummy_pass = DummyTP()
+
+            with patch.object(DummyTP, "run", wraps=dummy_pass.run) as mock_pass:
+                bound_pass = PassManager(dummy_pass)
+                sampler = BackendSampler(backend=FakeNairobi(), bound_pass_manager=bound_pass)
+                _ = sampler.run([self._circuit[0], self._circuit[0]]).result()
+                self.assertEqual(mock_pass.call_count, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The slow nightly tests have been failing for a while on a specific unit test for the backend primitives (https://github.com/Qiskit/qiskit-terra/issues/7864#issuecomment-1556493785) that seems to be pretty hard to reproduce locally/on CI (at least, I haven't been able to). 

I don't know exactly why these tests are failing, but I find it suspicious that there are two consecutive assertions that reuse the same instance of `DummyTP()` and they always fail on the second one. I know that the order of tests shouldn't matter, but I don't know, there might be some interference related to reusing instances with `mock`. 

After spending some time trying to reproduce the failure unsuccessfully, I figured that it might make sense to push a potential fix and see if it works. I have separated the test into sub-tests (which I think would be a good practice anyways), and made sure I do not reuse the dummy pass. Hopefully that will help and stop the spamming from the nightly failure log issue. 

### Details and comments


