### PR TITLE
Monodromy Depth AnalysisPass

### DIFF
--- a/qiskit/transpiler/passes/analysis/monodromy_depth.py
+++ b/qiskit/transpiler/passes/analysis/monodromy_depth.py
@@ -1,0 +1,131 @@
+from qiskit.transpiler import AnalysisPass
+from qiskit.transpiler.exceptions import TranspilerError
+from qiskit.circuit import Instruction
+from fractions import Fraction
+from monodromy.coordinates import unitary_to_monodromy_coordinate
+from monodromy.coverage import deduce_qlr_consequences
+from monodromy.static.examples import exactly, identity_polytope, \
+    everything_polytope
+from monodromy.coverage import build_coverage_set, CircuitPolytope, print_coverage_set
+import logging
+from qiskit.dagcircuit import DAGCircuit, DAGOpNode
+from qiskit.transpiler.passes import Collect2qBlocks, ConsolidateBlocks
+import retworkx
+
+class MonodromyDepth(AnalysisPass):
+    """
+    MonodromyDepth class extends the AnalysisPass to perform cost analysis on a given 
+    CircuitDAG with respect to a specified 2-qubit basis gate. This basis gate is crucial in 
+    calculating the minimum execution cost of 2-qubit blocks within the CircuitDAG.
+
+    This class is particularly useful for quantum circuit optimization where the cost 
+    associated with the execution of certain gates is a crucial factor in the overall performance 
+    of the quantum computer.
+
+    This class requires the Collect2qBlocks and ConsolidateBlocks passes to decompose the 
+    CircuitDAG into 2-qubit blocks and consolidate them respectively. 
+
+    Reference: https://github.com/evmckinney9/monodromy/blob/main/monodromy/depthPass.py
+    """
+
+    def __init__(self, basis_gate: Instruction):
+        """
+        Constructor takes a qiskit.Instruction for the basis gate.
+        In the future, this can be extended to accept a list of basis gates.
+        
+        :param basis_gate: A unitary representing the basis gate for the analysis.
+        """
+        super().__init__()
+        assert basis_gate.num_qubits == 2, "Basis gate must be a 2Q gate."
+        self.requires = [Collect2qBlocks(), ConsolidateBlocks(force_consolidate=True)]
+        self.basis_gate = basis_gate
+        self.chatty = False
+        self.coverage_set = self._gate_set_to_coverage()
+    
+    def _operation_to_circuit_polytope(self, operation: Instruction) -> CircuitPolytope:
+        """
+        The operation_to_circuit_polytope() function takes a qiskit.Instruction object and returns a 
+        CircuitPolytope object that represents the unitary of the operation.
+
+        Reference: https://github.com/evmckinney9/monodromy/blob/main/scripts/single_circuit.py
+
+        :param operation: A qiskit.Instruction object.
+        :return: A CircuitPolytope object
+        """
+
+        gd = operation.to_matrix()
+        b_polytope = exactly(
+            *(
+                Fraction(x).limit_denominator(10_000)
+                for x in unitary_to_monodromy_coordinate(gd)[:-1]
+            )
+        )
+        convex_polytope = deduce_qlr_consequences(
+            target="c",
+            a_polytope=identity_polytope,
+            b_polytope=b_polytope,
+            c_polytope=everything_polytope,
+        )
+
+        return CircuitPolytope(
+            operations=[operation.name],
+            cost=1,
+            convex_subpolytopes=convex_polytope.convex_subpolytopes,
+        )
+    
+    def _gate_set_to_coverage(self):
+        """
+        The gate_set_to_coverage() function takes the basis gate and creates a CircuitPolytope object 
+        that represents all the possible 2Q unitaries that can be formed by piecing together different 
+        instances of the basis gate.
+
+        :return: A CircuitPolytope object
+        """
+        if self.chatty:
+            logging.info("==== Working to build a set of covering polytopes ====")
+
+        # TODO, here could add functionality for multiple basis gates
+        # just need to fix the cost function to account for relative durations
+        operations = [self._operation_to_circuit_polytope(self.basis_gate)]
+        coverage_set = build_coverage_set(operations, chatty=self.chatty)
+
+        # TODO: add some warning or fail condition if the coverage set fails to coverage
+        # one way, (but there may be a more direct way) is to check if expected haar == 0
+
+        if self.chatty:
+            logging.info("==== Done. Here's what we found: ====")
+            logging.info(print_coverage_set(coverage_set))
+
+        sorted_polytopes = sorted(coverage_set, key=lambda k: k.cost)
+        return sorted_polytopes
+
+    def _operation_to_cost(self, operation: Instruction) -> int:
+        target_coords = unitary_to_monodromy_coordinate(operation.to_matrix())
+        for i, circuit_polytope in enumerate(self.coverage_set):
+            if circuit_polytope.has_element(target_coords):
+                return i
+        raise TranspilerError("Operation not found in coverage set.")
+
+    def run(self, dag: DAGCircuit) -> DAGCircuit:
+        """
+        The run() method is the main entry point for the AnalysisPass. It takes a CircuitDAG as input 
+        and returns an updated CircuitDAG. This method applies the basis gate to the CircuitDAG, 
+        computes the cost of the applied gate, and updates the CircuitDAG accordingly.
+
+        :param dag: The CircuitDAG to be analyzed.
+        :return: An updated CircuitDAG.
+        """
+        def weight_fn(_1, node, _2):
+            """Weight function for longest path algorithm"""
+            target_node = dag._multi_graph[node]
+            if not isinstance(target_node, DAGOpNode):
+                return 0
+            else:
+                return self._operation_to_cost(target_node.op)
+        
+        longest_path_length = retworkx.dag_longest_path_length(dag._multi_graph, weight_fn=weight_fn)
+        if self.chatty:
+            logging.info(f"Longest path length: {longest_path_length}")
+        
+        self.property_set["monodromy_depth"] = longest_path_length
+        return dag


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In this Pull Request, I introduce an `AnalysisPass`, `MonodromyDepth`, which allows for the evaluation of the depth (or cost) of a quantum circuit without explicit decomposition. The pass operates by consolidating unitary blocks in the circuit, calculating the cost via monodromy polytope, and returning the length of the longest path in the circuit, where the length is determined by the decomposition cost. This functionality offers a quick and efficient way to measure the cost of a circuit in the context of specific basis gates, without requiring immediate decomposition into those gates.

