### PR TITLE
Fix QuantumCircuit.draw() not outputting pdf in latex mode

### DIFF
--- a/qiskit/visualization/circuit/circuit_visualization.py
+++ b/qiskit/visualization/circuit/circuit_visualization.py
@@ -28,6 +28,7 @@ import logging
 import os
 import subprocess
 import tempfile
+import shutil
 from warnings import warn
 
 from qiskit import user_config
@@ -495,7 +496,6 @@ def _latex_circuit_drawer(
         image = trim_image(image)
         if filename:
             if filename.endswith(".pdf"):
-                import shutil
                 shutil.move(base + ".pdf", filename)
             else:
                 try:

--- a/qiskit/visualization/circuit/circuit_visualization.py
+++ b/qiskit/visualization/circuit/circuit_visualization.py
@@ -495,7 +495,8 @@ def _latex_circuit_drawer(
         image = trim_image(image)
         if filename:
             if filename.endswith(".pdf"):
-                os.rename(base + ".pdf", filename)
+                import shutil
+                shutil.move(base + ".pdf", filename)
             else:
                 try:
                     image.save(filename)

--- a/releasenotes/notes/fix-regression-in-the-LaTeX-drawer-of-QuantumCircuit-7dd3e84e1dea1abd.yaml
+++ b/releasenotes/notes/fix-regression-in-the-LaTeX-drawer-of-QuantumCircuit-7dd3e84e1dea1abd.yaml
@@ -1,0 +1,6 @@
+
+fixes:
+  - |
+    Fixed regression in the LaTeX drawer of `QuantumCircuit`.
+    See `#10211 <https://github.com/Qiskit/qiskit-terra/issues/10211>`__
+

--- a/releasenotes/notes/fix-regression-in-the-LaTeX-drawer-of-QuantumCircuit-7dd3e84e1dea1abd.yaml
+++ b/releasenotes/notes/fix-regression-in-the-LaTeX-drawer-of-QuantumCircuit-7dd3e84e1dea1abd.yaml
@@ -1,6 +1,8 @@
 
 fixes:
   - |
-    Fixed regression in the LaTeX drawer of `QuantumCircuit`.
-    See `#10211 <https://github.com/Qiskit/qiskit-terra/issues/10211>`__
+    Fixed a regression in the LaTeX drawer of :meth:`.QuantumCircuit.draw`
+    when temporary files are placed on a separate filesystem to the working
+    directory.  See
+    `#10211 <https://github.com/Qiskit/qiskit-terra/issues/10211>`__.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Per the discussion in #10211 I've filed this quick fix. 

When calling `QuantumCircuit.draw('latex', out.pdf)`, the program breaking when qiskit tries to move the compiled pdf from the tmp folder to the target directory. The generated pdf is then deleted alongside the tmp folder.

The bug is due to 'os.rename(...)' not working properly across filesystems.
Resorting to `shutil.move(...)` solved the problem.


### Details and comments

I'm afraid there isn't a test I can add for the bug since it is device-dependent.
