### PR TITLE
Make `circuit_to_dag` convert blocks in control flow ops to `DAGCircuit`

### DIFF
--- a/qiskit/circuit/controlflow/__init__.py
+++ b/qiskit/circuit/controlflow/__init__.py
@@ -21,3 +21,8 @@ from .if_else import IfElseOp
 from .while_loop import WhileLoopOp
 from .for_loop import ForLoopOp
 from .switch_case import SwitchCaseOp, CASE_DEFAULT
+
+_CONTROL_FLOW_OP_NAMES = {"for_loop", "if_else", "while_loop", "switch_case"}
+
+def is_control_flow_name(name):
+    return name in _CONTROL_FLOW_OP_NAMES

--- a/qiskit/circuit/controlflow/for_loop.py
+++ b/qiskit/circuit/controlflow/for_loop.py
@@ -18,6 +18,8 @@ from typing import Iterable, Optional, Union
 from qiskit.circuit.parameter import Parameter
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit.quantumcircuit import QuantumCircuit
+# from qiskit.utils.circuit import is_circuit
+
 from .control_flow import ControlFlowOp
 
 
@@ -78,10 +80,10 @@ class ForLoopOp(ControlFlowOp):
                 f"{type(loop_parameter)}."
             )
 
-        if not isinstance(body, QuantumCircuit):
+        if not is_circuit(body):
             raise CircuitError(
                 "ForLoopOp expects a body parameter to be of type "
-                f"QuantumCircuit, but received {type(body)}."
+                f"QuantumCircuit or DAGCircuit, but received {type(body)}."
             )
 
         if body.num_qubits != self.num_qubits or body.num_clbits != self.num_clbits:

--- a/qiskit/circuit/controlflow/for_loop.py
+++ b/qiskit/circuit/controlflow/for_loop.py
@@ -57,8 +57,10 @@ class ForLoopOp(ControlFlowOp):
         body: QuantumCircuit,
         label: Optional[str] = None,
     ):
-        num_qubits = body.num_qubits
-        num_clbits = body.num_clbits
+        from qiskit.converters.circuit import num_qubits as _num_qubits
+        from qiskit.converters.circuit import num_clbits as _num_clbits
+        num_qubits = _num_qubits(body)
+        num_clbits = _num_clbits(body)
 
         super().__init__(
             "for_loop", num_qubits, num_clbits, [indexset, loop_parameter, body], label=label
@@ -80,22 +82,25 @@ class ForLoopOp(ControlFlowOp):
             )
 
         from qiskit.converters.circuit import is_circuit
+        from qiskit.converters.circuit import num_qubits as _num_qubits
+        from qiskit.converters.circuit import num_clbits as _num_clbits
         if not is_circuit(body):
             raise CircuitError(
                 "ForLoopOp expects a body parameter to be of type "
                 f"QuantumCircuit or DAGCircuit, but received {type(body)}."
             )
 
-        if body.num_qubits != self.num_qubits or body.num_clbits != self.num_clbits:
+        if _num_qubits(body) != self.num_qubits or _num_clbits(body) != self.num_clbits:
             raise CircuitError(
                 "Attempted to assign a body parameter with a num_qubits or "
                 "num_clbits different than that of the ForLoopOp. "
                 f"ForLoopOp num_qubits/clbits: {self.num_qubits}/{self.num_clbits} "
-                f"Supplied body num_qubits/clbits: {body.num_qubits}/{body.num_clbits}."
+                f"Supplied body num_qubits/clbits: {_num_qubits(body)}/{_num_clbits(body)}."
             )
 
         if (
             loop_parameter is not None
+            and hasattr(body, "parameters")
             and loop_parameter not in body.parameters
             and loop_parameter.name in (p.name for p in body.parameters)
         ):

--- a/qiskit/circuit/controlflow/for_loop.py
+++ b/qiskit/circuit/controlflow/for_loop.py
@@ -18,7 +18,6 @@ from typing import Iterable, Optional, Union
 from qiskit.circuit.parameter import Parameter
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit.quantumcircuit import QuantumCircuit
-# from qiskit.utils.circuit import is_circuit
 
 from .control_flow import ControlFlowOp
 