### Details and comments

The motivation behind this addition comes from the necessity of understanding the post-decomposition costs of circuits during the process of creating quantum transpiler passes. It's beneficial to work with a basis such as SWAPs and CX gates, but an actual decomposition of the circuit may not be desirable until a later stage. The `MonodromyDepth` pass allows for a rapid evaluation of the cost implications of various strategic decisions during the transpilation process, thereby guiding the development of efficient transpiler passes.

The code for `MonodromyDepth` is maintained in a separate repository: [evmckinney9/monodromy](https://github.com/evmckinney9/monodromy/tree/main). Since Qiskit does not currently have monodromy as a dependency, it seems reasonable to keep this as a separate repository. However, I believe the concept and implementation could be of interest to the Qiskit community, hence this Pull Request.

For example, `MonodromyDepth` could be used as a heuristic measure by other transpiler passes to quickly evaluate the impact of their decisions. In fact, this work is part of a larger project aimed at developing a routing pass that utilizes this capability. While the routing pass is still under development and not yet open-source at time of routing, I plan to release it in the near future.
#### Example
Using this pass is key to recognizing the changing cost of depth post-decomposition.

```python
from monodromy.depthPass import MonodromyDepth
from qiskit.transpiler.passmanager import PassManager
from qiskit.circuit.library import iSwapGate
from qiskit.transpiler.passes import Depth
from qiskit import QuantumCircuit

pm = PassManager()
pm.append(Depth())
pm.append(MonodromyDepth(basis_gate=iSwapGate().power(1/2)))

qc= QuantumCircuit(4)
qc.swap(0,1)
qc.cx(0,1)
qc.cx(1,2)
qc.swap(0,1)
qc.cx(0,1)
qc.cx(0,1)
qc.swap(2,3)
qc.cx(0,2)
qc.cx(1,2)
qc.swap(0,1)
qc.cx(2,3)
qc.cx(2,3)
display(qc.draw())

pm.run(qc)
expected_value = 14
print(f"Depth: {pm.property_set['depth']}")
print(f"Monodromy depth: {pm.property_set['monodromy_depth']}")
assert pm.property_set["monodromy_depth"] == expected_value, "Monodromy depth not calculated correctly!"
```
```bash
                                                   
q_0: ─X───■────────X───■────■────■─────────X───────
      │ ┌─┴─┐      │ ┌─┴─┐┌─┴─┐  │         │       
q_1: ─X─┤ X ├──■───X─┤ X ├┤ X ├──┼────■────X───────
        └───┘┌─┴─┐   └───┘└───┘┌─┴─┐┌─┴─┐          
q_2: ────────┤ X ├─X───────────┤ X ├┤ X ├──■────■──
             └───┘ │           └───┘└───┘┌─┴─┐┌─┴─┐
q_3: ──────────────X─────────────────────┤ X ├┤ X ├
                                         └───┘└───┘
Depth: 10
Monodromy depth: 14
```
#### Reference
Peterson, Eric C., Gavin E. Crooks, and Robert S. Smith. "Fixed-depth two-qubit circuits and the monodromy polytope." Quantum 4 (2020): 247.