### PR TITLE
Deprecate namespace packaging hooks

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -73,8 +73,8 @@ import qiskit.circuit.reset
 # to be placed *before* the wrapper imports or any non-import code AND *before*
 # importing the package you want to allow extensions for (in this case `backends`).
 
-# TODO: Remove when we drop support for importing qiskit-aer < 0.11.0 and the
-# qiskit-ibmq-provider package is retired/archived.
+# Support for the deprecated extending this namespace.
+# Remove this after 0.46.0 release
 __path__ = pkgutil.extend_path(__path__, __name__)
 
 # Please note these are global instances, not modules.

--- a/qiskit/providers/__init__.py
+++ b/qiskit/providers/__init__.py
@@ -777,7 +777,6 @@ from qiskit.providers.exceptions import (
 from qiskit.providers.jobstatus import JobStatus
 
 
-# Allow extending this namespace.
-# TODO: Remove when we drop support for importing qiskit-aer < 0.11.0 and the
-# qiskit-ibmq-provider package is retired/archived.
+# Support for the deprecated extending this namespace.
+# Remove this after 0.46.0 release
 __path__ = pkgutil.extend_path(__path__, __name__)

--- a/releasenotes/notes/deprecate-namespace-a2ac600f140755e2.yaml
+++ b/releasenotes/notes/deprecate-namespace-a2ac600f140755e2.yaml
@@ -1,0 +1,17 @@
+---
+deprecations:
+  - |
+    Extensions of the ``qiskit`` and ``qiskit.providers`` namepace by external
+    packages is now deprecated and the hook points enabling this will be
+    removed in a future release. In the past the Qiskit project was composed
+    of elements that extended a shared namespace and these hook points enabled
+    doing that. However, it was not inteneded for these interfaces to ever be
+    used by other packages. Now that the overall Qiskit package is no longer
+    using that packaging model leaving the possiblity for these extensions
+    carry more risk than benefits and is therefore being deprecated for
+    future removal. If you're maintaining a package that extends the Qiskit
+    namespace (i.e. your users import from ``qiskit.x`` or
+    ``qiskit.providers.y``) you should transition to using a standalone
+    Python namespace for your package. No warning will be raised as part of this
+    because there is no method to inject a warning at the packaging level that
+    would be required to warn external packages of this change.


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit official deprecates the pkgutil namespace hooks that are used for extending the `qiskit.*` and `qiskit.providers.*` namespaces from external packages. These were previously used to enable the elements packaging model where different parts of qiskit lived in separate python packages under a shared namespace. This is no longer being used and leaving the namespace extendable by external packages carries a risk of issues or other accidental cross-interactions when an external package gets loaded as part of Qiskit.

### Details and comments

Fixes #8809