### PR TITLE
Assign values directly to fully bound parameters in quantum circuits

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2857,7 +2857,8 @@ class QuantumCircuit:
                         if new_param._symbol_expr.is_integer and new_param.is_real():
                             val = int(new_param)
                         elif new_param.is_real():
-                            val = float(new_param)
+                            # Workaround symengine not supporting float(<ComplexDouble>)
+                            val = complex(new_param).real
                         else:
                             val = complex(new_param)
                         instr.params[param_index] = instr.validate_parameter(val)
@@ -2920,7 +2921,8 @@ class QuantumCircuit:
                                 if new_param._symbol_expr.is_integer:
                                     new_param = int(new_param)
                                 else:
-                                    new_param = float(new_param)
+                                    # Workaround symengine not supporting float(<ComplexDouble>)
+                                    new_param = complex(new_param).real
                             new_cal_params.append(new_param)
                         else:
                             new_cal_params.append(p)

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2856,11 +2856,9 @@ class QuantumCircuit:
                     if len(new_param.parameters) == 0:
                         if new_param._symbol_expr.is_integer and new_param.is_real():
                             val = int(new_param)
-                        elif new_param.is_real():
+                        else:
                             # Workaround symengine not supporting float(<ComplexDouble>)
                             val = complex(new_param).real
-                        else:
-                            val = complex(new_param)
                         instr.params[param_index] = instr.validate_parameter(val)
                     else:
                         instr.params[param_index] = new_param

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2854,7 +2854,13 @@ class QuantumCircuit:
                     new_param = assignee.assign(parameter, value)
                     # if fully bound, validate
                     if len(new_param.parameters) == 0:
-                        instr.params[param_index] = instr.validate_parameter(new_param)
+                        if new_param._symbol_expr.is_integer and new_param.is_real():
+                            val = int(new_param)
+                        elif new_param.is_real():
+                            val = float(new_param)
+                        else:
+                            val = complex(new_param)
+                        instr.params[param_index] = instr.validate_parameter(val)
                     else:
                         instr.params[param_index] = new_param
 
@@ -2911,7 +2917,10 @@ class QuantumCircuit:
                         if isinstance(p, ParameterExpression) and parameter in p.parameters:
                             new_param = p.assign(parameter, value)
                             if not new_param.parameters:
-                                new_param = float(new_param)
+                                if new_param._symbol_expr.is_integer:
+                                    new_param = int(new_param)
+                                else:
+                                    new_param = float(new_param)
                             new_cal_params.append(new_param)
                         else:
                             new_cal_params.append(p)

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2856,9 +2856,14 @@ class QuantumCircuit:
                     if len(new_param.parameters) == 0:
                         if new_param._symbol_expr.is_integer and new_param.is_real():
                             val = int(new_param)
-                        else:
+                        elif new_param.is_real():
                             # Workaround symengine not supporting float(<ComplexDouble>)
                             val = complex(new_param).real
+                        else:
+                            # complex values may no longer be supported but we
+                            # defer raising an exception to validdate_parameter
+                            # below for now.
+                            val = complex(new_param)
                         instr.params[param_index] = instr.validate_parameter(val)
                     else:
                         instr.params[param_index] = new_param

--- a/releasenotes/notes/circuit-assign-parameter-to-concrete-value-7cad75c97183257f.yaml
+++ b/releasenotes/notes/circuit-assign-parameter-to-concrete-value-7cad75c97183257f.yaml
@@ -1,13 +1,29 @@
 ---
 fixes:
   - |
+    Changed the binding of numeric values with
+    :meth:`.QuantumCircuit.assign_parameters` to avoid a mismatch between the
+    values of circuit instruction parameters and corresponding parameter keys
+    in the circuit's calibration dictionary. Fixed `#9764
+    <https://github.com/Qiskit/qiskit-terra/issues/9764>`_ and `#10166
+    <https://github.com/Qiskit/qiskit-terra/issues/10166>`_. See also the
+    related upgrade note regarding :meth:`.QuantumCircuit.assign_parameters`.
+upgrade:
+  - |
     Changed :meth:`.QuantumCircuit.assign_parameters` to bind
     assigned integer and float values directly into the parameters of
     :class:`~qiskit.circuit.Instruction` instances in the circuit rather than
