### PR TITLE
Bump pyo3 and rust numpy version to 0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,9 +45,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -73,7 +73,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.8.0",
  "scopeguard",
 ]
 
@@ -100,9 +100,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -163,15 +163,15 @@ checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libm"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "lock_api"
@@ -185,10 +185,11 @@ dependencies = [
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.2"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
+checksum = "090126dc04f95dc0d1c1c91f61bdd474b3930ca064c1edc8a849da2c6cbe1e77"
 dependencies = [
+ "autocfg",
  "rawpointer",
 ]
 
@@ -197,6 +198,15 @@ name = "memoffset"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
@@ -267,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b0fee4571867d318651c24f4a570c3f18408cf95f16ccb576b3ce85496a46e"
+checksum = "437213adf41bbccf4aeae535fbfcdad0f6fed241e1ae182ebe97fa1f3ce19389"
 dependencies = [
  "libc",
  "ndarray",
@@ -282,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
 
 [[package]]
 name = "parking_lot"
@@ -337,25 +347,25 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.18.3"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b1ac5b3731ba34fdaa9785f8d74d17448cd18f30cf19e0c7e7b1fdb5272109"
+checksum = "cffef52f74ec3b1a1baf295d9b8fcc3070327aefc39a6d00656b13c1d0b8885c"
 dependencies = [
  "cfg-if",
  "hashbrown 0.13.2",
  "indexmap",
  "indoc",
  "libc",
- "memoffset",
+ "memoffset 0.9.0",
  "num-bigint",
  "num-complex",
  "parking_lot",
@@ -367,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.18.3"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cb946f5ac61bb61a5014924910d936ebd2b23b705f7a4a3c40b05c720b079a3"
+checksum = "713eccf888fb05f1a96eb78c0dbc51907fee42b3377272dc902eb38985f418d5"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -377,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.18.3"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd4d7c5337821916ea2a1d21d1092e8443cf34879e53a0ac653fbb98f44ff65c"
+checksum = "5b2ecbdcfb01cbbf56e179ce969a048fd7305a66d4cdf3303e0da09d69afe4c3"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -387,9 +397,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.18.3"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d39c55dab3fc5a4b25bbd1ac10a2da452c4aca13bb450f22818a002e29648d"
+checksum = "b78fdc0899f2ea781c463679b20cb08af9247febc8d052de941951024cd8aea0"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -399,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.18.3"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97daff08a4c48320587b5224cc98d609e3c27b6d437315bd40b605c98eeb5918"
+checksum = "60da7b84f1227c3e2fe7593505de274dcf4c8928b4e0a1c23d551a14e4e80a0f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -437,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -577,15 +587,15 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.6"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
+checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unindent"
@@ -616,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -631,42 +641,42 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"

--- a/crates/accelerate/Cargo.toml
+++ b/crates/accelerate/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rayon = "1.7"
-numpy = "0.18.0"
+numpy = "0.19.0"
 rand = "0.8"
 rand_pcg = "0.3"
 rand_distr = "0.4.3"
@@ -25,7 +25,7 @@ rustworkx-core = "0.12"
 # The base version of PyO3 and setting a minimum feature set (e.g. probably just 'extension-module')
 # can be done in the workspace and inherited once we hit Rust 1.64.
 [dependencies.pyo3]
-version = "0.18.3"
+version = "0.19.0"
 features = ["extension-module", "hashbrown", "indexmap", "num-complex", "num-bigint"]
 
 [dependencies.ndarray]

--- a/crates/accelerate/src/edge_collections.rs
+++ b/crates/accelerate/src/edge_collections.rs
@@ -17,7 +17,6 @@ use pyo3::Python;
 /// A simple container that contains a vector representing edges in the
 /// coupling map that are found to be optimal by the swap mapper.
 #[pyclass(module = "qiskit._accelerate.stochastic_swap")]
-#[pyo3(text_signature = "(/)")]
 #[derive(Clone, Debug)]
 pub struct EdgeCollection {
     pub edges: Vec<usize>,
@@ -32,6 +31,7 @@ impl Default for EdgeCollection {
 #[pymethods]
 impl EdgeCollection {
     #[new]
+    #[pyo3(text_signature = "(/)")]
     pub fn new() -> Self {
         EdgeCollection { edges: Vec::new() }
     }

--- a/crates/accelerate/src/error_map.rs
+++ b/crates/accelerate/src/error_map.rs
@@ -32,7 +32,6 @@ use hashbrown::HashMap;
 /// qubit index. If an edge or qubit is ideal and has no error rate, you can
 /// either set it to ``0.0`` explicitly or as ``NaN``.
 #[pyclass(mapping, module = "qiskit._accelerate.error_map")]
-#[pyo3(text_signature = "(num_qubits, num_edges, /")]
 #[derive(Clone, Debug)]
 pub struct ErrorMap {
     pub error_map: HashMap<[usize; 2], f64>,
@@ -41,6 +40,7 @@ pub struct ErrorMap {
 #[pymethods]
 impl ErrorMap {
     #[new]
+    #[pyo3(text_signature = "(num_qubits, num_edges, /")]
     fn new(size: Option<usize>) -> Self {
         match size {
             Some(size) => ErrorMap {

--- a/crates/accelerate/src/error_map.rs
+++ b/crates/accelerate/src/error_map.rs
@@ -40,7 +40,7 @@ pub struct ErrorMap {
 #[pymethods]
 impl ErrorMap {
     #[new]
-    #[pyo3(text_signature = "(num_qubits, num_edges, /")]
+    #[pyo3(text_signature = "(/, size=None)")]
     fn new(size: Option<usize>) -> Self {
         match size {
             Some(size) => ErrorMap {

--- a/crates/accelerate/src/nlayout.rs
+++ b/crates/accelerate/src/nlayout.rs
@@ -25,7 +25,6 @@ use hashbrown::HashMap;
 ///     logical_qubits (int): The number of logical qubits in the layout
 ///     physical_qubits (int): The number of physical qubits in the layout
 #[pyclass(module = "qiskit._accelerate.stochastic_swap")]
-#[pyo3(text_signature = "(qubit_indices, logical_qubits, physical_qubits, /)")]
 #[derive(Clone, Debug)]
 pub struct NLayout {
     pub logic_to_phys: Vec<usize>,
@@ -43,6 +42,7 @@ impl NLayout {
 #[pymethods]
 impl NLayout {
     #[new]
+    #[pyo3(text_signature = "(qubit_indices, logical_qubits, physical_qubits, /)")]
     fn new(
         qubit_indices: HashMap<usize, usize>,
         logical_qubits: usize,

--- a/crates/accelerate/src/sabre_swap/neighbor_table.rs
+++ b/crates/accelerate/src/sabre_swap/neighbor_table.rs
@@ -35,7 +35,7 @@ pub struct NeighborTable {
 #[pymethods]
 impl NeighborTable {
     #[new]
-    #[pyo3(text_signature = "(/)")]
+    #[pyo3(text_signature = "(/, adjacency_matrix=None)")]
     pub fn new(adjacency_matrix: Option<PyReadonlyArray2<f64>>) -> Self {
         let run_in_parallel = getenv_use_multiple_threads();
         let neighbors = match adjacency_matrix {

--- a/crates/accelerate/src/sabre_swap/neighbor_table.rs
+++ b/crates/accelerate/src/sabre_swap/neighbor_table.rs
@@ -27,7 +27,6 @@ use rayon::prelude::*;
 /// and used solely to represent neighbors of each node in qiskit-terra's rust
 /// module.
 #[pyclass(module = "qiskit._accelerate.sabre_swap")]
-#[pyo3(text_signature = "(/)")]
 #[derive(Clone, Debug)]
 pub struct NeighborTable {
     pub neighbors: Vec<Vec<usize>>,
@@ -36,6 +35,7 @@ pub struct NeighborTable {
 #[pymethods]
 impl NeighborTable {
     #[new]
+    #[pyo3(text_signature = "(/)")]
     pub fn new(adjacency_matrix: Option<PyReadonlyArray2<f64>>) -> Self {
         let run_in_parallel = getenv_use_multiple_threads();
         let neighbors = match adjacency_matrix {

--- a/crates/accelerate/src/sabre_swap/sabre_dag.rs
+++ b/crates/accelerate/src/sabre_swap/sabre_dag.rs
@@ -19,7 +19,6 @@ use rustworkx_core::petgraph::prelude::*;
 /// DAGCircuit, but the contents of the node are a tuple of DAGCircuit node ids,
 /// a list of qargs and a list of cargs
 #[pyclass(module = "qiskit._accelerate.sabre_swap")]
-#[pyo3(text_signature = "(num_qubits, num_clbits, nodes, /)")]
 #[derive(Clone, Debug)]
 pub struct SabreDAG {
     pub dag: DiGraph<(usize, Vec<usize>), ()>,
@@ -29,6 +28,7 @@ pub struct SabreDAG {
 #[pymethods]
 impl SabreDAG {
     #[new]
+    #[pyo3(text_signature = "(num_qubits, num_clbits, nodes, /)")]
     pub fn new(
         num_qubits: usize,
         num_clbits: usize,

--- a/crates/qasm2/Cargo.toml
+++ b/crates/qasm2/Cargo.toml
@@ -13,4 +13,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 hashbrown = "0.13.2"
-pyo3 = { version = "0.18.3", features = ["extension-module"] }
+pyo3 = { version = "0.19.0", features = ["extension-module"] }

--- a/crates/qasm2/src/lib.rs
+++ b/crates/qasm2/src/lib.rs
@@ -51,7 +51,7 @@ impl CustomInstruction {
 /// The given `callable` must be a Python function that takes `num_params` floats, and returns a
 /// float.  The `name` is the identifier that refers to it in the OpenQASM 2 program.  This cannot
 /// clash with any defined gates.
-#[pyclass(text_signature = "(name, num_params, callable, /)")]
+#[pyclass()]
 #[derive(Clone)]
 pub struct CustomClassical {
     pub name: String,
@@ -62,6 +62,7 @@ pub struct CustomClassical {
 #[pymethods]
 impl CustomClassical {
     #[new]
+    #[pyo3(text_signature = "(name, num_params, callable, /)")]
     fn __new__(name: String, num_params: usize, callable: PyObject) -> Self {
         Self {
             name,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

PyO3 0.19.0 and rust-numpy 0.19.0 were just released. This commit updates the version used in qiskit to these latest releases. At the same time this updates usage of text signature for classes that was deprecated in the PyO3 0.19.0 release. While not fatal for normal builds this would have failed clippy in CI because we treat warnings as errors.

### Details and comments