### PR TITLE
Deprecate pulse Call instruction

### DIFF
--- a/qiskit/pulse/instructions/call.py
+++ b/qiskit/pulse/instructions/call.py
@@ -18,6 +18,7 @@ from qiskit.circuit.parameterexpression import ParameterExpression, ParameterVal
 from qiskit.pulse.channels import Channel
 from qiskit.pulse.exceptions import PulseError
 from qiskit.pulse.instructions import instruction
+from qiskit.utils.deprecation import deprecate_func
 
 
 class Call(instruction.Instruction):
@@ -30,6 +31,11 @@ class Call(instruction.Instruction):
     # Prefix to use for auto naming.
     prefix = "call"
 
+    @deprecate_func(
+        since="0.25.0",
+        additional_msg="Instead, use the pulse builder function "
+        "qiskit.pulse.builder.call(subroutine) within an active building context.",
+    )
     def __init__(
         self,
         subroutine,

--- a/releasenotes/notes/deprecate-pulse-Call-instruction-538802d8fad7e257.yaml
+++ b/releasenotes/notes/deprecate-pulse-Call-instruction-538802d8fad7e257.yaml
@@ -1,0 +1,7 @@
+---
+deprecations:
+  - |
+    The :class:`~qiskit.pulse.instructions.Call` has been deprecated and will
+    be removed in a future release.
+    Instead, use the pulse builder function :func:`~qiskit.pulse.builder.call`
+    within an active building context.

--- a/test/python/pulse/test_block.py
+++ b/test/python/pulse/test_block.py
@@ -678,7 +678,8 @@ class TestParametrizedBlockOperation(BaseTestBlock):
         test_waveform = pulse.Constant(100, self.amp0)
 
         param_sched = pulse.Schedule(pulse.Play(test_waveform, self.d0))
-        call_inst = pulse.instructions.Call(param_sched)
+        with self.assertWarns(DeprecationWarning):
+            call_inst = pulse.instructions.Call(param_sched)
 
         sub_block = pulse.ScheduleBlock()
         sub_block += call_inst

--- a/test/python/pulse/test_builder.py
+++ b/test/python/pulse/test_builder.py
@@ -212,7 +212,8 @@ class TestContexts(TestBuilder):
         inst_map.add("x", (0,), test_x_sched)
 
         ref_sched = pulse.Schedule()
-        ref_sched += pulse.instructions.Call(test_x_sched)
+        with self.assertWarns(DeprecationWarning):
+            ref_sched += pulse.instructions.Call(test_x_sched)
 
         x_qc = circuit.QuantumCircuit(2)
         x_qc.x(0)
@@ -961,7 +962,8 @@ class TestSubroutineCall(TestBuilder):
         reference += instructions.Delay(20, d1)
 
         ref_sched = pulse.Schedule()
-        ref_sched += pulse.instructions.Call(reference)
+        with self.assertWarns(DeprecationWarning):
+            ref_sched += pulse.instructions.Call(reference)
 
         with pulse.build() as schedule:
             with pulse.align_right():
@@ -981,7 +983,8 @@ class TestSubroutineCall(TestBuilder):
         reference = inst_map.get("u1", (0,), 0.0)
 
         ref_sched = pulse.Schedule()
-        ref_sched += pulse.instructions.Call(reference)
+        with self.assertWarns(DeprecationWarning):
+            ref_sched += pulse.instructions.Call(reference)
 
         u1_qc = circuit.QuantumCircuit(2)
         u1_qc.append(circuit.library.U1Gate(0.0), [0])
@@ -1009,7 +1012,8 @@ class TestSubroutineCall(TestBuilder):
         reference = compiler.schedule(reference_qc, self.backend)
 
         ref_sched = pulse.Schedule()
-        ref_sched += pulse.instructions.Call(reference)
+        with self.assertWarns(DeprecationWarning):
+            ref_sched += pulse.instructions.Call(reference)
 
         self.assertScheduleEqual(schedule, ref_sched)
 
@@ -1041,7 +1045,8 @@ class TestSubroutineCall(TestBuilder):
         )
 
         reference = pulse.Schedule()
-        reference += pulse.instructions.Call(h_reference)
+        with self.assertWarns(DeprecationWarning):
+            reference += pulse.instructions.Call(h_reference)
         reference += cx_reference
         reference += measure_reference << reference.duration
 

--- a/test/python/pulse/test_instructions.py
+++ b/test/python/pulse/test_instructions.py
@@ -361,14 +361,16 @@ class TestCall(QiskitTestCase):
 
     def test_call(self):
         """Test basic call instruction."""