@@ -80,6 +79,7 @@ class ForLoopOp(ControlFlowOp):
                 f"{type(loop_parameter)}."
             )
 
+        from qiskit.converters.circuit import is_circuit
         if not is_circuit(body):
             raise CircuitError(
                 "ForLoopOp expects a body parameter to be of type "

--- a/qiskit/circuit/controlflow/if_else.py
+++ b/qiskit/circuit/controlflow/if_else.py
@@ -16,6 +16,7 @@
 from typing import Optional, Tuple, Union, Iterable
 import itertools
 
+import qiskit
 from qiskit.circuit import ClassicalRegister, Clbit, QuantumCircuit
 from qiskit.circuit.instructionset import InstructionSet
 from qiskit.circuit.exceptions import CircuitError
@@ -78,10 +79,11 @@ class IfElseOp(ControlFlowOp):
     ):
         # Type checking generally left to @params.setter, but required here for
         # finding num_qubits and num_clbits.
-        if not isinstance(true_body, QuantumCircuit):
+        from qiskit.converters.circuit import is_circuit
+        if not is_circuit(true_body):
             raise CircuitError(
                 "IfElseOp expects a true_body parameter "
-                f"of type QuantumCircuit, but received {type(true_body)}."
+                f"of type QuantumCircuit or DAGCircuit, but received {type(true_body)}."
             )
 
         num_qubits = true_body.num_qubits
@@ -99,10 +101,11 @@ class IfElseOp(ControlFlowOp):
     def params(self, parameters):
         true_body, false_body = parameters
 
-        if not isinstance(true_body, QuantumCircuit):
+        from qiskit.converters.circuit import is_circuit
+        if not is_circuit(true_body):
             raise CircuitError(
                 "IfElseOp expects a true_body parameter of type "
-                f"QuantumCircuit, but received {type(true_body)}."
+                f"QuantumCircuit or DAGCircuit, but received {type(true_body)}."
             )
 
         if true_body.num_qubits != self.num_qubits or true_body.num_clbits != self.num_clbits:
@@ -114,10 +117,10 @@ class IfElseOp(ControlFlowOp):
             )
 
         if false_body is not None:
-            if not isinstance(false_body, QuantumCircuit):
+            if not is_circuit(false_body):
                 raise CircuitError(
                     "IfElseOp expects a false_body parameter of type "
-                    f"QuantumCircuit, but received {type(false_body)}."
+                    f"QuantumCircuit or DAGCircuit, but received {type(false_body)}."
                 )
 
             if false_body.num_qubits != self.num_qubits or false_body.num_clbits != self.num_clbits:

--- a/qiskit/circuit/controlflow/if_else.py
+++ b/qiskit/circuit/controlflow/if_else.py
@@ -80,14 +80,16 @@ class IfElseOp(ControlFlowOp):
         # Type checking generally left to @params.setter, but required here for
         # finding num_qubits and num_clbits.
         from qiskit.converters.circuit import is_circuit
+        from qiskit.converters.circuit import num_qubits as _num_qubits
+        from qiskit.converters.circuit import num_clbits as _num_clbits
         if not is_circuit(true_body):
             raise CircuitError(
                 "IfElseOp expects a true_body parameter "
                 f"of type QuantumCircuit or DAGCircuit, but received {type(true_body)}."
             )
 
-        num_qubits = true_body.num_qubits
-        num_clbits = true_body.num_clbits
+        num_qubits = _num_qubits(true_body)
+        num_clbits = _num_clbits(true_body)
 
         super().__init__("if_else", num_qubits, num_clbits, [true_body, false_body], label=label)
 
@@ -99,21 +101,23 @@ class IfElseOp(ControlFlowOp):
 
     @params.setter
     def params(self, parameters):
+        from qiskit.converters.circuit import is_circuit
+        from qiskit.converters.circuit import num_qubits as _num_qubits
+        from qiskit.converters.circuit import num_clbits as _num_clbits
         true_body, false_body = parameters
 
