### PR TITLE
Refactor disjoint routing tests to be more resilient

### DIFF
--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -92,6 +92,14 @@ class CustomCX(Gate):
         self._definition.cx(0, 1)
 
 
+def connected_qubits(physical: int, coupling_map: CouplingMap) -> set:
+    """Get the physical qubits that have a connection to this one in the coupling map."""
+    for component in coupling_map.connected_components():
+        if physical in (qubits := component.graph.nodes()):
+            return set(qubits)
+    raise ValueError(f"physical qubit {physical} is not in the coupling map")
+
+
 @ddt
 class TestTranspile(QiskitTestCase):
     """Test transpile function."""
@@ -2466,10 +2474,12 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
         creg = ClassicalRegister(2)
         qc = QuantumCircuit(25)
         qc.add_register(creg)
+        # Component 0
         qc.h(24)
         qc.cx(24, 23)
         qc.measure(24, creg[0])
         qc.measure(23, creg[1])
+        # Component 1
         qc.h(0).c_if(creg, 0)
         for i in range(18):
             qc.ecr(0, i + 1).c_if(creg, 0)
@@ -2495,14 +2505,22 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
             tqc,
             qubit_mapping={qubit: index for index, qubit in enumerate(tqc.qubits)},
         )
-        # Check clbits are in order
-        # Traverse the output dag over the sole clbit. Checking that the qubits of the ops
+        # Check that virtual qubits that interact with each other via quantum links are placed into
+        # the same component of the coupling map.
+        initial_layout = tqc.layout.initial_layout
+        coupling_map = self.backend.target.build_coupling_map()
+        components = [
+            connected_qubits(initial_layout[qc.qubits[23]], coupling_map),
+            connected_qubits(initial_layout[qc.qubits[0]], coupling_map),
+        ]
+        self.assertLessEqual({initial_layout[qc.qubits[i]] for i in [23, 24]}, components[0])
+        self.assertLessEqual({initial_layout[qc.qubits[i]] for i in range(19)}, components[1])
+
+        # Check clbits are in order.
+        # Traverse the output dag over the sole clbit, checking that the qubits of the ops
         # go in order between the components. This is a sanity check to ensure that routing
         # doesn't reorder a classical data dependency between components. Inside a component
         # we have the dag ordering so nothing should be out of order within a component.
-        initial_layout = tqc.layout.initial_layout
-        first_component = {qc.qubits[23], qc.qubits[24]}
-        second_component = {qc.qubits[i] for i in range(19)}
         tqc_dag = circuit_to_dag(tqc)
         qubit_map = {qubit: index for index, qubit in enumerate(tqc_dag.qubits)}
         input_node = tqc_dag.input_map[tqc_dag.clbits[0]]
@@ -2511,13 +2529,13 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
         )[0]
         # The first node should be a measurement
         self.assertIsInstance(first_meas_node.op, Measure)
-        # This shoulde be in the first ocmponent
-        self.assertIn(initial_layout._p2v[qubit_map[first_meas_node.qargs[0]]], first_component)
+        # This should be in the first component
+        self.assertIn(qubit_map[first_meas_node.qargs[0]], components[0])
         op_node = tqc_dag._multi_graph.find_successors_by_edge(
             first_meas_node._node_id, lambda edge_data: isinstance(edge_data, Clbit)
         )[0]
         while isinstance(op_node, DAGOpNode):
-            self.assertIn(initial_layout._p2v[qubit_map[op_node.qargs[0]]], second_component)
+            self.assertIn(qubit_map[op_node.qargs[0]], components[1])
             op_node = tqc_dag._multi_graph.find_successors_by_edge(
                 op_node._node_id, lambda edge_data: isinstance(edge_data, Clbit)
             )[0]
@@ -2530,10 +2548,12 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
         creg = ClassicalRegister(2)
         qc = QuantumCircuit(25)
         qc.add_register(creg)
+        # Component 0
         qc.h(0)
         qc.cx(0, 1)
         qc.measure(0, creg[0])
         qc.measure(1, creg[1])
+        # Component 1
         qc.h(24).c_if(creg, 0)
         for i in range(23, 5, -1):
             qc.ecr(24, i).c_if(creg, 0)
@@ -2559,14 +2579,22 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
             tqc,
             qubit_mapping={qubit: index for index, qubit in enumerate(tqc.qubits)},
         )
