### PR TITLE
Fix PassManagerConfig.from_backend with BackendV1 and no CouplingMap

### DIFF
--- a/qiskit/transpiler/passmanager_config.py
+++ b/qiskit/transpiler/passmanager_config.py
@@ -144,7 +144,9 @@ class PassManagerConfig:
                 res.inst_map = backend.instruction_schedule_map
         if res.coupling_map is None:
             if backend_version < 2:
-                res.coupling_map = CouplingMap(getattr(config, "coupling_map", None))
+                cmap_edge_list = getattr(config, "coupling_map", None)
+                if cmap_edge_list is not None:
+                    res.coupling_map = CouplingMap(cmap_edge_list)
             else:
                 res.coupling_map = backend.coupling_map
         if res.instruction_durations is None:

--- a/releasenotes/notes/fix-pm-config-from-backend-f3b71b11858b4f08.yaml
+++ b/releasenotes/notes/fix-pm-config-from-backend-f3b71b11858b4f08.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed an issue with the :meth:`.PassManagerConfig.from_backend` constructor
+    when building a :class:`~.PassManagerConfig` object from a :class:`~.BackendV1`
+    instance that didn't have a coupling map attribute defined. Previously, the
+    constructor would incorrectly create a :class:`~.CouplingMap` object with
+    0 qubits instead of using ``None``.
+    Fixed `#10171 <https://github.com/Qiskit/qiskit-terra/issues/10171>`__

--- a/test/python/transpiler/test_passmanager_config.py
+++ b/test/python/transpiler/test_passmanager_config.py
@@ -79,7 +79,6 @@ class TestPassManagerConfig(QiskitTestCase):
         config = PassManagerConfig.from_backend(backend)
         self.assertIsInstance(config, PassManagerConfig)
         self.assertIsNone(config.inst_map)
-        self.assertIsNone(config.coupling_map)
 
     def test_simulator_backend_v1(self):
         """Test that from_backend() works with backendv1 simulator."""
@@ -87,6 +86,7 @@ class TestPassManagerConfig(QiskitTestCase):
         config = PassManagerConfig.from_backend(backend)
         self.assertIsInstance(config, PassManagerConfig)
         self.assertIsNone(config.inst_map)
+        self.assertIsNone(config.coupling_map)
 
     def test_invalid_user_option(self):
         """Test from_backend() with an invalid user option."""
@@ -104,7 +104,7 @@ class TestPassManagerConfig(QiskitTestCase):
 	initial_layout: None
 	basis_gates: ['id', 'rz', 'sx', 'x']
 	inst_map: None
-	coupling_map: 
+	coupling_map: None
 	layout_method: None
 	routing_method: None
 	translation_method: None

--- a/test/python/transpiler/test_passmanager_config.py
+++ b/test/python/transpiler/test_passmanager_config.py
@@ -79,6 +79,7 @@ class TestPassManagerConfig(QiskitTestCase):
         config = PassManagerConfig.from_backend(backend)
         self.assertIsInstance(config, PassManagerConfig)
         self.assertIsNone(config.inst_map)
+        self.assertIsNone(config.coupling_map)
 
     def test_simulator_backend_v1(self):
         """Test that from_backend() works with backendv1 simulator."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue in the PassManagerConfig.from_backend constructor method when using BackendV1 based simulator backends. The pass was incorrectly handling the case when the backend configuration didn't have a coupling map defined and incorrectly creating a coupling map with 0 qubits instead of using None to indicate the lack of connectivity. This has been fixed so the coupling map creation is skipped if there is no coupling map attribute in the backend's configuration.

### Details and comments

Fixes #10171