-        from qiskit.converters.circuit import is_circuit
         if not is_circuit(true_body):
             raise CircuitError(
                 "IfElseOp expects a true_body parameter of type "
                 f"QuantumCircuit or DAGCircuit, but received {type(true_body)}."
             )
 
-        if true_body.num_qubits != self.num_qubits or true_body.num_clbits != self.num_clbits:
+        if _num_qubits(true_body) != self.num_qubits or _num_clbits(true_body) != self.num_clbits:
             raise CircuitError(
                 "Attempted to assign a true_body parameter with a num_qubits or "
                 "num_clbits different than that of the IfElseOp. "
                 f"IfElseOp num_qubits/clbits: {self.num_qubits}/{self.num_clbits} "
-                f"Supplied body num_qubits/clbits: {true_body.num_qubits}/{true_body.num_clbits}."
+                f"Supplied body num_qubits/clbits: {_num_qubits(true_body)}/{_num_clbits(true_body)}."
             )
 
         if false_body is not None:
@@ -123,7 +127,7 @@ class IfElseOp(ControlFlowOp):
                     f"QuantumCircuit or DAGCircuit, but received {type(false_body)}."
                 )
 
-            if false_body.num_qubits != self.num_qubits or false_body.num_clbits != self.num_clbits:
+            if _num_qubits(false_body) != self.num_qubits or _num_clbits(false_body) != self.num_clbits:
                 raise CircuitError(
                     "Attempted to assign a false_body parameter with a num_qubits or "
                     "num_clbits different than that of the IfElseOp. "

--- a/qiskit/circuit/controlflow/switch_case.py
+++ b/qiskit/circuit/controlflow/switch_case.py
@@ -69,6 +69,8 @@ class SwitchCaseOp(ControlFlowOp):
         *,
         label: Optional[str] = None,
     ):
+
+        from qiskit.converters.circuit import is_circuit
         if not isinstance(target, (Clbit, ClassicalRegister)):
             raise CircuitError("the switch target must be a classical bit or register")
 
@@ -108,7 +110,7 @@ class SwitchCaseOp(ControlFlowOp):
                         )
                 self._case_map[value] = i
             self._label_spec.append(values)
-            if not isinstance(case_, QuantumCircuit):
+            if not is_circuit(case_):
                 raise CircuitError("case blocks must be QuantumCircuit instances")
             if id(case_) in case_ids:
                 raise CircuitError("ungrouped cases cannot point to the same block")

--- a/qiskit/circuit/controlflow/switch_case.py
+++ b/qiskit/circuit/controlflow/switch_case.py
@@ -71,6 +71,8 @@ class SwitchCaseOp(ControlFlowOp):
     ):
 
         from qiskit.converters.circuit import is_circuit
+        from qiskit.converters.circuit import num_qubits as _num_qubits
+        from qiskit.converters.circuit import num_clbits as _num_clbits
         if not isinstance(target, (Clbit, ClassicalRegister)):
             raise CircuitError("the switch target must be a classical bit or register")
 
@@ -116,8 +118,8 @@ class SwitchCaseOp(ControlFlowOp):
                 raise CircuitError("ungrouped cases cannot point to the same block")
             case_ids.add(id(case_))
             if num_qubits is None:
-                num_qubits, num_clbits = case_.num_qubits, case_.num_clbits
-            if case_.num_qubits != num_qubits or case_.num_clbits != num_clbits:
+                num_qubits, num_clbits = _num_qubits(case_), _num_clbits(case_)
+            if _num_qubits(case_) != num_qubits or _num_clbits(case_) != num_clbits:
                 raise CircuitError("incompatible bits between cases")
             self._params.append(case_)
         if not self._params:

--- a/qiskit/circuit/controlflow/while_loop.py
+++ b/qiskit/circuit/controlflow/while_loop.py
@@ -61,8 +61,10 @@ class WhileLoopOp(ControlFlowOp):
         body: QuantumCircuit,
         label: Optional[str] = None,
     ):
