### PR TITLE
Add standard 1q Pauli equivalences to standard library

### DIFF
--- a/qiskit/circuit/library/standard_gates/equivalence_library.py
+++ b/qiskit/circuit/library/standard_gates/equivalence_library.py
@@ -1188,6 +1188,15 @@ for inst, qargs, cargs in [
     def_x.append(inst, qargs, cargs)
 _sel.add_equivalence(XGate(), def_x)
 
+# XGate
+#                 global phase: π/2
+#    ┌───┐        ┌───┐┌───┐
+# q: ┤ X ├  ≡  q: ┤ Y ├┤ Z ├
+#    └───┘        └───┘└───┘
+def_x = QuantumCircuit(1, global_phase=pi / 2)
+def_x.y(0)
+def_x.z(0)
+_sel.add_equivalence(XGate(), def_x)
 
 # CXGate
 
@@ -1407,6 +1416,16 @@ for inst, qargs, cargs in [
     def_y.append(inst, qargs, cargs)
 _sel.add_equivalence(YGate(), def_y)
 
+# YGate
+#                 global phase: π/2
+#    ┌───┐        ┌───┐┌───┐
+# q: ┤ Y ├  ≡  q: ┤ Z ├┤ X ├
+#    └───┘        └───┘└───┘
+def_y = QuantumCircuit(1, global_phase=pi / 2)
+def_y.z(0)
+def_y.x(0)
+_sel.add_equivalence(YGate(), def_y)
+
 # CYGate
 #
 # q_0: ──■──     q_0: ─────────■───────
@@ -1433,7 +1452,6 @@ def_z = QuantumCircuit(q)
 def_z.append(U1Gate(pi), [q[0]], [])
 _sel.add_equivalence(ZGate(), def_z)
 
-# """
 # ZGate
 #
 #    ┌───┐        ┌───┐┌───┐
@@ -1446,6 +1464,16 @@ for inst, qargs, cargs in [
     (SGate(), [q[0]], []),
 ]:
     def_z.append(inst, qargs, cargs)
+_sel.add_equivalence(ZGate(), def_z)
+
+# ZGate
+#                 global phase: π/2
+#    ┌───┐        ┌───┐┌───┐
+# q: ┤ Z ├  ≡  q: ┤ X ├┤ Y ├
+#    └───┘        └───┘└───┘
+def_z = QuantumCircuit(1, global_phase=pi / 2)
+def_z.x(0)
+def_z.y(0)
 _sel.add_equivalence(ZGate(), def_z)
 
 # CZGate

--- a/releasenotes/notes/add-pauli-equivalences-74c635ec5c23ee33.yaml
+++ b/releasenotes/notes/add-pauli-equivalences-74c635ec5c23ee33.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    The transpiler's built-in :class:`.EquivalenceLibrary` has been taught the circular Pauli
+    relations :math:`X = iYZ`, :math:`Y = iZX` and :math:`Z = iXY`.  This should make transpiling
+    to constrained, and potentially incomplete, basis sets more reliable.
+    See `#10293 <https://github.com/Qiskit/qiskit-terra/issues/10293>`__ for more detail.

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -1653,7 +1653,7 @@ class TestTranspile(QiskitTestCase):
         qc.y(0)
         qc.barrier()
         qc.z(0)
-        transpiled = transpile(qc, basis_gates=basis)
+        transpiled = transpile(qc, basis_gates=basis, optimization_level=opt_level)
         self.assertGreaterEqual(set(basis) | {"barrier"}, transpiled.count_ops().keys())
         self.assertEqual(Operator(qc), Operator(transpiled))
 

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -1643,6 +1643,20 @@ class TestTranspile(QiskitTestCase):
             transpiled.layout.initial_layout, Layout({0: qc.qubits[1], 1: qc.qubits[0]})
         )
 
+    @combine(opt_level=[0, 1, 2, 3], basis=[["rz", "x"], ["rx", "z"], ["rz", "y"], ["ry", "x"]])
+    def test_paulis_to_constrained_1q_basis(self, opt_level, basis):
+        """Test that Pauli-gate circuits can be transpiled to constrained 1q bases that do not
+        contain any root-Pauli gates."""
+        qc = QuantumCircuit(1)
+        qc.x(0)
+        qc.barrier()
+        qc.y(0)
+        qc.barrier()
+        qc.z(0)
+        transpiled = transpile(qc, basis_gates=basis)
+        self.assertGreaterEqual(set(basis) | {"barrier"}, transpiled.count_ops().keys())
+        self.assertEqual(Operator(qc), Operator(transpiled))
+
 
 @ddt
 class TestPostTranspileIntegration(QiskitTestCase):


### PR DESCRIPTION
### Summary

This makes `transpile` a little more reliable in cases where people are trying to use it to convert to a constrained basis.  We can't necessarily recognise _all_ possible transformations into an incomplete basis, but simple Pauli relations are things people may well expect.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->



### Details and comments

Fix #10293.
