### PR TITLE
Fix output of `DensityMatrix.partial_transpose` to match input dimensions

### DIFF
--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -832,4 +832,4 @@ class DensityMatrix(QuantumState, TolerancesMixin):
             lst[i], lst[i + n] = lst[i + n], lst[i]
         rho = np.transpose(arr, lst)
         rho = np.reshape(rho, self._op_shape.shape)
-        return DensityMatrix(rho)
+        return DensityMatrix(rho, dims=self.dims())

--- a/releasenotes/notes/fix-partial-transpose-output-dims-3082fcf4147055dc.yaml
+++ b/releasenotes/notes/fix-partial-transpose-output-dims-3082fcf4147055dc.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed the dimensions of the output density matrix from DensityMatrix.partial_transpose
+    so they match the dimensions of the corresponding input density matrix.

--- a/releasenotes/notes/fix-partial-transpose-output-dims-3082fcf4147055dc.yaml
+++ b/releasenotes/notes/fix-partial-transpose-output-dims-3082fcf4147055dc.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Fixed the dimensions of the output density matrix from DensityMatrix.partial_transpose
+    Fixed the dimensions of the output density matrix from :meth:`.DensityMatrix.partial_transpose`
     so they match the dimensions of the corresponding input density matrix.

--- a/test/python/quantum_info/states/test_densitymatrix.py
+++ b/test/python/quantum_info/states/test_densitymatrix.py
@@ -1219,6 +1219,15 @@ class TestDensityMatrix(QiskitTestCase):
             self.assertEqual(rho.partial_transpose([0]), DensityMatrix(rho1))
             self.assertEqual(rho.partial_transpose([1]), DensityMatrix(rho1))
 
+        with self.subTest(msg="dims(3,3)"):
+            mat = np.zeros((9,9))
+            mat1 = np.zeros((9,9))
+            mat[8,0] = 1
+            mat1[0,8] = 1
+            rho = DensityMatrix(mat, dims=(3, 3))
+            rho1 = DensityMatrix(mat1, dims=(3, 3))
+            self.assertEqual(rho.partial_transpose([0,1]), rho1)
+
     def test_clip_probabilities(self):
         """Test probabilities are clipped to [0, 1]."""
         dm = DensityMatrix([[1.1, 0], [0, 0]])

--- a/test/python/quantum_info/states/test_densitymatrix.py
+++ b/test/python/quantum_info/states/test_densitymatrix.py
@@ -1220,13 +1220,13 @@ class TestDensityMatrix(QiskitTestCase):
             self.assertEqual(rho.partial_transpose([1]), DensityMatrix(rho1))
 
         with self.subTest(msg="dims(3,3)"):
-            mat = np.zeros((9,9))
-            mat1 = np.zeros((9,9))
-            mat[8,0] = 1
-            mat1[0,8] = 1
+            mat = np.zeros((9, 9))
+            mat1 = np.zeros((9, 9))
+            mat[8, 0] = 1
+            mat1[0, 8] = 1
             rho = DensityMatrix(mat, dims=(3, 3))
             rho1 = DensityMatrix(mat1, dims=(3, 3))
-            self.assertEqual(rho.partial_transpose([0,1]), rho1)
+            self.assertEqual(rho.partial_transpose([0, 1]), rho1)
 
     def test_clip_probabilities(self):
         """Test probabilities are clipped to [0, 1]."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Add dimensions to the `DensityMatrix` returned by `partial_transpose` so its dimensions match those of the input density matrix.


### Details and comments
Fix #10155 

