### PR TITLE
Fix typo issue #10198

### DIFF
--- a/qiskit/circuit/library/standard_gates/global_phase.py
+++ b/qiskit/circuit/library/standard_gates/global_phase.py
@@ -25,7 +25,7 @@ class GlobalPhaseGate(Gate):
 
     Can be applied to a :class:`~qiskit.circuit.QuantumCircuit`
 
-    **Mathamatical Representation:**
+    **Mathematical Representation:**
 
     .. math::
         \text{GlobalPhaseGate}\ =


### PR DESCRIPTION
Fixed typo in issue #10198. Changed "Mathamatical" to "Mathematical" for GlobalPhaseGate in Qiskit docs.