### PR TITLE
Fix deprecation warnings emitted by `import qiskit.primitives`

### DIFF
--- a/qiskit/primitives/backend_estimator.py
+++ b/qiskit/primitives/backend_estimator.py
@@ -16,6 +16,7 @@ Expectation value class
 from __future__ import annotations
 
 import copy
+import typing
 from collections.abc import Sequence
 from itertools import accumulate
 
@@ -23,7 +24,6 @@ import numpy as np
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.compiler import transpile
-from qiskit.opflow import PauliSumOp
 from qiskit.providers import BackendV1, BackendV2, Options
 from qiskit.quantum_info import Pauli, PauliList
 from qiskit.quantum_info.operators.base_operator import BaseOperator
@@ -33,6 +33,9 @@ from qiskit.transpiler import PassManager
 from .base import BaseEstimator, EstimatorResult
 from .primitive_job import PrimitiveJob
 from .utils import _circuit_key, _observable_key, init_observable
+
+if typing.TYPE_CHECKING:
+    from qiskit.opflow import PauliSumOp
 
 
 def _run_circuits(

--- a/qiskit/primitives/base/base_estimator.py
+++ b/qiskit/primitives/base/base_estimator.py
@@ -84,16 +84,19 @@ from abc import abstractmethod
 from collections.abc import Sequence
 from copy import copy
 from typing import Generic, TypeVar
+import typing
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.parametertable import ParameterView
-from qiskit.opflow import PauliSumOp
 from qiskit.providers import JobV1 as Job
 from qiskit.quantum_info.operators import SparsePauliOp
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 
 from ..utils import init_observable
 from .base_primitive import BasePrimitive
+
+if typing.TYPE_CHECKING:
+    from qiskit.opflow import PauliSumOp
 
 T = TypeVar("T", bound=Job)
 

--- a/qiskit/primitives/estimator.py
+++ b/qiskit/primitives/estimator.py
@@ -17,12 +17,12 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from typing import Any
+import typing
 
 import numpy as np
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.exceptions import QiskitError
-from qiskit.opflow import PauliSumOp
 from qiskit.quantum_info import Statevector
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 
@@ -34,6 +34,9 @@ from .utils import (
     bound_circuit_to_instruction,
     init_observable,
 )
+
+if typing.TYPE_CHECKING:
+    from qiskit.opflow import PauliSumOp
 
 
 class Estimator(BaseEstimator[PrimitiveJob[EstimatorResult]]):

--- a/qiskit/primitives/utils.py
+++ b/qiskit/primitives/utils.py
@@ -14,6 +14,8 @@ Utility functions for primitives
 """
 from __future__ import annotations
 
+import sys
+import typing
 from collections.abc import Iterable
 
 import numpy as np
@@ -21,10 +23,12 @@ import numpy as np
 from qiskit.circuit import Instruction, ParameterExpression, QuantumCircuit
 from qiskit.circuit.bit import Bit
 from qiskit.extensions.quantum_initializer.initializer import Initialize
-from qiskit.opflow import PauliSumOp
 from qiskit.quantum_info import SparsePauliOp, Statevector
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 from qiskit.quantum_info.operators.symplectic.base_pauli import BasePauli
+
+if typing.TYPE_CHECKING:
+    from qiskit.opflow import PauliSumOp
 
 
 def init_circuit(state: QuantumCircuit | Statevector) -> QuantumCircuit:
@@ -58,9 +62,18 @@ def init_observable(observable: BaseOperator | PauliSumOp | str) -> SparsePauliO
         TypeError: If the observable is a :class:`~qiskit.opflow.PauliSumOp` and has a parameterized
             coefficient.
     """
+    # This dance is to avoid importing the deprecated `qiskit.opflow` if the user hasn't already
+    # done so.  They can't hold a `qiskit.opflow.PauliSumOp` if `qiskit.opflow` hasn't been
+    # imported, and we don't want unrelated Qiskit library code to be responsible for the first
+    # import, so the deprecation warnings will show.
+    if "qiskit.opflow" in sys.modules:
+        pauli_sum_check = sys.modules["qiskit.opflow"].PauliSumOp
+    else:
+        pauli_sum_check = ()
+
     if isinstance(observable, SparsePauliOp):
         return observable
-    elif isinstance(observable, PauliSumOp):
+    elif isinstance(observable, pauli_sum_check):
         if isinstance(observable.coeff, ParameterExpression):
             raise TypeError(
                 f"Observable must have numerical coefficient, not {type(observable.coeff)}."

--- a/releasenotes/notes/fix-primitives-import-warnings-439e3e237fdb9d7b.yaml
+++ b/releasenotes/notes/fix-primitives-import-warnings-439e3e237fdb9d7b.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Importing :mod:`qiskit.primitives` will no longer cause deprecation warnings stemming from the
+    deprecated :mod:`qiskit.opflow` module.  These warnings would have been hidden to users by the
+    default Python filters, but triggered the eager import of :mod:`.opflow`, which meant that a
+    subsequent import by a user would not trigger the warnings.


### PR DESCRIPTION
### Summary

The primitives still need to support the legacy
`qiskit.opflow.PauliSumOp` while that object is deprecated but not removed.  However, we do not want the import of `qiskit.primitives` to need to import `opflow` to do that, since that will cause the deprecation warnings emitted by the import of `opflow` to be hidden (they'll be blamed on Qiskit library code, so hidden by default).

All type-hint usage we can hide behind the `TYPE_CHECKING` static analysis gate.  For cases where we were actively runtime type-checking an object, we can gate the `isinstance` check behind a check that `qiskit.opflow` is already imported; the object cannot be a `PauliSumOp` if the module isn't initialised.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->



### Details and comments

Fix #10245