### PR TITLE
Fix the bug when doing schedule with measurements for BackendV2

### DIFF
--- a/qiskit/compiler/scheduler.py
+++ b/qiskit/compiler/scheduler.py
@@ -96,7 +96,7 @@ def schedule(
             if backend is not None:
                 dt = backend.configuration().dt
 
-    schedule_config = ScheduleConfig(inst_map=inst_map, meas_map=meas_map, dt=dt)
+    schedule_config = ScheduleConfig(inst_map=inst_map, meas_map=meas_map, dt=dt, backend=backend)
     circuits = circuits if isinstance(circuits, list) else [circuits]
     schedules = parallel_map(schedule_circuit, circuits, (schedule_config, method))
     end_time = time()

--- a/qiskit/scheduler/config.py
+++ b/qiskit/scheduler/config.py
@@ -16,12 +16,13 @@ from typing import List
 
 from qiskit.pulse.instruction_schedule_map import InstructionScheduleMap
 from qiskit.pulse.utils import format_meas_map
+from qiskit.providers.backend import Backend
 
 
 class ScheduleConfig:
     """Configuration for pulse scheduling."""
 
-    def __init__(self, inst_map: InstructionScheduleMap, meas_map: List[List[int]], dt: float):
+    def __init__(self, inst_map: InstructionScheduleMap, meas_map: List[List[int]], dt: float, backend: Backend = None):
         """
         Container for information needed to schedule a QuantumCircuit into a pulse Schedule.
 
@@ -29,7 +30,9 @@ class ScheduleConfig:
             inst_map: The schedule definition of all gates supported on a backend.
             meas_map: A list of groups of qubits which have to be measured together.
             dt: Sample duration.
+            backend: The Backend of this configuration.
         """
         self.inst_map = inst_map
         self.meas_map = format_meas_map(meas_map)
         self.dt = dt
+        self.backend = backend

--- a/qiskit/scheduler/lowering.py
+++ b/qiskit/scheduler/lowering.py
@@ -97,6 +97,7 @@ def lower_gates(circuit: QuantumCircuit, schedule_config: ScheduleConfig) -> Lis
             qubit_mem_slots.update(acquire_excludes)
             meas_sched = measure(
                 qubits=qubits,
+                backend=schedule_config.backend,
                 inst_map=inst_map,
                 meas_map=schedule_config.meas_map,
                 qubit_mem_slots=qubit_mem_slots,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Currently, it does not support `BackendV2` for scheduling.
I check `backend.instruction_schedule_map`, and it seems that the difference is that `BackendV1` has the simultaneous measurement operation for all qubits, while `BackendV2` does not have such an operation.

### Details and comments

More details can be found in #10298 .

I solved this with simple changes.
Only added one argument for `ScheduleConfig`.