-    binding those values wrapped within a :class:`~qiskit.circuit.Parameter`.
-    Binding the value directly avoids mismatches between the values of circuit
-    instruction parameters and corresponding parameter keys in the circuit's
-    calibration dictionary which were already being cast from
-    :class:`~qiskit.circuit.Parameter` to ``float``. Fixes `#9764
-    <https://github.com/Qiskit/qiskit-terra/issues/9764>`_ and `#10166
-    <https://github.com/Qiskit/qiskit-terra/issues/10166>`_
+    binding the values wrapped within a
+    :class:`~qiskit.circuit.ParameterExpression`. This change should have
+    little user impact as ``float(QuantumCircuit.data[i].operation.params[j])``
+    still produces a ``float`` (and is the only way to access the value of a
+    :class:`~qiskit.circuit.ParameterExpression`). Also,
+    :meth:`~qiskit.circuit.Instruction` parameters could already be ``float``
+    as well as a :class:`~qiskit.circuit.ParameterExpression`, so code dealing
+    with instruction parameters should already handle both cases. The most
+    likely chance for user impact is in code that uses ``isinstance`` to check
+    for :class:`~qiskit.circuit.ParameterExpression` and behaves differently
+    depending on the result. Additionally, qpy serializes the numeric value in
+    a bound :class:`~qiskit.circuit.ParameterExpression` at a different
+    precision than a ``float`` (see also the related bug fix note about
+    :meth:`.QuantumCircuit.assign_parameters`).

--- a/releasenotes/notes/circuit-assign-parameter-to-concrete-value-7cad75c97183257f.yaml
+++ b/releasenotes/notes/circuit-assign-parameter-to-concrete-value-7cad75c97183257f.yaml
@@ -1,0 +1,13 @@
+---
+fixes:
+  - |
+    Changed :meth:`~qiskit.circuit.QuantumCircuit.assign_parameters` to bind
+    assigned integer and float values directly into the parameters of
+    :class:`~qiskit.circuit.Instruction` instances in the circuit rather than
+    binding those values wrapped within a :class:`~qiskit.circuit.Parameter`.
+    Binding the value directly avoids mismatches between the values of circuit
+    instruction parameters and corresponding paramter keys in the circuit's
+    calibration dictionary which were already being cast from
+    :class:`~qiskit.circuit.Parameter` to ``float``. Fixes `#9764
+    <https://github.com/Qiskit/qiskit-terra/issues/9764>`_ and `#10166
+    <https://github.com/Qiskit/qiskit-terra/issues/10166>`_

--- a/releasenotes/notes/circuit-assign-parameter-to-concrete-value-7cad75c97183257f.yaml
+++ b/releasenotes/notes/circuit-assign-parameter-to-concrete-value-7cad75c97183257f.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    Changed :meth:`~qiskit.circuit.QuantumCircuit.assign_parameters` to bind
+    Changed :meth:`.QuantumCircuit.assign_parameters` to bind
     assigned integer and float values directly into the parameters of
     :class:`~qiskit.circuit.Instruction` instances in the circuit rather than
     binding those values wrapped within a :class:`~qiskit.circuit.Parameter`.

--- a/releasenotes/notes/circuit-assign-parameter-to-concrete-value-7cad75c97183257f.yaml
+++ b/releasenotes/notes/circuit-assign-parameter-to-concrete-value-7cad75c97183257f.yaml
@@ -6,7 +6,7 @@ fixes:
     :class:`~qiskit.circuit.Instruction` instances in the circuit rather than
     binding those values wrapped within a :class:`~qiskit.circuit.Parameter`.
     Binding the value directly avoids mismatches between the values of circuit
