### PR TITLE
Warning about removal of extras

### DIFF
--- a/releasenotes/notes/remove-extras-71a8b8c0542f308e.yaml
+++ b/releasenotes/notes/remove-extras-71a8b8c0542f308e.yaml
@@ -1,0 +1,12 @@
+---
+prelude: >
+    This is the last version qiskit metapackage is providing the following optional components as extras:
+
+      * ``nature``
+      * ``machine-learning``
+      * ``finance``
+      * ``optimization``
+      * ``experiments``
+
+    In the coming Qiskit release, ``pip install "qiskit[<entries in this list>]"`` will stop working and
+    ``pip install "qiskit[all]"`` will not include them.


### PR DESCRIPTION
Qiskit 0.44 (with terra 0.25) needs to have an warning about the fact that Qiskit 0.45 (with terra 0.45) will stop having application as extras. This entry is more of a reminder about that.