-        num_qubits = body.num_qubits
-        num_clbits = body.num_clbits
+        from qiskit.converters.circuit import num_qubits as _num_qubits
+        from qiskit.converters.circuit import num_clbits as _num_clbits
+        num_qubits = _num_qubits(body)
+        num_clbits = _num_clbits(body)
 
         super().__init__("while_loop", num_qubits, num_clbits, [body], label=label)
         self.condition = validate_condition(condition)
@@ -76,18 +78,20 @@ class WhileLoopOp(ControlFlowOp):
         (body,) = parameters
 
         from qiskit.converters.circuit import is_circuit
+        from qiskit.converters.circuit import num_qubits as _num_qubits
+        from qiskit.converters.circuit import num_clbits as _num_clbits
         if not is_circuit(body):
             raise CircuitError(
                 "WhileLoopOp expects a body parameter of type "
                 f"QuantumCircuit, but received {type(body)}."
             )
 
-        if body.num_qubits != self.num_qubits or body.num_clbits != self.num_clbits:
+        if _num_qubits(body) != self.num_qubits or _num_clbits(body) != self.num_clbits:
             raise CircuitError(
                 "Attempted to assign a body parameter with a num_qubits or "
                 "num_clbits different than that of the WhileLoopOp. "
                 f"WhileLoopOp num_qubits/clbits: {self.num_qubits}/{self.num_clbits} "
-                f"Supplied body num_qubits/clbits: {body.num_qubits}/{body.num_clbits}."
+                f"Supplied body num_qubits/clbits: {_num_qubits(body)}/{_num_clbits(body)}."
             )
 
         self._params = [body]

--- a/qiskit/circuit/controlflow/while_loop.py
+++ b/qiskit/circuit/controlflow/while_loop.py
@@ -75,7 +75,8 @@ class WhileLoopOp(ControlFlowOp):
     def params(self, parameters):
         (body,) = parameters
 