-    instruction parameters and corresponding paramter keys in the circuit's
+    instruction parameters and corresponding parameter keys in the circuit's
     calibration dictionary which were already being cast from
     :class:`~qiskit.circuit.Parameter` to ``float``. Fixes `#9764
     <https://github.com/Qiskit/qiskit-terra/issues/9764>`_ and `#10166

--- a/test/python/circuit/test_circuit_load_from_qpy.py
+++ b/test/python/circuit/test_circuit_load_from_qpy.py
@@ -291,7 +291,7 @@ class TestLoadFromQPY(QiskitTestCase):
         qc = QuantumCircuit(1)
         qc.append(gate, (0,))
         qc.add_calibration(gate, (0,), sched)
-        qc.assign_parameters({amp: 1/3}, inplace=True)
+        qc.assign_parameters({amp: 1 / 3}, inplace=True)
 
         qpy_file = io.BytesIO()
         dump(qc, qpy_file)

--- a/test/python/circuit/test_circuit_load_from_qpy.py
+++ b/test/python/circuit/test_circuit_load_from_qpy.py
@@ -305,7 +305,7 @@ class TestLoadFromQPY(QiskitTestCase):
         )
         # Make sure that looking for a calibration based on the instruction's
         # parameters succeeds
-        self.assertTrue(cal_key in new_circ.calibrations[gate.name])
+        self.assertIn(cal_key, new_circ.calibrations[gate.name])
 
     def test_parameter_expression(self):
         """Test a circuit with a parameter expression."""

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -799,8 +799,7 @@ class TestParameters(QiskitTestCase):
         self.assertEqual(len(qobj.experiments[0].instructions), 4)
         self.assertTrue(
             all(
-                len(inst.params) == 1
-                and float(inst.params[0]) == 1
+                len(inst.params) == 1 and float(inst.params[0]) == 1
                 for inst in qobj.experiments[0].instructions
             )
         )

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -404,7 +404,6 @@ class TestParameters(QiskitTestCase):
                 fbqc = getattr(pqc, assign_fun)({phi: 1})
 
                 self.assertEqual(fbqc.parameters, set())
-                self.assertTrue(isinstance(fbqc.data[0].operation.params[0], ParameterExpression))
                 self.assertEqual(float(fbqc.data[0].operation.params[0]), 3)
 
     def test_two_parameter_expression_binding(self):
@@ -448,7 +447,6 @@ class TestParameters(QiskitTestCase):
                 fbqc = getattr(pqc, assign_fun)({phi: 1})
 
                 self.assertEqual(fbqc.parameters, set())
-                self.assertTrue(isinstance(fbqc.data[0].operation.params[0], ParameterExpression))
                 self.assertEqual(float(fbqc.data[0].operation.params[0]), 0)
 
     def test_raise_if_assigning_params_not_in_circuit(self):
@@ -802,7 +800,6 @@ class TestParameters(QiskitTestCase):
         self.assertTrue(
             all(
                 len(inst.params) == 1
-                and isinstance(inst.params[0], ParameterExpression)
                 and float(inst.params[0]) == 1
                 for inst in qobj.experiments[0].instructions
             )

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -421,7 +421,7 @@ class TestParameters(QiskitTestCase):
                 fbqc = getattr(pqc, assign_fun)({phi: 1.0})
 
                 self.assertEqual(fbqc.parameters, set())
-                self.assertTrue(isinstance(fbqc.data[0].operation.params[0], float))
+                self.assertIsInstance(fbqc.data[0].operation.params[0], float)
                 self.assertEqual(float(fbqc.data[0].operation.params[0]), 3)
 
     def test_two_parameter_expression_binding(self):
@@ -465,7 +465,7 @@ class TestParameters(QiskitTestCase):
                 fbqc = getattr(pqc, assign_fun)({phi: 1})
 
                 self.assertEqual(fbqc.parameters, set())
-                self.assertTrue(isinstance(fbqc.data[0].operation.params[0], int))
+                self.assertIsInstance(fbqc.data[0].operation.params[0], int)
                 self.assertEqual(float(fbqc.data[0].operation.params[0]), 0)
 
     def test_raise_if_assigning_params_not_in_circuit(self):
@@ -529,7 +529,7 @@ class TestParameters(QiskitTestCase):
         )
         self.assertEqual(cal_key, ((0,), (3.14,)))
         # Make sure that key from instruction data matches the calibrations dictionary
-        self.assertTrue(cal_key in circ.calibrations["rxt"])
+        self.assertIn(cal_key, circ.calibrations["rxt"])
         sched = circ.calibrations["rxt"][cal_key]
         self.assertEqual(sched.instructions[0][1].pulse.amp, 0.2)
 
@@ -579,7 +579,7 @@ class TestParameters(QiskitTestCase):
         )
         self.assertEqual(cal_key, ((0,), (3.14 / 2, 4)))
         # Make sure that key from instruction data matches the calibrations dictionary
-        self.assertTrue(cal_key in circ.calibrations["rxt"])
+        self.assertIn(cal_key, circ.calibrations["rxt"])
         sched = circ.calibrations["rxt"][cal_key]
         self.assertEqual(sched.instructions[0][1].pulse.amp, 0.2)
         self.assertEqual(sched.instructions[0][1].pulse.sigma, 16)

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -352,7 +352,6 @@ class TestParameters(QiskitTestCase):
         ["float16", numpy.float16(2.1), float],
         ["float32", numpy.float32(2.1), float],
         ["float64", numpy.float64(2.1), float],
-        ["complex", 1 + 2j, complex],
     )
     def test_circuit_assignment_to_numeric(self, value, type_):
         """Test binding a numeric value to a circuit instruction"""

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -21,7 +21,7 @@ from operator import add, mul, sub, truediv
 from test import combine
 
 import numpy
-from ddt import data, ddt
+from ddt import data, ddt, named_data
 
 import qiskit
 import qiskit.circuit.library as circlib
@@ -345,6 +345,24 @@ class TestParameters(QiskitTestCase):
         qc.u(0, theta, x, qr)
         self.assertEqual(theta.name, "θ")
         self.assertEqual(qc.parameters, {theta, x})
+
+    @named_data(
+        ["int", 2, int],
+        ["float", 2.1, float],
+        ["float16", numpy.float16(2.1), float],
+        ["float32", numpy.float32(2.1), float],
+        ["float64", numpy.float64(2.1), float],
+        ["complex", 1 + 2j, complex],
+    )
+    def test_circuit_assignment_to_numeric(self, value, type_):
+        """Test binding a numeric value to a circuit instruction"""
+        x = Parameter("x")
+        qc = QuantumCircuit(1)
+        qc.append(Instruction("inst", 1, 0, [x]), (0,))
+        qc.assign_parameters({x: value}, inplace=True)
+        bound = qc.data[0].operation.params[0]
+        self.assertIsInstance(bound, type_)
+        self.assertAlmostEqual(bound, value, delta=1e-4)
 
     def test_partial_binding(self):
         """Test that binding a subset of circuit parameters returns a new parameterized circuit."""

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -348,10 +348,10 @@ class TestParameters(QiskitTestCase):
 
     @named_data(
         ["int", 2, int],
-        ["float", 2.1, float],
-        ["float16", numpy.float16(2.1), float],
-        ["float32", numpy.float32(2.1), float],
-        ["float64", numpy.float64(2.1), float],
+        ["float", 2.5, float],
+        ["float16", numpy.float16(2.5), float],
+        ["float32", numpy.float32(2.5), float],
+        ["float64", numpy.float64(2.5), float],
     )
     def test_circuit_assignment_to_numeric(self, value, type_):
         """Test binding a numeric value to a circuit instruction"""
@@ -361,7 +361,7 @@ class TestParameters(QiskitTestCase):
         qc.assign_parameters({x: value}, inplace=True)
         bound = qc.data[0].operation.params[0]
         self.assertIsInstance(bound, type_)
-        self.assertAlmostEqual(bound, value, delta=1e-4)
+        self.assertEqual(bound, value)
 
     def test_partial_binding(self):
         """Test that binding a subset of circuit parameters returns a new parameterized circuit."""

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -401,9 +401,10 @@ class TestParameters(QiskitTestCase):
                 self.assertTrue(isinstance(pqc.data[0].operation.params[0], ParameterExpression))
                 self.assertEqual(str(pqc.data[0].operation.params[0]), "phi + 2")
 
-                fbqc = getattr(pqc, assign_fun)({phi: 1})
+                fbqc = getattr(pqc, assign_fun)({phi: 1.0})
 
                 self.assertEqual(fbqc.parameters, set())
+                self.assertTrue(isinstance(fbqc.data[0].operation.params[0], float))
                 self.assertEqual(float(fbqc.data[0].operation.params[0]), 3)
 
     def test_two_parameter_expression_binding(self):
@@ -447,6 +448,7 @@ class TestParameters(QiskitTestCase):
                 fbqc = getattr(pqc, assign_fun)({phi: 1})
 
                 self.assertEqual(fbqc.parameters, set())
+                self.assertTrue(isinstance(fbqc.data[0].operation.params[0], int))
                 self.assertEqual(float(fbqc.data[0].operation.params[0]), 0)
 
     def test_raise_if_assigning_params_not_in_circuit(self):
@@ -787,7 +789,7 @@ class TestParameters(QiskitTestCase):
         for qc in results:
             circuit.compose(qc, inplace=True)
 
-        parameter_values = [{x: 1 for x in parameters}]
+        parameter_values = [{x: 1.0 for x in parameters}]
 
         qobj = assemble(
             circuit,
@@ -799,7 +801,9 @@ class TestParameters(QiskitTestCase):
         self.assertEqual(len(qobj.experiments[0].instructions), 4)
         self.assertTrue(
             all(
-                len(inst.params) == 1 and float(inst.params[0]) == 1
+                len(inst.params) == 1
+                and isinstance(inst.params[0], float)
+                and float(inst.params[0]) == 1
                 for inst in qobj.experiments[0].instructions
             )
         )

--- a/test/python/qasm3/test_export.py
+++ b/test/python/qasm3/test_export.py
@@ -469,7 +469,7 @@ class TestCircuitQASM3(QiskitTestCase):
                 "  rx(0.5) _gate_q_0;",
                 "}",
                 f"gate {circuit_name_1} _gate_q_0 {{",
-                "  rx(1) _gate_q_0;",
+                "  rx(1.0) _gate_q_0;",
                 "}",
                 "qubit[1] _all_qubits;",
                 "let q = _all_qubits[0:0];",


### PR DESCRIPTION
### Summary

Changed `QuantumCircuit.assign_parameters` so that assigning a concrete value to a parameter inserts that value directly into the circuit's instructions' parameter rather than inserting a `ParameterExpression` containing only that value.

### Details and comments

When `QuantumCircuit.assign_parameters` is called, parameter substitution occurs in the list of parameters for each instruction, in the definition of each instrution, in the global phase of the circuit, and in the mapping of gates to schedules in the circuit's calibrations dictionary. Before this change, numeric assigned values were inserted into the instructions' parameters lists as `ParameterExpression` instances with no free parameters and into the calibrations dictionary as floats. This discrepancy in handling of parameters in these two cases was a problem because qpy serializes `ParameterExpression` differently from `float`. After a round trip, the numeric content in an instruction's parameters list might no longer match the numeric key in the calibrations dictionary. Code that takes circuits as input and executes them needs the instruction parameters and calibrations keys to match as it needs to look up the calibrations for the circuit's instructions in order to run the circuit.

To address this issue, here `QuantumCircuit.assign_parameters` is changed to insert the numeric value directly into the instruction's parameter list, so that it matches the key in the calibrations dictionary. There is some precedent for this as the `Delay` instruction already does type casting in its `validate_parameter` method which `assign_parameters` calls:

https://github.com/Qiskit/qiskit-terra/blob/291824a392f131e3b7d7ffca4c6fafdecf72c007/qiskit/circuit/delay.py#L88-L102

This change is not without impact, but its impact needs to be weighed against the impact of not addressing the issue, which prevents parameterized pulse gates from being used with circuits serialized with qpy (such as with qiskit-ibm-provider). The updated unit tests give an indication of the impact:

* Three tests in `test_parameters.py` were modified to remove an `isinstance` check for `ParameterExpression`. `int` and `float` are valid in instruction params lists as well as `ParameterExpression` so I think these changes reflect overly tight test conditions and cases like this would be rare in user code.
* A test in `test_export.py` was updated to change a `1` to a `1.0`. This change was the result of the behavior of `pi_check`. `pi_check(1)` gives `"1.0"` while `a = Parameter("a"); pi_check(a.assign(a, 1))` gives `"1"`. Based on this discrepancy, I think likely both float and integer representations need to be allowed in these cases or maybe `pi_check` needs to be more careful about changing types.
* `test_complex_parameter_bound_to_real` was still failing. It tests that a complex `ParameterExpression` that evaluates to a real number gets treated as a real number by code that does not allow an imaginary component. Here is the test code:
https://github.com/Qiskit/qiskit-terra/blob/291824a392f131e3b7d7ffca4c6fafdecf72c007/test/python/circuit/test_parameters.py#L1382-L1390
  Interestingly, even though the equality check passes, the bound parameter can not be accessed directly as a float. This code:
```python
from qiskit import QuantumCircuit
from qiskit.circuit import Parameter


x = Parameter("x")
  
qc = QuantumCircuit(1)
qc.rx(1j * x, 0)
bound = qc.bind_parameters({x: 1j})
bound.data[0].params
```
gives
```
RuntimeError                              Traceback (most recent call last)
File ~/.conda/envs/qiskit/lib/python3.10/site-packages/qiskit/circuit/parameterexpression.py:474, in ParameterExpression.__float__(self)
    473 try:
--> 474     return float(self._symbol_expr)
    475 # TypeError is for sympy, RuntimeError for symengine

File symengine_wrapper.pyx:1151, in symengine.lib.symengine_wrapper.Basic.__float__()

File symengine_wrapper.pyx:976, in symengine.lib.symengine_wrapper.Basic.n()

File symengine_wrapper.pyx:4346, in symengine.lib.symengine_wrapper.evalf()

RuntimeError: Not Implemented
```
To work around this, this change casts to `complex` and then takes the real part after checking that the value is real rather than casting to `float` directly.


Closes #9764 and #10166