### PR TITLE
Fix Numpy 1.25 deprecations

### DIFF
--- a/qiskit/opflow/primitive_ops/pauli_op.py
+++ b/qiskit/opflow/primitive_ops/pauli_op.py
@@ -250,8 +250,8 @@ class PauliOp(PrimitiveOp):
                     bitstr = np.fromiter(bstr, dtype=int).astype(bool)
                     new_b_str = np.logical_xor(bitstr, corrected_x_bits)
                     new_str = "".join(map(str, 1 * new_b_str))
-                    z_factor = np.product(1 - 2 * np.logical_and(bitstr, corrected_z_bits))
-                    y_factor = np.product(
+                    z_factor = np.prod(1 - 2 * np.logical_and(bitstr, corrected_z_bits))
+                    y_factor = np.prod(
                         np.sqrt(1 - 2 * np.logical_and(corrected_x_bits, corrected_z_bits) + 0j)
                     )
                     new_dict[new_str] = (v * z_factor * y_factor) + new_dict.get(new_str, 0)

--- a/qiskit/opflow/primitive_ops/pauli_sum_op.py
+++ b/qiskit/opflow/primitive_ops/pauli_sum_op.py
@@ -334,8 +334,8 @@ class PauliSumOp(PrimitiveOp):
                     bitstr = np.fromiter(bstr, dtype=int).astype(bool)
                     new_b_str = np.logical_xor(bitstr, corrected_x_bits)
                     new_str = ["".join([str(b) for b in bs]) for bs in new_b_str.astype(int)]
-                    z_factor = np.product(1 - 2 * np.logical_and(bitstr, corrected_z_bits), axis=1)
-                    y_factor = np.product(
+                    z_factor = np.prod(1 - 2 * np.logical_and(bitstr, corrected_z_bits), axis=1)
+                    y_factor = np.prod(
                         np.sqrt(1 - 2 * np.logical_and(corrected_x_bits, corrected_z_bits) + 0j),
                         axis=1,
                     )

--- a/qiskit/quantum_info/operators/channel/chi.py
+++ b/qiskit/quantum_info/operators/channel/chi.py
@@ -83,9 +83,9 @@ class Chi(QuantumChannel):
             if dim_l != dim_r:
                 raise QiskitError("Invalid Chi-matrix input.")
             if input_dims:
-                input_dim = np.product(input_dims)
+                input_dim = np.prod(input_dims)
             if output_dims:
-                output_dim = np.product(input_dims)
+                output_dim = np.prod(input_dims)
             if output_dims is None and input_dims is None:
                 output_dim = int(np.sqrt(dim_l))
                 input_dim = dim_l // output_dim

--- a/qiskit/quantum_info/operators/channel/choi.py
+++ b/qiskit/quantum_info/operators/channel/choi.py
@@ -92,9 +92,9 @@ class Choi(QuantumChannel):
             if dim_l != dim_r:
                 raise QiskitError("Invalid Choi-matrix input.")
             if input_dims:
-                input_dim = np.product(input_dims)
+                input_dim = np.prod(input_dims)
             if output_dims:
-                output_dim = np.product(output_dims)
+                output_dim = np.prod(output_dims)
             if output_dims is None and input_dims is None:
                 output_dim = int(np.sqrt(dim_l))
                 input_dim = dim_l // output_dim

--- a/qiskit/quantum_info/operators/channel/ptm.py
+++ b/qiskit/quantum_info/operators/channel/ptm.py
@@ -91,11 +91,11 @@ class PTM(QuantumChannel):
             # Determine input and output dimensions
             dout, din = ptm.shape
             if input_dims:
-                input_dim = np.product(input_dims)
+                input_dim = np.prod(input_dims)
             else:
                 input_dim = int(np.sqrt(din))
             if output_dims:
-                output_dim = np.product(input_dims)
+                output_dim = np.prod(input_dims)
             else:
                 output_dim = int(np.sqrt(dout))
             if output_dim**2 != dout or input_dim**2 != din or input_dim != output_dim:

--- a/qiskit/quantum_info/operators/channel/stinespring.py
+++ b/qiskit/quantum_info/operators/channel/stinespring.py
@@ -102,7 +102,7 @@ class Stinespring(QuantumChannel):
                     raise QiskitError("Invalid Stinespring input.")
             input_dim = dim_right
             if output_dims:
-                output_dim = np.product(output_dims)
+                output_dim = np.prod(output_dims)
             else:
                 output_dim = input_dim
             if dim_left % output_dim != 0:

--- a/qiskit/quantum_info/operators/channel/superop.py
+++ b/qiskit/quantum_info/operators/channel/superop.py
@@ -212,7 +212,7 @@ class SuperOp(QuantumChannel):
         indices = [2 * num_indices - 1 - qubit for qubit in qargs] + [
             num_indices - 1 - qubit for qubit in qargs
         ]
-        final_shape = [np.product(output_dims) ** 2, np.product(input_dims) ** 2]
+        final_shape = [np.prod(output_dims) ** 2, np.prod(input_dims) ** 2]
         data = np.reshape(
             Operator._einsum_matmul(tensor, mat, indices, shift, right_mul), final_shape
         )
@@ -279,7 +279,7 @@ class SuperOp(QuantumChannel):
         output_dims = self.output_dims()
         for i, qubit in enumerate(qargs):
             new_dims[qubit] = output_dims[i]
-        new_dim = np.product(new_dims)
+        new_dim = np.prod(new_dims)
         # reshape tensor to density matrix
         tensor = np.reshape(tensor, (new_dim, new_dim))
         return DensityMatrix(tensor, dims=new_dims)

--- a/qiskit/quantum_info/operators/channel/transformations.py
+++ b/qiskit/quantum_info/operators/channel/transformations.py
@@ -396,7 +396,7 @@ def _reravel(mat1, mat2, shape1, shape2):
     left_dims = shape1[:2] + shape2[:2]
     right_dims = shape1[2:] + shape2[2:]
     tensor_shape = left_dims + right_dims
-    final_shape = (np.product(left_dims), np.product(right_dims))
+    final_shape = (np.prod(left_dims), np.prod(right_dims))
     # Tensor product matrices
     data = np.kron(mat1, mat2)
     data = np.reshape(

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -418,7 +418,7 @@ class Operator(LinearOp):
         tensor = np.reshape(self.data, self._op_shape.tensor_shape)
         mat = np.reshape(other.data, other._op_shape.tensor_shape)
         indices = [num_indices - 1 - qubit for qubit in qargs]
-        final_shape = [int(np.product(output_dims)), int(np.product(input_dims))]
+        final_shape = [int(np.prod(output_dims)), int(np.prod(input_dims))]
         data = np.reshape(
             Operator._einsum_matmul(tensor, mat, indices, shift, right_mul), final_shape
         )

--- a/qiskit/quantum_info/operators/random.py
+++ b/qiskit/quantum_info/operators/random.py
@@ -53,7 +53,7 @@ def random_unitary(dims, seed=None):
     else:
         random_state = default_rng(seed)
 
-    dim = np.product(dims)
+    dim = np.prod(dims)
     from scipy import stats
 
     mat = stats.unitary_group.rvs(dim, random_state=random_state)
@@ -84,7 +84,7 @@ def random_hermitian(dims, traceless=False, seed=None):
         rng = default_rng(seed)
 
     # Total dimension
-    dim = np.product(dims)
+    dim = np.prod(dims)
     from scipy import stats
 
     if traceless:
@@ -133,8 +133,8 @@ def random_quantum_channel(input_dims=None, output_dims=None, rank=None, seed=No
     elif output_dims is None:
         output_dims = input_dims
 
-    d_in = np.product(input_dims)
-    d_out = np.product(output_dims)
+    d_in = np.prod(input_dims)
+    d_out = np.prod(output_dims)
 
     # If rank is not specified set to the maximum rank for the
     # Choi matrix (input_dim * output_dim)

--- a/qiskit/quantum_info/operators/symplectic/pauli_list.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_list.py
@@ -197,7 +197,7 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
                 )
             base_z[i] = pauli._z
             base_x[i] = pauli._x
-            base_phase[i] = pauli._phase
+            base_phase[i] = pauli._phase.item()
         return base_z, base_x, base_phase
 
     def __repr__(self):
@@ -348,7 +348,7 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
             self._phase[index] = value._phase
         else:
             # Row and Qubit indexing
-            self._phase[index[0]] += value._phase
+            self._phase[index[0]] += value._phase.item()
             self._phase %= 4
 
     def delete(self, ind, qubit=False):

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -581,7 +581,7 @@ class DensityMatrix(QuantumState, TolerancesMixin):
               as an N-qubit state. If it is not a power of  two the state
               will have a single d-dimensional subsystem.
         """
-        size = np.product(dims)
+        size = np.prod(dims)
         state = np.zeros((size, size), dtype=complex)
         state[i, i] = 1.0
         return DensityMatrix(state, dims=dims)

--- a/qiskit/quantum_info/states/random.py
+++ b/qiskit/quantum_info/states/random.py
@@ -43,7 +43,7 @@ def random_statevector(dims, seed=None):
     else:
         rng = default_rng(seed)
 
-    dim = np.product(dims)
+    dim = np.prod(dims)
 
     # Random array over interval (0, 1]
     x = rng.random(dim)
@@ -74,7 +74,7 @@ def random_density_matrix(dims, rank=None, method="Hilbert-Schmidt", seed=None):
         QiskitError: if the method is not valid.
     """
     # Flatten dimensions
-    dim = np.product(dims)
+    dim = np.prod(dims)
     if rank is None:
         rank = dim  # Use full rank
 

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -723,7 +723,7 @@ class Statevector(QuantumState, TolerancesMixin):
               as an N-qubit state. If it is not a power of  two the state
               will have a single d-dimensional subsystem.
         """
-        size = np.product(dims)
+        size = np.prod(dims)
         state = np.zeros(size, dtype=complex)
         state[i] = 1.0
         return Statevector(state, dims=dims)

--- a/qiskit/result/mitigation/local_readout_mitigator.py
+++ b/qiskit/result/mitigation/local_readout_mitigator.py
@@ -275,7 +275,7 @@ class LocalReadoutMitigator(BaseReadoutMitigator):
         else:
             qubit_indices = [self._qubit_index[qubit] for qubit in qubits]
             gammas = self._gammas[qubit_indices]
-        return np.product(gammas)
+        return np.prod(gammas)
 
     def stddev_upper_bound(self, shots: int, qubits: List[int] = None):
         """Return an upper bound on standard deviation of expval estimator.

--- a/qiskit/synthesis/discrete_basis/commutator_decompose.py
+++ b/qiskit/synthesis/discrete_basis/commutator_decompose.py
@@ -89,11 +89,11 @@ def _solve_decomposition_angle(matrix: np.ndarray) -> float:
     trace = _compute_trace_so3(matrix)
     angle = math.acos((1 / 2) * (trace - 1))
 
+    lhs = math.sin(angle / 2)
+
     def objective(phi):
-        rhs = 2 * math.sin(phi / 2) ** 2
-        rhs *= math.sqrt(1 - math.sin(phi / 2) ** 4)
-        lhs = math.sin(angle / 2)
-        return rhs - lhs
+        sin_sq = np.sin(phi / 2) ** 2
+        return 2 * sin_sq * np.sqrt(1 - sin_sq**2) - lhs
 
     decomposition_angle = fsolve(objective, angle)[0]
     return decomposition_angle

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -179,7 +179,7 @@ def _error(circuit, target=None, qubits=None):
                 f"Target has no {inst.operation} on qubits {qubits}."
             ) from error
     # TODO:return np.sum(gate_durations)
-    return 1 - np.product(gate_fidelities)
+    return 1 - np.prod(gate_fidelities)
 
 
 def _preferred_direction(

--- a/test/python/quantum_info/operators/test_random.py
+++ b/test/python/quantum_info/operators/test_random.py
@@ -59,8 +59,8 @@ class TestRandomUnitary(QiskitTestCase):
         value = random_unitary(dim)
         self.assertIsInstance(value, Operator)
         self.assertTrue(value.is_unitary())
-        self.assertEqual(np.product(value.input_dims()), dim)
-        self.assertEqual(np.product(value.output_dims()), dim)
+        self.assertEqual(np.prod(value.input_dims()), dim)
+        self.assertEqual(np.prod(value.output_dims()), dim)
 
     def test_fixed_seed(self):
         """Test fixing seed fixes output"""
@@ -99,8 +99,8 @@ class TestRandomHermitian(QiskitTestCase):
         value = random_hermitian(dim)
         self.assertIsInstance(value, Operator)
         self.assertTrue(is_hermitian_matrix(value.data))
-        self.assertEqual(np.product(value.input_dims()), dim)
-        self.assertEqual(np.product(value.output_dims()), dim)
+        self.assertEqual(np.prod(value.input_dims()), dim)
+        self.assertEqual(np.prod(value.output_dims()), dim)
 
     def test_fixed_seed(self):
         """Test fixing seed fixes output"""
@@ -139,8 +139,8 @@ class TestRandomQuantumChannel(QiskitTestCase):
         value = random_quantum_channel(dim)
         self.assertIsInstance(value, Stinespring)
         self.assertTrue(value.is_cptp())
-        self.assertEqual(np.product(value.input_dims()), dim)
-        self.assertEqual(np.product(value.output_dims()), dim)
+        self.assertEqual(np.prod(value.input_dims()), dim)
+        self.assertEqual(np.prod(value.output_dims()), dim)
 
     @combine(rank=[1, 2, 3, 4])
     def test_rank(self, rank):

--- a/test/python/quantum_info/operators/test_scalar_op.py
+++ b/test/python/quantum_info/operators/test_scalar_op.py
@@ -58,7 +58,7 @@ class TestScalarOpInit(ScalarOpTestCase):
     def test_custom_dims(self):
         """Test custom dims."""
         dims = (2, 3, 4, 5)
-        dim = np.product(dims)
+        dim = np.prod(dims)
         op = ScalarOp(dims)
         self.assertEqual(op.dim, (dim, dim))
         self.assertEqual(op.input_dims(), dims)
@@ -84,7 +84,7 @@ class TestScalarOpMethods(ScalarOpTestCase):
     @combine(dims=[2, 4, 5, (2, 3), (3, 2)], coeff=[0, 1, 2.1 - 3.1j])
     def test_to_operator(self, dims, coeff):
         """Test to_matrix and to_operator methods (dims={dims}, coeff={coeff})"""
-        dim = np.product(dims)
+        dim = np.prod(dims)
         iden = ScalarOp(dims, coeff=coeff)
         target = Operator(coeff * np.eye(dim), input_dims=dims, output_dims=dims)
         with self.subTest(msg="to_operator"):

--- a/test/python/quantum_info/states/test_random.py
+++ b/test/python/quantum_info/states/test_random.py
@@ -41,7 +41,7 @@ class TestRandomStatevector(QiskitTestCase):
         value = random_statevector(dim)
         self.assertIsInstance(value, Statevector)
         self.assertTrue(value.is_valid())
-        self.assertEqual(np.product(value.dims()), dim)
+        self.assertEqual(np.prod(value.dims()), dim)
 
     def test_fixed_seed(self):
         """Test fixing seed fixes output"""
@@ -79,7 +79,7 @@ class TestRandomDensityMatrix(QiskitTestCase):
         value = random_density_matrix(dim, method=method)
         self.assertIsInstance(value, DensityMatrix)
         self.assertTrue(value.is_valid())
-        self.assertEqual(np.product(value.dims()), dim)
+        self.assertEqual(np.prod(value.dims()), dim)
 
     @combine(method=["Hilbert-Schmidt", "Bures"])
     def test_fixed_seed(self, method):


### PR DESCRIPTION
### Summary

Most of the effects we see are because of the removal of various aliases (`np.product` being a common one), but the new warning on implicit conversion of size-1 arrays to scalars that was initially found in parts of c463b3c has reared its head again too.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

This is not a complete resolution of #10305 because of larger issues with correctness of the `Isometry` code triggered by Numpy 1.25.  It should fix all the new deprecation warnings, though.