-        # Check clbits are in order
-        # Traverse the output dag over the sole clbit. Checking that the qubits of the ops
+        # Check that virtual qubits that interact with each other via quantum links are placed into
+        # the same component of the coupling map.
+        initial_layout = tqc.layout.initial_layout
+        coupling_map = self.backend.target.build_coupling_map()
+        components = [
+            connected_qubits(initial_layout[qc.qubits[0]], coupling_map),
+            connected_qubits(initial_layout[qc.qubits[6]], coupling_map),
+        ]
+        self.assertLessEqual({initial_layout[qc.qubits[i]] for i in range(2)}, components[0])
+        self.assertLessEqual({initial_layout[qc.qubits[i]] for i in range(6, 25)}, components[1])
+
+        # Check clbits are in order.
+        # Traverse the output dag over the sole clbit, checking that the qubits of the ops
         # go in order between the components. This is a sanity check to ensure that routing
         # doesn't reorder a classical data dependency between components. Inside a component
         # we have the dag ordering so nothing should be out of order within a component.
-        initial_layout = tqc.layout.initial_layout
-        first_component = {qc.qubits[i] for i in range(2)}
-        second_component = {qc.qubits[i] for i in range(6, 25)}
         tqc_dag = circuit_to_dag(tqc)
         qubit_map = {qubit: index for index, qubit in enumerate(tqc_dag.qubits)}
         input_node = tqc_dag.input_map[tqc_dag.clbits[0]]
@@ -2576,39 +2604,35 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
         # The first node should be a measurement
         self.assertIsInstance(first_meas_node.op, Measure)
         # This shoulde be in the first ocmponent
-        self.assertIn(initial_layout._p2v[qubit_map[first_meas_node.qargs[0]]], first_component)
+        self.assertIn(qubit_map[first_meas_node.qargs[0]], components[0])
         op_node = tqc_dag._multi_graph.find_successors_by_edge(
             first_meas_node._node_id, lambda edge_data: isinstance(edge_data, Clbit)
         )[0]
         while isinstance(op_node, DAGOpNode):
-            self.assertIn(initial_layout._p2v[qubit_map[op_node.qargs[0]]], second_component)
+            self.assertIn(qubit_map[op_node.qargs[0]], components[1])
             op_node = tqc_dag._multi_graph.find_successors_by_edge(
                 op_node._node_id, lambda edge_data: isinstance(edge_data, Clbit)
             )[0]
 
-    # Level 1 skipped in this test for now because routing inserts more swaps
-    # and tricking the intermediate layout permutation to validate ordering
-    # will be different compared to higher optimization levels. We have similar
-    # coverage provided by above tests for level 1.
-    @data(2, 3)
+    @data(1, 2, 3)
     def test_chained_data_dependency(self, opt_level):
         """Test 3 component circuit with shared clbits between each component."""
         creg = ClassicalRegister(1)
         qc = QuantumCircuit(30)
         qc.add_register(creg)
-        # Component 1
+        # Component 0
         qc.h(0)
         for i in range(9):
             qc.cx(0, i + 1)
         measure_op = Measure()
         qc.append(measure_op, [9], [creg[0]])
-        # Component 2
+        # Component 1
         qc.h(10).c_if(creg, 0)
         for i in range(11, 20):
             qc.ecr(10, i).c_if(creg, 0)
         measure_op = Measure()
         qc.append(measure_op, [19], [creg[0]])
-        # Component 3
+        # Component 2
         qc.h(20).c_if(creg, 0)
         for i in range(21, 30):
             qc.cz(20, i).c_if(creg, 0)
@@ -2636,16 +2660,24 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
             tqc,
             qubit_mapping={qubit: index for index, qubit in enumerate(tqc.qubits)},
         )
-        # Check clbits are in order
-        # Traverse the output dag over the sole clbit. Checking that the qubits of the ops
+        # Check that virtual qubits that interact with each other via quantum links are placed into
+        # the same component of the coupling map.
+        initial_layout = tqc.layout.initial_layout
+        coupling_map = self.backend.target.build_coupling_map()
+        components = [
+            connected_qubits(initial_layout[qc.qubits[0]], coupling_map),
+            connected_qubits(initial_layout[qc.qubits[10]], coupling_map),
+            connected_qubits(initial_layout[qc.qubits[20]], coupling_map),
+        ]
+        self.assertLessEqual({initial_layout[qc.qubits[i]] for i in range(10)}, components[0])
+        self.assertLessEqual({initial_layout[qc.qubits[i]] for i in range(10, 20)}, components[1])
+        self.assertLessEqual({initial_layout[qc.qubits[i]] for i in range(20, 30)}, components[2])
+
+        # Check clbits are in order.
+        # Traverse the output dag over the sole clbit, checking that the qubits of the ops
         # go in order between the components. This is a sanity check to ensure that routing
         # doesn't reorder a classical data dependency between components. Inside a component
