### PR TITLE
Fix `initial_layout` in `transpile` with loose qubits

### DIFF
--- a/releasenotes/notes/fix-initial_layout-loose-qubits-0c59b2d6fb99d7e6.yaml
+++ b/releasenotes/notes/fix-initial_layout-loose-qubits-0c59b2d6fb99d7e6.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Using ``initial_layout`` in calls to :func:`.transpile` will no longer error if the
+    circuit contains qubits not in any registers, or qubits that exist in more than one
+    register.  See `#10125 <https://github.com/Qiskit/qiskit-terra/issues/10125>`__.


### PR DESCRIPTION
### Summary

The previous logic around building a `Layout` object from an `initial_layout` was still couched in the "registers own bits" model, so could not cope with loose bits.  It's most convenient to just build the mapping ourselves during the parsing, since the logic is quite specific to the form of the `initial_layout` argument, rather than being something that's inherently tied to the `Layout` class.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments


Fix #10125.