-        call = instructions.Call(subroutine=self.subroutine)
+        with self.assertWarns(DeprecationWarning):
+            call = instructions.Call(subroutine=self.subroutine)
 
         self.assertEqual(call.duration, 10)
         self.assertEqual(call.subroutine, self.subroutine)
 
     def test_parameterized_call(self):
         """Test call instruction with parameterized subroutine."""
-        call = instructions.Call(subroutine=self.function)
+        with self.assertWarns(DeprecationWarning):
+            call = instructions.Call(subroutine=self.function)
 
         self.assertTrue(call.is_parameterized())
         self.assertEqual(len(call.parameters), 2)
@@ -393,7 +395,8 @@ class TestCall(QiskitTestCase):
     def test_call_initialize_with_parameter(self):
         """Test call instruction with parameterized subroutine with initial dict."""
         init_dict = {self.param1: 0.1, self.param2: 0.5}
-        call = instructions.Call(subroutine=self.function, value_dict=init_dict)
+        with self.assertWarns(DeprecationWarning):
+            call = instructions.Call(subroutine=self.function, value_dict=init_dict)
 
         with pulse.build() as ref_sched:
             pulse.play(pulse.Gaussian(160, 0.1, 40), pulse.DriveChannel(0))

--- a/test/python/pulse/test_parameter_manager.py
+++ b/test/python/pulse/test_parameter_manager.py
@@ -87,7 +87,8 @@ class ParameterTestBase(QiskitTestCase):
         long_schedule += subroutine
         long_schedule += pulse.ShiftPhase(self.phi2, self.d2)
         long_schedule += pulse.Play(self.parametric_waveform2, self.d2)
