### PR TITLE
add a Meyer-Wallach-Brennen measure

### DIFF
--- a/qiskit/quantum_info/__init__.py
+++ b/qiskit/quantum_info/__init__.py
@@ -173,6 +173,7 @@ from .states import (
     purity,
     shannon_entropy,
     state_fidelity,
+    mwb_measure,
 )
 from .synthesis import (
     OneQubitEulerDecomposer,

--- a/qiskit/quantum_info/states/__init__.py
+++ b/qiskit/quantum_info/states/__init__.py
@@ -23,4 +23,5 @@ from .measures import (
     concurrence,
     mutual_information,
     entanglement_of_formation,
+    mwb_measure,
 )

--- a/qiskit/quantum_info/states/measures.py
+++ b/qiskit/quantum_info/states/measures.py
@@ -252,3 +252,35 @@ def entanglement_of_formation(state):
     conc = concurrence(state)
     val = (1 + np.sqrt(1 - (conc**2))) / 2
     return shannon_entropy([val, 1 - val])
+
+
+def mwb_measure(state):
+    r"""Calculate the Meyer-Wallach-Brennen measure of the quantum state.
+
+    The Meyer-Wallach-Brennen measure :math:`Q` is given by:
+
+    .. math::
+
+        Q=2\left(1-\frac{1}{n}\sum_{i=1}^n Tr(\rho_i^2)\right)
+
+    where :math:`\rho_i` is a density matrix obtained by tracing all the other
+     subsystems except the ith subsystems and N is the total number of subsystems.
+
+    Args:
+        state (Statevector or DensityMatrix)
+
+    Returns:
+        float: The Meyer-Wallach-Brennen measure :math:`Q`.
+
+    Raises:
+        QiskitError: if the input state is not a valid QuantumState.
+    """
+
+    state = _format_state(state, validate=True)
+    summ = 0.0
+    n = len(state.dims())
+    for i in range(n):
+        rhored = partial_trace(state, [i])
+        summ = summ + purity(rhored)
+    q_measure = 2 * (1 - summ / n)
+    return q_measure

--- a/releasenotes/notes/add_mwb_measure.yaml
+++ b/releasenotes/notes/add_mwb_measure.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    Added a new function , :func:mwb_measure is an estimation of the quantum entanglement
+     measure known as the Meyer-Wallach-Brennen measure. This measure calculates the average 
+     subsystem linear entropy of the constituent qubits.
+
+     The mathematical formula for this measure is, 
+     $Q=2\left(1-\frac{1}{n}\sum_{i=1}^n Tr(\rho_i^2)\right)$
+
+     where :math:`\rho_i` is a density matrix obtained by tracing all the other
+     subsystems except the ith subsystem and n is the total number of subsystems.

--- a/test/python/quantum_info/states/test_measures.py
+++ b/test/python/quantum_info/states/test_measures.py
@@ -25,6 +25,7 @@ from qiskit.quantum_info import concurrence
 from qiskit.quantum_info import entanglement_of_formation
 from qiskit.quantum_info import mutual_information
 from qiskit.quantum_info.states import shannon_entropy
+from qiskit.quantum_info import mwb_measure
 
 
 class TestStateMeasures(QiskitTestCase):
@@ -340,6 +341,28 @@ class TestStateMeasures(QiskitTestCase):
             psi = Statevector([alpha, beta, 0, 1j * np.sqrt(1 - alpha**2 - beta**2)])
             rho = DensityMatrix(psi)
             self.assertAlmostEqual(mutual_information(psi), mutual_information(rho))
+
+    def test_mwb_measure_statevector(self):
+        """Test mwb_measure function on statevector inputs"""
+        # Constructing separable quantum statevector
+        state = Statevector([1 / np.sqrt(2), 1 / np.sqrt(2), 0, 0])
+        q_measure = mwb_measure(state)
+        self.assertAlmostEqual(q_measure, 0, places=7)
+        # Constructing entangled quantum statevector
+        state = Statevector([0, 1 / np.sqrt(2), -1 / np.sqrt(2), 0])
+        q_measure = mwb_measure(state)
+        self.assertAlmostEqual(q_measure, 1.0, places=7)
+
+    def test_mwb_measure_density_matrix(self):
+        """Test mwb_measure function on density matrix inputs"""
+        # Constructing separable quantum state
+        rho = DensityMatrix.from_label("10+")
+        q_measure = mwb_measure(rho)
+        self.assertAlmostEqual(q_measure, 0, places=7)
+        # Constructing entangled quantum state
+        rho = DensityMatrix([[0, 0, 0, 0], [0, 0.5, -0.5, 0], [0, -0.5, 0.5, 0], [0, 0, 0, 0]])
+        q_measure = mwb_measure(rho)
+        self.assertAlmostEqual(q_measure, 1.0, places=7)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
 Meyer-Wallach-Brennen measure calculates the average subsystem linear entropy of the constituent subsystems.

The mathematical formula for this measure is, 

$$Q=2\left(1-\frac{1}{n}\sum_{i=1}^n Tr(\rho_i^2)\right),$$
where $\rho_i$ is a density matrix obtained by tracing all the other subsystems except the ith subsystem and n is the total number of subsystems.