### PR TITLE
Fix top-level `switch` statements in `QuantumCircuit.compose`

### DIFF
--- a/releasenotes/notes/fix-compose-switch-19ada3828d939353.yaml
+++ b/releasenotes/notes/fix-compose-switch-19ada3828d939353.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a bug in :meth:`.QuantumCircuit.compose` where the :attr:`.SwitchCaseOp.target` attribute
+    in the subcircuit would not get mapped to a register in the base circuit correctly.


### PR DESCRIPTION
### Summary

The register-mapping code was not being applied to `SwitchCaseOp.target` in the same way that it is for conditions.  This commit does not change any behaviour about recursing into _nested_ control-flow blocks, which still likely have problems with composition.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Fix #10108, at least as far as the top-level issue that's being reported there.  See that issue for a further discussion of other problems that stem from the root of that issue.