-        # we have the dag ordering so nothing should be incompatible there.
-
-        initial_layout = tqc.layout.initial_layout
-        first_component = {qc.qubits[i] for i in range(10)}
-        second_component = {qc.qubits[i] for i in range(10, 20)}
-        third_component = {qc.qubits[i] for i in range(20, 30)}
+        # we have the dag ordering so nothing should be out of order within a component.
         tqc_dag = circuit_to_dag(tqc)
         qubit_map = {qubit: index for index, qubit in enumerate(tqc_dag.qubits)}
         input_node = tqc_dag.input_map[tqc_dag.clbits[0]]
@@ -2653,25 +2685,25 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
             input_node._node_id, lambda edge_data: isinstance(edge_data, Clbit)
         )[0]
         self.assertIsInstance(first_meas_node.op, Measure)
-        self.assertIn(initial_layout._p2v[qubit_map[first_meas_node.qargs[0]]], first_component)
+        self.assertIn(qubit_map[first_meas_node.qargs[0]], components[0])
         op_node = tqc_dag._multi_graph.find_successors_by_edge(
             first_meas_node._node_id, lambda edge_data: isinstance(edge_data, Clbit)
         )[0]
         while not isinstance(op_node.op, Measure):
-            self.assertIn(initial_layout._p2v[qubit_map[op_node.qargs[0]]], second_component)
+            self.assertIn(qubit_map[op_node.qargs[0]], components[1])
             op_node = tqc_dag._multi_graph.find_successors_by_edge(
                 op_node._node_id, lambda edge_data: isinstance(edge_data, Clbit)
             )[0]
-        self.assertIn(initial_layout._p2v[qubit_map[op_node.qargs[0]]], second_component)
+        self.assertIn(qubit_map[op_node.qargs[0]], components[1])
         op_node = tqc_dag._multi_graph.find_successors_by_edge(
             op_node._node_id, lambda edge_data: isinstance(edge_data, Clbit)
         )[0]
         while not isinstance(op_node.op, Measure):
-            self.assertIn(initial_layout._p2v[qubit_map[op_node.qargs[0]]], third_component)
+            self.assertIn(qubit_map[op_node.qargs[0]], components[2])
             op_node = tqc_dag._multi_graph.find_successors_by_edge(
                 op_node._node_id, lambda edge_data: isinstance(edge_data, Clbit)
             )[0]
-        self.assertIn(initial_layout._p2v[qubit_map[op_node.qargs[0]]], third_component)
+        self.assertIn(qubit_map[op_node.qargs[0]], components[2])
 
     @data("sabre", "stochastic", "basic", "lookahead")
     def test_basic_connected_circuit_dense_layout(self, routing_method):

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -95,8 +95,8 @@ class CustomCX(Gate):
 def connected_qubits(physical: int, coupling_map: CouplingMap) -> set:
     """Get the physical qubits that have a connection to this one in the coupling map."""
     for component in coupling_map.connected_components():
-        if physical in (qubits := component.graph.nodes()):
-            return set(qubits)
+        if physical in (qubits := set(component.graph.nodes())):
+            return qubits
     raise ValueError(f"physical qubit {physical} is not in the coupling map")
 
 


### PR DESCRIPTION
### Summary

The previous method of running the assertions in these tests could produce false negatives if routing caused an operation to take place on a virtual qubit that was initially an ancilla.  It was tricky to make sensible assertions in these cases, since it is slightly fiddly to determine which ancillas have been assigned to which physical components of the chip.  This lead to `optimization_level=1` being skipped in one test, because the routing would use these ancillas.

This refactors the test to be more resistant to valid choices the routing algorithm might make.  We instead find _all_ the physical qubits that are in each connected component, determine the mapping of virtual qubits to components, and then make assertions based on the physical qubits.  This is resistant to ancillas being used in the comparisons.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

This came about because I was playing with some changes to Sabre and caused these tests to fail in situations where the routing was valid.  It's better to PR the change to the tests separately to a change in behaviour for history tracking.
