### PR TITLE
Update the typo in __init__.py

### DIFF
--- a/qiskit/circuit/__init__.py
+++ b/qiskit/circuit/__init__.py
@@ -26,7 +26,7 @@ operations on quantum data, such as qubits. It is an ordered sequence of quantum
 gates, measurements and resets, which may be conditioned on real-time classical
 computation. A set of quantum gates is said to be universal if any unitary
 transformation of the quantum data can be efficiently approximated arbitrarily well
-as as sequence of gates in the set. Any quantum program can be represented by a
+as a sequence of gates in the set. Any quantum program can be represented by a
 sequence of quantum circuits and classical near-time computation.
 
 In Qiskit, this core element is represented by the :class:`QuantumCircuit` class.


### PR DESCRIPTION
I cleared a small typo in this file  
as as to as a



![bf223bc1-f25c-4375-8e20-456724bb9115](https://github.com/Qiskit/qiskit-terra/assets/73220998/5ee85e0b-0b09-46f8-a673-9c67c73a1296)