-        if not isinstance(body, QuantumCircuit):
+        from qiskit.converters.circuit import is_circuit
+        if not is_circuit(body):
             raise CircuitError(
                 "WhileLoopOp expects a body parameter of type "
                 f"QuantumCircuit, but received {type(body)}."

--- a/qiskit/converters/circuit.py
+++ b/qiskit/converters/circuit.py
@@ -1,10 +1,22 @@
 from qiskit import QuantumCircuit
-# from qiskit.dagcircuit import DAGCircuit
+from qiskit.dagcircuit import DAGCircuit
 
 def is_circuit(obj):
     """Return `True` if `obj` implements methods that a circuit must."""
-    return isinstance(obj, (QuantumCircuit,))
+    return isinstance(obj, (QuantumCircuit, DAGCircuit))
 
-# def is_circuit(obj):
-#     """Return `True` if `obj` implements methods that a circuit must."""
-#     return isinstance(obj, (QuantumCircuit, DAGCircuit))
+def num_qubits(obj):
+    if isinstance(obj, QuantumCircuit):
+        return obj.num_qubits
+    elif isinstance(obj, DAGCircuit):
+        return obj.num_qubits()
+    else:
+        raise RuntimeError(f"num_qubits does not support object of type {type(obj)}")
+
+def num_clbits(obj):
+    if isinstance(obj, QuantumCircuit):
+        return obj.num_clbits
+    elif isinstance(obj, DAGCircuit):
+        return obj.num_clbits()
+    else:
+        raise RuntimeError(f"num_clbits does not support object of type {type(obj)}")

--- a/qiskit/converters/circuit.py
+++ b/qiskit/converters/circuit.py
@@ -1,0 +1,10 @@
+from qiskit import QuantumCircuit
+# from qiskit.dagcircuit import DAGCircuit
+
+def is_circuit(obj):
+    """Return `True` if `obj` implements methods that a circuit must."""
+    return isinstance(obj, (QuantumCircuit,))
+
+# def is_circuit(obj):
+#     """Return `True` if `obj` implements methods that a circuit must."""
+#     return isinstance(obj, (QuantumCircuit, DAGCircuit))

--- a/qiskit/converters/circuit_to_dag.py
+++ b/qiskit/converters/circuit_to_dag.py
@@ -14,9 +14,9 @@
 import copy
 
 from qiskit.dagcircuit.dagcircuit import DAGCircuit
+from qiskit.circuit.controlflow import is_control_flow_name
 
-
-def circuit_to_dag(circuit, copy_operations=True):
+def circuit_to_dag(circuit, copy_operations=True, recurse=False):
     """Build a ``DAGCircuit`` object from a ``QuantumCircuit``.
 
     Args:
@@ -67,6 +67,8 @@ def circuit_to_dag(circuit, copy_operations=True):
         op = instruction.operation
         if copy_operations:
             op = copy.deepcopy(op)
+        if is_control_flow_name(op.name) and recurse and op.name == "if_else":
+            op.params = [circuit_to_dag(param, recurse=True) for param in op.params]
         dagcircuit.apply_operation_back(op, instruction.qubits, instruction.clbits)
 
     dagcircuit.duration = circuit.duration

--- a/qiskit/converters/dag_to_circuit.py
+++ b/qiskit/converters/dag_to_circuit.py
@@ -14,9 +14,9 @@
 import copy
 
 from qiskit.circuit import QuantumCircuit, CircuitInstruction
+from qiskit.circuit.controlflow import is_control_flow_name
 
-
-def dag_to_circuit(dag, copy_operations=True):
+def dag_to_circuit(dag, copy_operations=True, recurse=False):
     """Build a ``QuantumCircuit`` object from a ``DAGCircuit``.
 
     Args:
@@ -70,6 +70,8 @@ def dag_to_circuit(dag, copy_operations=True):
         op = node.op
         if copy_operations:
             op = copy.deepcopy(op)
+        if is_control_flow_name(op.name) and recurse and op.name == "if_else":
+            op.params = [dag_to_circuit(param, recurse=True) for param in op.params]
         circuit._append(CircuitInstruction(op, node.qargs, node.cargs))
 
     circuit.duration = dag.duration

--- a/qiskit/converters/dag_to_circuit.py
+++ b/qiskit/converters/dag_to_circuit.py
@@ -16,7 +16,7 @@ import copy
 from qiskit.circuit import QuantumCircuit, CircuitInstruction
 from qiskit.circuit.controlflow import is_control_flow_name
 
-def dag_to_circuit(dag, copy_operations=True, recurse=False):
+def dag_to_circuit(dag, copy_operations=True, recurse=True):
     """Build a ``QuantumCircuit`` object from a ``DAGCircuit``.
 
     Args:
@@ -54,6 +54,9 @@ def dag_to_circuit(dag, copy_operations=True, recurse=False):
            circuit.draw('mpl')
     """
 
+    if isinstance(dag, QuantumCircuit):
+        return dag
+
     name = dag.name or None
     circuit = QuantumCircuit(
         dag.qubits,
@@ -70,8 +73,10 @@ def dag_to_circuit(dag, copy_operations=True, recurse=False):
         op = node.op
         if copy_operations:
             op = copy.deepcopy(op)
-        if is_control_flow_name(op.name) and recurse and op.name == "if_else":
-            op.params = [dag_to_circuit(param, recurse=True) for param in op.params]
+        if is_control_flow_name(op.name) and recurse:
+#        if is_control_flow_name(op.name) and recurse and op.name in ("if_else", "for_loop", "while_loop", "switch_case"):
+            op = op.replace_blocks([dag_to_circuit(block, recurse=True) if block is not None else None for block in op.blocks])
+#            op.params = [dag_to_circuit(param, recurse=True) if param is not None else None for param in op.params]
         circuit._append(CircuitInstruction(op, node.qargs, node.cargs))
 
     circuit.duration = dag.duration

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -30,6 +30,7 @@ import numpy as np
 import rustworkx as rx
 
 from qiskit.circuit import ControlFlowOp, ForLoopOp, IfElseOp, WhileLoopOp, SwitchCaseOp
+from qiskit.circuit.controlflow import is_control_flow_name
 from qiskit.circuit.controlflow.condition import condition_bits
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit.quantumregister import QuantumRegister, Qubit
@@ -900,9 +901,7 @@ class DAGCircuit:
         """
         length = len(self._multi_graph) - 2 * len(self._wires)
         if not recurse:
-            if any(
-                x in self._op_names for x in ("for_loop", "while_loop", "if_else", "switch_case")
-            ):
+            if any(is_control_flow_name(op_name) for op_name in self._op_names):
                 raise DAGCircuitError(
                     "Size with control flow is ambiguous."
                     " You may use `recurse=True` to get a result,"
@@ -964,9 +963,7 @@ class DAGCircuit:
                 return node_lookup.get(target, 1)
 
         else:
-            if any(
-                x in self._op_names for x in ("for_loop", "while_loop", "if_else", "switch_case")
-            ):
+            if any(is_control_flow_name(op_name) for op_name in self._op_names):
                 raise DAGCircuitError(
                     "Depth with control flow is ambiguous."
                     " You may use `recurse=True` to get a result,"

--- a/qiskit/transpiler/passes/basis/unroller.py
+++ b/qiskit/transpiler/passes/basis/unroller.py
@@ -90,7 +90,8 @@ class Unroller(TransformationPass):
                         continue
 
             if isinstance(node.op, ControlFlowOp):
-                node.op = control_flow.map_blocks(self.run, node.op)
+                node.op = node.op.replace_blocks([self.run(block) for block in node.op.blocks])
+#                node.op = control_flow.map_blocks(self.run, node.op)
                 continue
 
             try:

--- a/qiskit/transpiler/preset_passmanagers/common.py
+++ b/qiskit/transpiler/preset_passmanagers/common.py
@@ -1,4 +1,3 @@
-# This code is part of Qiskit.
 #
 # (C) Copyright IBM 2022.
 #
@@ -53,7 +52,9 @@ from qiskit.transpiler.passes.layout.vf2_post_layout import VF2PostLayoutStopRea
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.layout import Layout
 
-_CONTROL_FLOW_OP_NAMES = {"for_loop", "if_else", "while_loop", "switch_case"}
+from qiskit.circuit.controlflow import _CONTROL_FLOW_OP_NAMES
+
+_CONTROL_FLOW_PROPERTIES = tuple(f"contains_{x}" for x in _CONTROL_FLOW_OP_NAMES)
 
 _ControlFlowState = collections.namedtuple("_ControlFlowState", ("working", "not_working"))
 
@@ -78,12 +79,10 @@ _CONTROL_FLOW_STATES = {
 
 
 def _has_control_flow(property_set):
-    return any(property_set[f"contains_{x}"] for x in _CONTROL_FLOW_OP_NAMES)
-
+    return any(property_set[x] for x in _CONTROL_FLOW_PROPERTIES)
 
 def _without_control_flow(property_set):
-    return not any(property_set[f"contains_{x}"] for x in _CONTROL_FLOW_OP_NAMES)
-
+    return not _has_control_flow(property_set)
 
 class _InvalidControlFlowForBackend:
     # Explicitly stateful closure to allow pickling.

--- a/qiskit/visualization/circuit/_utils.py
+++ b/qiskit/visualization/circuit/_utils.py
@@ -416,7 +416,7 @@ def _get_layered_instructions(
         qubits = new_qubits
         clbits = new_clbits
 
-    dag = circuit_to_dag(circuit)
+    dag = circuit_to_dag(circuit, recurse=False)
     dag.qubits = qubits
     dag.clbits = clbits
 


### PR DESCRIPTION
The two main data structures for storing a circuit in Qiskit are `QuantumCircuit` and `DAGCircuit`. They support lossless conversion. Control flow operations include blocks of "code" as subcircuits. Currently these are stored only as `QuantumCircuit`s. This necessitates an increasing amount of conversion between the two when manipulating circuits. In particular when doing transpilation.

This PR modifies `circuit_to_dag` and `dag_to_circuit` to recursive descend into blocks in control flow operations to convert them to the same type as the top-level structure.

There is a concomitant simplification of the code that (at present partially) supports control flow operations.