### PR TITLE
Collect 2q runs in control flow blocks

### DIFF
--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -1107,6 +1107,25 @@ class TestDagNodeSelection(QiskitTestCase):
             else:
                 self.fail("Unknown run encountered")
 
+    def test_dag_collect_2q_runs(self):
+        """Test collect_2q_runs."""
+        qc = QuantumCircuit(2, 1)
+        clbit = qc.clbits[0]
+        qc.x(0)
+        qc.cx(0, 1)
+        with qc.if_test((clbit, 0)) as else_:
+            qc.y(1)
+            qc.cz(0, 1)
+        with else_:
+            qc.cy(0, 1)
+            qc.h(0)
+        dag = circuit_to_dag(qc)
+        runs = dag.collect_2q_runs()
+        runnames = []
+        for run in runs:
+            runnames.append([node.op.name for node in run])
+        self.assertEqual(runnames, [["x", "cx"], ["y", "cz"], ["cy", "h"]])
+
 
 class TestDagLayers(QiskitTestCase):
     """Test finding layers on the dag"""


### PR DESCRIPTION
This PR modifies `DAGCircuit.collect_2q_circuits` to descend into the blocks of control flow ops.

Top level runs are collected as before. I still need to add some more structure and test against `ConsolidateBlocks`.

The following is not sufficient. 
~~Runs in the control flow op are appended. No new data  structure is introduced. The output is still a list of lists of nodes. In particular, information on which control flow op and which block within it the runs come from is lost. As far as I can tell, this is sufficient for the optimization passes.~~

TODO:

- [ ] add sufficient structure to support `ConsolidateBlocks`.
- [x] Need to do the other control flow ops. Only `if_else` is implemented.
- [ ] Doc string modification. Blocked by #10246 
- [ ] Release note (see https://github.com/Qiskit/qiskit-terra/issues/9425#issuecomment-1588539178)
- [ ] Tests

Closes: #9425

