### PR TITLE
Fix fake backend checks for number of qubits and basis gates

### DIFF
--- a/qiskit/providers/fake_provider/fake_backend.py
+++ b/qiskit/providers/fake_provider/fake_backend.py
@@ -330,6 +330,20 @@ class FakeBackendV2(BackendV2):
             QiskitError: If a pulse job is supplied and qiskit-aer is not
             installed.
         """
+
+        # Assert that the QauntumCircuit number of qubits and gates are supported by the backend.
+        if type(run_input) == QuantumCircuit:
+
+            supported_qubits = self.conf_filename['n_qubits']
+            requested_qubits = run_input.num_qubit
+
+            if  supported_qubits < requested_qubits :
+                # Number of Qubits Error
+                real_backend = self.conf_filename["backend_name"]
+                raise QiskitError("The provided QuantunCircuit was implemented with " + str(requested_qubits)   + " the requested backend " + real_backend + " only supports " +  str(supported_qubits) + ".")
+
+
+
         circuits = run_input
         pulse_job = None
         if isinstance(circuits, (pulse.Schedule, pulse.ScheduleBlock)):

--- a/qiskit/providers/fake_provider/fake_backend.py
+++ b/qiskit/providers/fake_provider/fake_backend.py
@@ -342,16 +342,22 @@ class FakeBackendV2(BackendV2):
 
             if supported_qubits < requested_qubits:
                 # Number of Qubits Error
-                raise QiskitError(f"The provided QuantumCircuit was implemented with {str(requested_qubits)} but the requested {self.backend_name} backend only supports {str(supported_qubits)}.")
-            
+                raise QiskitError(
+                    f"""The provided QuantumCircuit was implemented with 
+                    {str(requested_qubits)}, but the requested {self.backend_name} 
+                    backend only supports {str(supported_qubits)}."""
+                )
+
             # Get dict of operations
             ops_dict = dict(circuits.count_ops())
             supported_gates = self._conf_dict["basis_gates"]
             # Check if gates used in circuit are supported by backend
             if any((x not in supported_gates) for x in ops_dict.keys()):
-                raise QiskitError(f"The provided QuantumCircuit was implemented with gates unsupported on {str(self.backend_name)} backend. Supported gates are {str(supported_gates)}.")
-
-
+                raise QiskitError(
+                    f"""The provided QuantumCircuit was implemented with 
+                    gates unsupported on {str(self.backend_name)} backend.
+                    Supported gates are {str(supported_gates)}."""
+                )
 
         if isinstance(circuits, (pulse.Schedule, pulse.ScheduleBlock)):
             pulse_job = True
@@ -555,6 +561,32 @@ class FakeBackend(BackendV1):
         """Main job in simulator"""
         circuits = run_input
         pulse_job = None
+
+        # Assert that the QuantumCircuit number of qubits and gates are supported by the backend.
+        if isinstance(circuits, circuit.QuantumCircuit):
+
+            supported_qubits = self._conf_dict["n_qubits"]
+            requested_qubits = circuits.num_qubits()
+
+            if supported_qubits < requested_qubits:
+                # Number of Qubits Error
+                raise QiskitError(
+                    f"""The provided QuantumCircuit was implemented with 
+                    {str(requested_qubits)}, but the requested {self.backend_name} 
+                    backend only supports {str(supported_qubits)}."""
+                )
+
+            # Get dict of operations
+            ops_dict = dict(circuits.count_ops())
+            supported_gates = self._conf_dict["basis_gates"]
+            # Check if gates used in circuit are supported by backend
+            if any((x not in supported_gates) for x in ops_dict.keys()):
+                raise QiskitError(
+                    f"""The provided QuantumCircuit was implemented with 
+                    gates unsupported on {str(self.backend_name)} backend.
+                    Supported gates are {str(supported_gates)}."""
+                )
+
         if isinstance(circuits, (pulse.Schedule, pulse.ScheduleBlock)):
             pulse_job = True
         elif isinstance(circuits, circuit.QuantumCircuit):

--- a/qiskit/providers/fake_provider/fake_backend.py
+++ b/qiskit/providers/fake_provider/fake_backend.py
@@ -565,26 +565,26 @@ class FakeBackend(BackendV1):
         # Assert that the QuantumCircuit number of qubits and gates are supported by the backend.
         if isinstance(circuits, circuit.QuantumCircuit):
 
-            supported_qubits = self._conf_dict["n_qubits"]
-            requested_qubits = circuits.num_qubits()
+            supported_qubits = self.configuration().num_qubits
+            requested_qubits = circuits.num_qubits
 
             if supported_qubits < requested_qubits:
                 # Number of Qubits Error
                 raise QiskitError(
-                    f"""The provided QuantumCircuit was implemented with 
-                    {str(requested_qubits)}, but the requested {self.backend_name} 
-                    backend only supports {str(supported_qubits)}."""
+                    f"The provided QuantumCircuit was implemented with "
+                    f"{str(requested_qubits)} qubits, but the requested {self.backend_name} "
+                    f"backend only supports {str(supported_qubits)} qubits."
                 )
 
             # Get dict of operations
             ops_dict = dict(circuits.count_ops())
-            supported_gates = self._conf_dict["basis_gates"]
+            supported_gates = self.configuration().basis_gates
             # Check if gates used in circuit are supported by backend
             if any((x not in supported_gates) for x in ops_dict.keys()):
                 raise QiskitError(
-                    f"""The provided QuantumCircuit was implemented with 
-                    gates unsupported on {str(self.backend_name)} backend.
-                    Supported gates are {str(supported_gates)}."""
+                    f"The provided QuantumCircuit was implemented with "
+                    f"gates unsupported on {str(self.backend_name)} backend. "
+                    f"Supported gates are {str(supported_gates)}."
                 )
 
         if isinstance(circuits, (pulse.Schedule, pulse.ScheduleBlock)):

--- a/qiskit/providers/fake_provider/fake_backend.py
+++ b/qiskit/providers/fake_provider/fake_backend.py
@@ -337,15 +337,15 @@ class FakeBackendV2(BackendV2):
         # Assert that the QuantumCircuit number of qubits and gates are supported by the backend.
         if isinstance(circuits, circuit.QuantumCircuit):
 
-            supported_qubits = self._conf_dict["n_qubits"]
-            requested_qubits = circuits.num_qubits()
+            supported_qubits = self.num_qubits
+            requested_qubits = circuits.num_qubits
 
             if supported_qubits < requested_qubits:
-                # Number of Qubits Error
+                # Error: Number of qubits exceeds backend qubit count
                 raise QiskitError(
-                    f"""The provided QuantumCircuit was implemented with 
-                    {str(requested_qubits)}, but the requested {self.backend_name} 
-                    backend only supports {str(supported_qubits)}."""
+                    f"The provided QuantumCircuit was implemented with "
+                    f"{str(requested_qubits)} qubits, but the requested {self.backend_name} "
+                    f"backend only supports {str(supported_qubits)} qubits."
                 )
 
             # Get dict of operations
@@ -354,9 +354,9 @@ class FakeBackendV2(BackendV2):
             # Check if gates used in circuit are supported by backend
             if any((x not in supported_gates) for x in ops_dict.keys()):
                 raise QiskitError(
-                    f"""The provided QuantumCircuit was implemented with 
-                    gates unsupported on {str(self.backend_name)} backend.
-                    Supported gates are {str(supported_gates)}."""
+                    f"The provided QuantumCircuit was implemented with "
+                    f"gates unsupported on {str(self.backend_name)} backend. "
+                    f"Supported gates are {str(supported_gates)}."
                 )
 
         if isinstance(circuits, (pulse.Schedule, pulse.ScheduleBlock)):

--- a/releasenotes/notes/fix-fake-backend-errors-num-qubits-basis-gates-de7178f025b54609.yaml
+++ b/releasenotes/notes/fix-fake-backend-errors-num-qubits-basis-gates-de7178f025b54609.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixes an issue where fake backends could run circuits
+    with gates not in basis gates, or circuits with more
+    qubits than available on the corresponding real device.
+    Attempting to do so now raises appropriate errors.
+    Refer to `#8509 <https://github.com/Qiskit/qiskit-terra/issues/8509>`
+    for more details.


### PR DESCRIPTION
### Summary
Fixes an issue where fake backends could run circuits with gates not in basis gate set, or circuits with more qubits than available on the corresponding real device. This PR fixes this bug as attempting to do so now raises appropriate errors.


### Details and comments
Fixes #8509, #9439, #9440.

