### PR TITLE
Improve casting and error message for `ParameterExpression`

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2857,8 +2857,7 @@ class QuantumCircuit:
                         if new_param._symbol_expr.is_integer and new_param.is_real():
                             val = int(new_param)
                         elif new_param.is_real():
-                            # Workaround symengine not supporting float(<ComplexDouble>)
-                            val = complex(new_param).real
+                            val = float(new_param)
                         else:
                             # complex values may no longer be supported but we
                             # defer raising an exception to validdate_parameter
@@ -2924,8 +2923,7 @@ class QuantumCircuit:
                                 if new_param._symbol_expr.is_integer:
                                     new_param = int(new_param)
                                 else:
-                                    # Workaround symengine not supporting float(<ComplexDouble>)
-                                    new_param = complex(new_param).real
+                                    new_param = float(new_param)
                             new_cal_params.append(new_param)
                         else:
                             new_cal_params.append(p)

--- a/releasenotes/notes/parameter-float-cast-48f3731fec5e47cd.yaml
+++ b/releasenotes/notes/parameter-float-cast-48f3731fec5e47cd.yaml
@@ -1,0 +1,13 @@
+---
+fixes:
+  - |
+    Improved the error messages returned when an attempt to convert a fully bound
+    :class:`.ParameterExpression` into a concrete ``float`` or ``int`` failed, for example because
+    the expression was naturally a complex number.
+  - |
+    Fixed ``float`` conversions for :class:`.ParameterExpression` values which had, at some point in
+    their construction history, an imaginary component that was subsequently been cancelled.  When
+    using Sympy as a backend, these conversions would usually already have worked.  When using
+    Symengine as the backend, these conversions would often fail with type errors, despite the
+    result having been symbolically evaluated to be real, and :meth:`.ParameterExpression.is_real`
+    being true.

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -1289,6 +1289,22 @@ class TestParameterExpressions(QiskitTestCase):
         self.assertEqual(abs(x) * abs(y), abs(x * y))
         self.assertEqual(abs(x) / abs(y), abs(x / y))
 
+    def test_cast_to_complex_when_bound(self):
+        """Verify that the cast to complex works for bound objects."""
+        x = Parameter("x")
+        y = Parameter("y")
+        bound_expr = (x + y).bind({x: 1.0, y: 1j})
+        self.assertEqual(complex(bound_expr), 1 + 1j)
+
+    def test_raise_if_cast_to_complex_when_not_fully_bound(self):
+        """Verify raises if casting to complex and not fully bound."""
+
+        x = Parameter("x")
+        y = Parameter("y")
+        bound_expr = (x + y).bind({x: 1j})
+        with self.assertRaisesRegex(TypeError, "unbound parameters"):
+            complex(bound_expr)
+
     def test_cast_to_float_when_bound(self):
         """Verify expression can be cast to a float when fully bound."""
 
@@ -1302,6 +1318,22 @@ class TestParameterExpressions(QiskitTestCase):
         x = Parameter("x")
         expr = x - x + 2.3
         self.assertEqual(float(expr), 2.3)
+
+    def test_cast_to_float_intermediate_complex_value(self):
+        """Verify expression can be cast to a float when it is fully bound, but an intermediate part
+        of the expression evaluation involved complex types.  Sympy is generally more permissive
+        than symengine here, and sympy's tends to be the expected behaviour for our users."""
+        x = Parameter("x")
+        bound_expr = (x + 1.0 + 1.0j).bind({x: -1.0j})
+        self.assertEqual(float(bound_expr), 1.0)
+
+    def test_cast_to_float_of_complex_fails(self):
+        """Test that an attempt to produce a float from a complex value fails if there is an
+        imaginary part, with a sensible error message."""
+        x = Parameter("x")
+        bound_expr = (x + 1.0j).bind({x: 1.0})
+        with self.assertRaisesRegex(TypeError, "cannot cast to float"):
+            float(bound_expr)
 
     def test_raise_if_cast_to_float_when_not_fully_bound(self):
         """Verify raises if casting to float and not fully bound."""


### PR DESCRIPTION
### Summary

Previously, we assumed that the only reason a cast of `ParameterExpression` to `complex`/`float`/`int` could fail was because of unbound parameters, and emitted an error accordingly.  This is not the case; a fully bound complex value will still fail to convert to `float`.

This PR improves the error messages in these cases, and works around a difference of Sympy and Symengine, where the latter will fail to convert real-valued expressions that were symbollically complex at some point in their binding history to `float`.  Sympy more reliably reduces values down to real-only values when the imaginary part is exactly cancelled, which is a use-case our users tend to expect.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #9187
Fix #10191

@wshanks: could I ask you to test this with one of your previous failing examples, just to check any regression?  I think we included all the relevant parts in our test suite, but I don't want to accidentally regress for you.
