### PR TITLE
Fix qasm export for gates with same name

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -5090,6 +5090,11 @@ def _qasm2_define_custom_operation(operation, existing_gate_names, gates_to_defi
             bits_qasm = ",".join(qubit_labels[q] for q in instruction.qubits)
             statements.append(f"{new_operation.qasm()} {bits_qasm};")
         body_qasm = " ".join(statements)
+
+        if operation.name in gates_to_define:
+            new_name = f"{operation.name}_{id(operation)}"
+            operation = operation.copy(name=new_name)
+
         definition_qasm = f"gate {new_name}{parameters_qasm} {qubits_qasm} {{ {body_qasm} }}"
         gates_to_define[new_name] = (parameterized_operation, definition_qasm)
     return operation

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -5090,7 +5090,7 @@ def _qasm2_define_custom_operation(operation, existing_gate_names, gates_to_defi
             statements.append(f"{new_operation.qasm()} {bits_qasm};")
         body_qasm = " ".join(statements)
 
-        # if an inner gate has the same name as the actual gate, it needs to be renamed
+        # if an inner operation has the same name as the actual operation, it needs to be renamed
         if operation.name in gates_to_define:
             operation = _rename_operation(operation)
             new_name = operation.name
@@ -5099,11 +5099,13 @@ def _qasm2_define_custom_operation(operation, existing_gate_names, gates_to_defi
         gates_to_define[new_name] = (parameterized_operation, definition_qasm)
     return operation
 
+
 def _rename_operation(operation):
     """Returns the operation with a new name following this pattern: {operation name}_{operation id}"""
     new_name = f"{operation.name}_{id(operation)}"
     updated_operation = operation.copy(name=new_name)
     return updated_operation
+
 
 def _qasm_escape_name(name: str, prefix: str) -> str:
     """Returns a valid OpenQASM identifier, using `prefix` as a prefix if necessary.  `prefix` must

--- a/releasenotes/notes/fix-qasm-circuit-export-943394536bc0d292.yaml
+++ b/releasenotes/notes/fix-qasm-circuit-export-943394536bc0d292.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix wrong qasm exported when you have two inner gates sequentially added with the same name.
+    Before that, algorithms, like Grover's algorithm, wasn't possible to be exported with ``qasm()``
+    in a correct way.
+    Fixed: `#10162 <https://github.com/Qiskit/qiskit-terra/issues/10162>`

--- a/releasenotes/notes/fix-qasm-circuit-export-943394536bc0d292.yaml
+++ b/releasenotes/notes/fix-qasm-circuit-export-943394536bc0d292.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    Fix wrong qasm exported when you have two inner gates sequentially added with the same name.
-    Before that, algorithms, like Grover's algorithm, wasn't possible to be exported with ``qasm()``
-    in a correct way.
-    Fixed: `#10162 <https://github.com/Qiskit/qiskit-terra/issues/10162>`
+    Fixed the OpenQASM 2 output of :meth:`.QuantumCircuit.qasm` when a custom gate object contained
+    a gate with the same name.  Ideally this shouldn't happen for most gates, but complex algorithmic
+    operations like the :class:`.GroverOperator` class could produce such structures accidentally.
+    See `#10162 <https://github.com/Qiskit/qiskit-terra/issues/10162>`__.

--- a/test/python/circuit/test_circuit_qasm.py
+++ b/test/python/circuit/test_circuit_qasm.py
@@ -796,8 +796,11 @@ a_{} q[0],q[1],q[2];
 z q[0];
 z q[1];
 z q[2];
-""".format(gate_a_id, gate_a_id)
+""".format(
+            gate_a_id, gate_a_id
+        )
         self.assertEqual(qc.qasm(), expected_output)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/circuit/test_circuit_qasm.py
+++ b/test/python/circuit/test_circuit_qasm.py
@@ -790,14 +790,14 @@ custom q[0];
         expected_output = """OPENQASM 2.0;
 include "qelib1.inc";
 gate a q0,q1,q2 {{ h q0; h q1; h q2; }}
-gate a_{} q0,q1,q2 {{ a q0,q1,q2; x q0; x q1; x q2; }}
+gate a_{0} q0,q1,q2 {{ a q0,q1,q2; x q0; x q1; x q2; }}
 qreg q[3];
-a_{} q[0],q[1],q[2];
+a_{0} q[0],q[1],q[2];
 z q[0];
 z q[1];
 z q[2];
 """.format(
-            gate_a_id, gate_a_id
+            gate_a_id
         )
         self.assertEqual(qc.qasm(), expected_output)
 

--- a/test/python/circuit/test_circuit_qasm.py
+++ b/test/python/circuit/test_circuit_qasm.py
@@ -787,18 +787,17 @@ custom q[0];
 
         gate_a_id = id(qc.data[0].operation)
 
-        expected_output = """OPENQASM 2.0;
+        expected_output = f"""OPENQASM 2.0;
 include "qelib1.inc";
 gate a q0,q1,q2 {{ h q0; h q1; h q2; }}
-gate a_{0} q0,q1,q2 {{ a q0,q1,q2; x q0; x q1; x q2; }}
+gate a_{gate_a_id} q0,q1,q2 {{ a q0,q1,q2; x q0; x q1; x q2; }}
 qreg q[3];
-a_{0} q[0],q[1],q[2];
+a_{gate_a_id} q[0],q[1],q[2];
 z q[0];
 z q[1];
 z q[2];
-""".format(
-            gate_a_id
-        )
+"""
+
         self.assertEqual(qc.qasm(), expected_output)
 
 

--- a/test/python/circuit/test_circuit_qasm.py
+++ b/test/python/circuit/test_circuit_qasm.py
@@ -785,7 +785,7 @@ custom q[0];
         qc.append(gate_b, qubits_range)
         qc.z(qubits_range)
 
-        gate_a_id = id(gate_a)
+        gate_a_id = id(qc.data[0].operation)
 
         expected_output = """OPENQASM 2.0;
 include "qelib1.inc";

--- a/test/python/circuit/test_circuit_qasm.py
+++ b/test/python/circuit/test_circuit_qasm.py
@@ -768,6 +768,36 @@ custom q[0];
 """
         self.assertEqual(qasm, expected)
 
+    def test_sequencial_inner_gates_with_same_name(self):
+        """Test if inner gates sequencially added with the same name, result in the correct number of gates"""
+        qubits_range = range(3)
+
+        gate_a = QuantumCircuit(3, name="a")
+        gate_a.h(qubits_range)
+        gate_a = gate_a.to_instruction()
+
+        gate_b = QuantumCircuit(3, name="a")
+        gate_b.append(gate_a, qubits_range)
+        gate_b.x(qubits_range)
+        gate_b = gate_b.to_instruction()
+
+        qc = QuantumCircuit(3)
+        qc.append(gate_b, qubits_range)
+        qc.z(qubits_range)
+
+        gate_a_id = id(gate_a)
+
+        expected_output = """OPENQASM 2.0;
+include "qelib1.inc";
+gate a q0,q1,q2 {{ h q0; h q1; h q2; }}
+gate a_{} q0,q1,q2 {{ a q0,q1,q2; x q0; x q1; x q2; }}
+qreg q[3];
+a_{} q[0],q[1],q[2];
+z q[0];
+z q[1];
+z q[2];
+""".format(gate_a_id, gate_a_id)
+        self.assertEqual(qc.qasm(), expected_output)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/circuit/test_circuit_qasm.py
+++ b/test/python/circuit/test_circuit_qasm.py
@@ -769,7 +769,7 @@ custom q[0];
         self.assertEqual(qasm, expected)
 
     def test_sequencial_inner_gates_with_same_name(self):
-        """Test if inner gates sequencially added with the same name, result in the correct number of gates"""
+        """Test if inner gates sequentially added with the same name result in the correct qasm"""
         qubits_range = range(3)
 
         gate_a = QuantumCircuit(3, name="a")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Before this fix, the resulting qasm for a circuit with inner gates sequentially added with the same name, was wrong.
Some Algorithms, like Grover's algorithm, produce a wrong qasm by this problem.  

To fix it, just a name recheck was added!

### Details and comments
See #10162 for further information