-        long_schedule += pulse.Call(sched)
+        with self.assertWarns(DeprecationWarning):
+            long_schedule += pulse.Call(sched)
         long_schedule += pulse.Play(self.parametric_waveform3, self.d3)
 
         long_schedule += pulse.Acquire(
@@ -152,7 +153,8 @@ class TestParameterGetter(ParameterTestBase):
         sched = pulse.Schedule()
         sched += pulse.ShiftPhase(self.phi1, self.d1)
 
-        test_obj = pulse.Call(subroutine=sched)
+        with self.assertWarns(DeprecationWarning):
+            test_obj = pulse.Call(subroutine=sched)
 
         visitor = ParameterGetter()
         visitor.visit(test_obj)
@@ -257,7 +259,8 @@ class TestParameterSetter(ParameterTestBase):
         sched = pulse.Schedule()
         sched += pulse.ShiftPhase(self.phi1, self.d1)
 
-        test_obj = pulse.Call(subroutine=sched)
+        with self.assertWarns(DeprecationWarning):
+            test_obj = pulse.Call(subroutine=sched)
 
         value_dict = {self.phi1: 1.57, self.ch1: 2}
 
@@ -267,7 +270,8 @@ class TestParameterSetter(ParameterTestBase):
         ref_sched = pulse.Schedule()
         ref_sched += pulse.ShiftPhase(1.57, pulse.DriveChannel(2))
 
-        ref_obj = pulse.Call(subroutine=ref_sched)
+        with self.assertWarns(DeprecationWarning):
+            ref_obj = pulse.Call(subroutine=ref_sched)
 
         self.assertEqual(assigned, ref_obj)
 
@@ -309,7 +313,8 @@ class TestParameterSetter(ParameterTestBase):
         subroutine += pulse.Play(self.parametric_waveform1, self.d1)
 
         nested_block = pulse.ScheduleBlock()
-        nested_block += pulse.Call(subroutine=subroutine)
+        with self.assertWarns(DeprecationWarning):
+            nested_block += pulse.Call(subroutine=subroutine)
 
         test_obj = pulse.ScheduleBlock()
         test_obj += nested_block
@@ -451,7 +456,8 @@ class TestParameterSetter(ParameterTestBase):
         ref_obj += subroutine
         ref_obj += pulse.ShiftPhase(2.0, pulse.DriveChannel(2))
         ref_obj += pulse.Play(pulse.Gaussian(125, 0.3, 25), pulse.DriveChannel(2))
-        ref_obj += pulse.Call(sched)
+        with self.assertWarns(DeprecationWarning):
+            ref_obj += pulse.Call(sched)
         ref_obj += pulse.Play(pulse.Gaussian(150, 0.4, 25), pulse.DriveChannel(4))
 
         ref_obj += pulse.Acquire(
@@ -503,12 +509,14 @@ class TestAssignFromProgram(QiskitTestCase):
 
         # from call instruction
         program_layer1 = pulse.Schedule()
-        program_layer1 += pulse.instructions.Call(program_layer0)
+        with self.assertWarns(DeprecationWarning):
+            program_layer1 += pulse.instructions.Call(program_layer0)
         self.assertEqual(program_layer1.get_parameters("amp")[0], param1)
 
         # from nested call instruction
         program_layer2 = pulse.Schedule()
-        program_layer2 += pulse.instructions.Call(program_layer1)
+        with self.assertWarns(DeprecationWarning):
+            program_layer2 += pulse.instructions.Call(program_layer1)
         self.assertEqual(program_layer2.get_parameters("amp")[0], param1)
 
     def test_assign_parameter_to_subroutine(self):
@@ -522,13 +530,15 @@ class TestAssignFromProgram(QiskitTestCase):
 
         # to call instruction
         program_layer1 = pulse.Schedule()
-        program_layer1 += pulse.instructions.Call(program_layer0)
+        with self.assertWarns(DeprecationWarning):
+            program_layer1 += pulse.instructions.Call(program_layer0)
         target = program_layer1.assign_parameters({param1: 0.1}, inplace=False)
         self.assertEqual(inline_subroutines(target), reference)
 
         # to nested call instruction
         program_layer2 = pulse.Schedule()
-        program_layer2 += pulse.instructions.Call(program_layer1)
+        with self.assertWarns(DeprecationWarning):
+            program_layer2 += pulse.instructions.Call(program_layer1)
         target = program_layer2.assign_parameters({param1: 0.1}, inplace=False)
         self.assertEqual(inline_subroutines(target), reference)
 
@@ -546,7 +556,8 @@ class TestAssignFromProgram(QiskitTestCase):
 
         main_prog = pulse.Schedule()
         pdict = {param1: param_sub1 + param_sub2}
-        main_prog += pulse.instructions.Call(subroutine, value_dict=pdict)
+        with self.assertWarns(DeprecationWarning):
+            main_prog += pulse.instructions.Call(subroutine, value_dict=pdict)
 
         # parameter is overwritten by parameters
         self.assertEqual(len(main_prog.parameters), 2)

--- a/test/python/pulse/test_transforms.py
+++ b/test/python/pulse/test_transforms.py
@@ -907,12 +907,14 @@ class TestRemoveSubroutines(QiskitTestCase):
 
         subroutine = pulse.Schedule()
         subroutine.insert(0, pulse.Delay(20, d0), inplace=True)
-        subroutine.insert(20, pulse.instructions.Call(nested_routine), inplace=True)
+        with self.assertWarns(DeprecationWarning):
+            subroutine.insert(20, pulse.instructions.Call(nested_routine), inplace=True)
         subroutine.insert(50, pulse.Delay(10, d0), inplace=True)
 
         main_program = pulse.Schedule()
         main_program.insert(0, pulse.Delay(10, d0), inplace=True)
-        main_program.insert(30, pulse.instructions.Call(subroutine), inplace=True)
+        with self.assertWarns(DeprecationWarning):
+            main_program.insert(30, pulse.instructions.Call(subroutine), inplace=True)
 
         target = transforms.inline_subroutines(main_program)
 
@@ -932,7 +934,8 @@ class TestRemoveSubroutines(QiskitTestCase):
         subroutine.insert(10, pulse.Delay(10, d0), inplace=True)
 
         nested_sched = pulse.Schedule()
-        nested_sched.insert(0, pulse.instructions.Call(subroutine), inplace=True)
+        with self.assertWarns(DeprecationWarning):
+            nested_sched.insert(0, pulse.instructions.Call(subroutine), inplace=True)
 
         main_sched = pulse.Schedule()
         main_sched.insert(0, nested_sched, inplace=True)
@@ -956,7 +959,8 @@ class TestRemoveSubroutines(QiskitTestCase):
         subroutine.append(pulse.Delay(10, d0), inplace=True)
 
         nested_block = pulse.ScheduleBlock()
-        nested_block.append(pulse.instructions.Call(subroutine), inplace=True)
+        with self.assertWarns(DeprecationWarning):
+            nested_block.append(pulse.instructions.Call(subroutine), inplace=True)
 
         main_block = pulse.ScheduleBlock()
         main_block.append(nested_block, inplace=True)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR intends to implement #10103 by deprecating the class  `qiskit.pulse.instructions.Call`.





