### PR TITLE
Pin Aer to known good version

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,10 +39,10 @@ jobs:
       # Modern pip (23.1+) can error out if it doesn't have `wheel` and we ask for one
       # of these legacy packages.
       - name: Ensure basic build requirements
-        run: python -m pip install --upgrade pip setuptools wheel
+        run: python -m pip install -c constraints.txt --upgrade pip setuptools wheel
 
       - name: Build and install qiskit-terra
-        run: python -m pip install -e .
+        run: python -m pip install -c constraints.txt -e .
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-Cinstrument-coverage"
@@ -52,7 +52,7 @@ jobs:
       - name: Generate unittest coverage report
         run: |
           set -e
-          python -m pip install -r requirements-dev.txt qiskit-aer
+          python -m pip install -c constraints.txt -r requirements-dev.txt qiskit-aer
           stestr run
           # We set the --source-dir to '.' because we want all paths to appear relative to the repo
           # root (we need to combine them with the Python ones), but we only care about `grcov`

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,7 @@
 # jsonschema pinning needed due nbformat==5.1.3 using deprecated behaviour in
 # 4.0+. The pin can be removed after nbformat is updated.
 jsonschema==3.2.0
+
+# Aer 0.12.1 has a bad value in the results output that prevents pickling.
+# Remove pin once https://github.com/Qiskit/qiskit-aer/pull/1845 is released.
+qiskit-aer==0.12.0


### PR DESCRIPTION
### Summary

The release of Aer 0.12.1 included a bug in the results output that made the general `Result` object unpickleable.  Several places in our tests assume that these objects should be able to be pickled to be sent across a process boundary, or such like.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

See Qiskit/qiskit-aer#1845
