### PR TITLE
Fix BasicSwap FakeRun Typo

### DIFF
--- a/qiskit/transpiler/passes/routing/basic_swap.py
+++ b/qiskit/transpiler/passes/routing/basic_swap.py
@@ -60,7 +60,7 @@ class BasicSwap(TransformationPass):
             compatible with the DAG, or if the coupling_map=None.
         """
         if self.fake_run:
-            return self.fake_run(dag)
+            return self._fake_run(dag)
 
         new_dag = dag.copy_empty_like()
 

--- a/releasenotes/notes/fix-basicswap-fakerun-7469835327f6c8a1.yaml
+++ b/releasenotes/notes/fix-basicswap-fakerun-7469835327f6c8a1.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    Fixes a typo where BasicSwap called ``fake_run()`` the attribute instead of  ``_fake_run()`` the function.
+    Refer to `#10149 <hhttps://github.com/Qiskit/qiskit-terra/issues/10147>` for more details.

--- a/test/python/transpiler/test_basic_swap.py
+++ b/test/python/transpiler/test_basic_swap.py
@@ -370,8 +370,7 @@ class TestBasicSwap(QiskitTestCase):
         after = pass_.run(dag)
 
         self.assertEqual(circuit_to_dag(expected), after)
-      
-    
+
     def test_fake_run(self):
         """A fake run, doesn't change dag
         q0:--(+)-------.--
@@ -400,7 +399,7 @@ class TestBasicSwap(QiskitTestCase):
         circuit.cx(qr[3], qr[0])
         circuit.h(qr[3])
         circuit.cx(qr[0], qr[3])
- 
+
         fake_pm = PassManager([BasicSwap(coupling, fake_run=True)])
         real_pm = PassManager([BasicSwap(coupling, fake_run=False)])
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This is a repeat of #10149. This change is fixing a minor typo, where a variable was referenced instead of a method.


### Details and comments

I initially made changes directly on the main branch of my forked repository, and opened a PR from this branch. Instead, I should have first created a new branch from main, made my changes on this new branch, and then opened the PR from the new branch. This error led to conflicts with the upstream main branch, requiring me to reset and force push on main, which closed the original PR.

As far as I can tell, opening a new PR is the best practice for fixing this mistake.
