### PR TITLE
fixes issue 4792

### DIFF
--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -173,6 +173,14 @@ def assemble(
         pulse_qobj=pulse_qobj,
         **run_config,
     )
+    # Verify that rep_time is chosen from the backend's rep_times
+    backend_rep_times = backend.configuration().rep_times
+
+    if rep_time is not None and rep_time not in backend_rep_times:
+        raise QiskitError(
+            "Invalid repetition time. Choose from the list provided by the backend: "
+            f"{backend_rep_times}"
+        )
 
     # assemble either circuits or schedules
     if all(isinstance(exp, QuantumCircuit) for exp in experiments):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes issue 4792




### Details and comments
- gives Qiskit Error if rep time is not set from available rep times for that backend
- the error is as follows : "Invalid repetition time. Choose from the list provided by the backend: "
f"{backend_rep_times}"

