### PR TITLE
Add option to collect gates from the back of the circuit

### DIFF
--- a/qiskit/transpiler/passes/optimization/collect_and_collapse.py
+++ b/qiskit/transpiler/passes/optimization/collect_and_collapse.py
@@ -88,12 +88,17 @@ class CollectAndCollapse(TransformationPass):
         return dag
 
 
-def collect_using_filter_function(dag, filter_function, split_blocks, min_block_size):
+def collect_using_filter_function(
+    dag, filter_function, split_blocks, min_block_size, collect_from_back=False
+):
     """Corresponds to an important block collection strategy that greedily collects
     maximal blocks of nodes matching a given ``filter_function``.
     """
     return BlockCollector(dag).collect_all_matching_blocks(
-        filter_fn=filter_function, split_blocks=split_blocks, min_block_size=min_block_size
+        filter_fn=filter_function,
+        split_blocks=split_blocks,
+        min_block_size=min_block_size,
+        collect_from_back=collect_from_back,
     )
 
 

--- a/qiskit/transpiler/passes/optimization/collect_cliffords.py
+++ b/qiskit/transpiler/passes/optimization/collect_cliffords.py
@@ -29,7 +29,13 @@ class CollectCliffords(CollectAndCollapse):
     object.
     """
 
-    def __init__(self, do_commutative_analysis=False, split_blocks=True, min_block_size=2):
+    def __init__(
+        self,
+        do_commutative_analysis=False,
+        split_blocks=True,
+        min_block_size=2,
+        collect_from_back=False,
+    ):
         """CollectCliffords initializer.
 
         Args:
@@ -39,6 +45,8 @@ class CollectCliffords(CollectAndCollapse):
                 over disjoint qubit subsets.
             min_block_size (int): specifies the minimum number of gates in the block
                 for the block to be collected.
+            collect_from_back (bool): specifies if blocks should be collected started
+                from the end of the circuit.
         """
 
         collect_function = partial(
@@ -46,6 +54,7 @@ class CollectCliffords(CollectAndCollapse):
             filter_function=_is_clifford_gate,
             split_blocks=split_blocks,
             min_block_size=min_block_size,
+            collect_from_back=collect_from_back,
         )
         collapse_function = partial(collapse_to_operation, collapse_function=_collapse_to_clifford)
 

--- a/qiskit/transpiler/passes/optimization/collect_linear_functions.py
+++ b/qiskit/transpiler/passes/optimization/collect_linear_functions.py
@@ -27,7 +27,13 @@ class CollectLinearFunctions(CollectAndCollapse):
     """Collect blocks of linear gates (:class:`.CXGate` and :class:`.SwapGate` gates)
     and replaces them by linear functions (:class:`.LinearFunction`)."""
 
-    def __init__(self, do_commutative_analysis=False, split_blocks=True, min_block_size=2):
+    def __init__(
+        self,
+        do_commutative_analysis=False,
+        split_blocks=True,
+        min_block_size=2,
+        collect_from_back=False,
+    ):
         """CollectLinearFunctions initializer.
 
         Args:
@@ -37,6 +43,8 @@ class CollectLinearFunctions(CollectAndCollapse):
                 over disjoint qubit subsets.
             min_block_size (int): specifies the minimum number of gates in the block
                 for the block to be collected.
+            collect_from_back (bool): specifies if blocks should be collected started
+                from the end of the circuit.
         """
 
         collect_function = partial(
@@ -44,6 +52,7 @@ class CollectLinearFunctions(CollectAndCollapse):
             filter_function=_is_linear_gate,
             split_blocks=split_blocks,
             min_block_size=min_block_size,
+            collect_from_back=collect_from_back,
         )
         collapse_function = partial(
             collapse_to_operation, collapse_function=_collapse_to_linear_function

--- a/releasenotes/notes/add-collect-from-back-359d5e496313acdb.yaml
+++ b/releasenotes/notes/add-collect-from-back-359d5e496313acdb.yaml
@@ -1,0 +1,27 @@
+---
+features:
+  - |
+    Added a new option ``collect_from_back`` to :class:`~BlockCollector`. By default, blocks are
+    greedily collected in the direction from the inputs towards the outputs of the circuit.
+    The option ``collect_from_back`` allows to change this direction, that is to collect
+    blocks from the outputs towards the inputs of the circuit. This is important in combination
+    with ALAP-scheduling passes where we may prefer to put gates in the later rather than earlier
+    blocks.
+
+  - |
+    Added a new option ``collect_from_back`` to :class:`~CollectLinearFunctions` and
+    :class:`~CollectCliffords` transpiler passes. When `True`, the blocks are collected
+    and from the outputs towards the inputs of the circuit.
+    As an example, the default behaviour of running the :class:`~CollectLinearFunctions`
+    transpiler pass on the following circuit::
+
+        circuit = QuantumCircuit(3)
+        circuit.cx(1, 2)
+        circuit.cx(1, 0)
+        circuit.h(2)
+        circuit.cx(1, 2)
+
+    will produce two :class:`.LinearFunction` objects, the first from gates `CX(1, 2)` and
+    `CX(1, 0)`, and the second from gate `CX(1, 2)`.
+    Running the pass with the option ``collect_from_back=True``, will put the gate `CX(1, 0)`
+    into the second linear function instead.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

By default, block collection (`BlockCollector` as used in `CollectLinearFunctions`, `CollectCliffords`, and the standalone function `collect_using_filter_function`) greedily collects blocks of nodes from the inputs towards the outputs of the circuit. For some applications (for instance, related to ALAP-scheduling of gates), it is preferable to put gates into later rather than earlier blocks, that is to greedily collect blocks from the outputs towards the inputs of the circuit instead.

This PR adds the option `collect_from_back` to `BlockCollector`, `CollectLinearFunctions`, `CollectCliffords`, `collect_using_filter_function`. The algorithmic change is minor: the internal `BlockCollector` functions `_direct_preds` and `_direct_succs` are modified to take the collection direction into account, and at the very end both the blocks and the gates in each block are reversed.

