### PR TITLE
pyupgrade and fix imports

### DIFF
--- a/qiskit/algorithms/amplitude_amplifiers/amplitude_amplifier.py
+++ b/qiskit/algorithms/amplitude_amplifiers/amplitude_amplifier.py
@@ -26,7 +26,7 @@ class AmplitudeAmplifier(ABC):
     """The interface for amplification algorithms."""
 
     @abstractmethod
-    def amplify(self, amplification_problem: AmplificationProblem) -> "AmplitudeAmplifierResult":
+    def amplify(self, amplification_problem: AmplificationProblem) -> AmplitudeAmplifierResult:
         """Run the amplification algorithm.
 
         Args:

--- a/qiskit/algorithms/amplitude_amplifiers/grover.py
+++ b/qiskit/algorithms/amplitude_amplifiers/grover.py
@@ -243,7 +243,7 @@ class Grover(AmplitudeAmplifier):
         """
         self._sampler = sampler
 
-    def amplify(self, amplification_problem: AmplificationProblem) -> "GroverResult":
+    def amplify(self, amplification_problem: AmplificationProblem) -> GroverResult:
         """Run the Grover algorithm.
 
         Args:

--- a/qiskit/algorithms/amplitude_estimators/ae.py
+++ b/qiskit/algorithms/amplitude_estimators/ae.py
@@ -282,7 +282,7 @@ class AmplitudeEstimation(AmplitudeEstimator):
 
     @staticmethod
     def compute_mle(
-        result: "AmplitudeEstimationResult", apply_post_processing: bool = False
+        result: AmplitudeEstimationResult, apply_post_processing: bool = False
     ) -> float:
         """Compute the Maximum Likelihood Estimator (MLE).
 
@@ -339,7 +339,7 @@ class AmplitudeEstimation(AmplitudeEstimator):
 
         return a_opt
 
-    def estimate(self, estimation_problem: EstimationProblem) -> "AmplitudeEstimationResult":
+    def estimate(self, estimation_problem: EstimationProblem) -> AmplitudeEstimationResult:
         """Run the amplitude estimation algorithm on provided estimation problem.
 
         Args:
@@ -444,7 +444,7 @@ class AmplitudeEstimation(AmplitudeEstimator):
 
     @staticmethod
     def compute_confidence_interval(
-        result: "AmplitudeEstimationResult", alpha: float = 0.05, kind: str = "likelihood_ratio"
+        result: AmplitudeEstimationResult, alpha: float = 0.05, kind: str = "likelihood_ratio"
     ) -> tuple[float, float]:
         """Compute the (1 - alpha) confidence interval.
 

--- a/qiskit/algorithms/amplitude_estimators/amplitude_estimator.py
+++ b/qiskit/algorithms/amplitude_estimators/amplitude_estimator.py
@@ -26,7 +26,7 @@ class AmplitudeEstimator(ABC):
     """The Amplitude Estimation interface."""
 
     @abstractmethod
-    def estimate(self, estimation_problem: EstimationProblem) -> "AmplitudeEstimatorResult":
+    def estimate(self, estimation_problem: EstimationProblem) -> AmplitudeEstimatorResult:
         """Run the amplitude estimation algorithm.
 
         Args:

--- a/qiskit/algorithms/amplitude_estimators/estimation_problem.py
+++ b/qiskit/algorithms/amplitude_estimators/estimation_problem.py
@@ -196,7 +196,7 @@ class EstimationProblem:
         """
         self._grover_operator = grover_operator
 
-    def rescale(self, scaling_factor: float) -> "EstimationProblem":
+    def rescale(self, scaling_factor: float) -> EstimationProblem:
         """Rescale the good state amplitude in the estimation problem.
 
         Args:

--- a/qiskit/algorithms/amplitude_estimators/fae.py
+++ b/qiskit/algorithms/amplitude_estimators/fae.py
@@ -244,7 +244,7 @@ class FasterAmplitudeEstimation(AmplitudeEstimator):
 
         return circuit
 
-    def estimate(self, estimation_problem: EstimationProblem) -> "FasterAmplitudeEstimationResult":
+    def estimate(self, estimation_problem: EstimationProblem) -> FasterAmplitudeEstimationResult:
         """Run the amplitude estimation algorithm on provided estimation problem.
 
         Args:

--- a/qiskit/algorithms/amplitude_estimators/iae.py
+++ b/qiskit/algorithms/amplitude_estimators/iae.py
@@ -321,9 +321,7 @@ class IterativeAmplitudeEstimation(AmplitudeEstimator):
 
             return prob
 
-    def estimate(
-        self, estimation_problem: EstimationProblem
-    ) -> "IterativeAmplitudeEstimationResult":
+    def estimate(self, estimation_problem: EstimationProblem) -> IterativeAmplitudeEstimationResult:
         """Run the amplitude estimation algorithm on provided estimation problem.
 
         Args:

--- a/qiskit/algorithms/amplitude_estimators/mlae.py
+++ b/qiskit/algorithms/amplitude_estimators/mlae.py
@@ -214,7 +214,7 @@ class MaximumLikelihoodAmplitudeEstimation(AmplitudeEstimator):
 
     @staticmethod
     def compute_confidence_interval(
-        result: "MaximumLikelihoodAmplitudeEstimationResult",
+        result: MaximumLikelihoodAmplitudeEstimationResult,
         alpha: float,
         kind: str = "fisher",
         apply_post_processing: bool = False,
@@ -306,7 +306,7 @@ class MaximumLikelihoodAmplitudeEstimation(AmplitudeEstimator):
 
     def estimate(
         self, estimation_problem: EstimationProblem
-    ) -> "MaximumLikelihoodAmplitudeEstimationResult":
+    ) -> MaximumLikelihoodAmplitudeEstimationResult:
         """Run the amplitude estimation algorithm on provided estimation problem.
 
         Args:
@@ -481,7 +481,7 @@ def _safe_max(array, default=(np.pi / 2)):
 
 
 def _compute_fisher_information(
-    result: "MaximumLikelihoodAmplitudeEstimationResult",
+    result: MaximumLikelihoodAmplitudeEstimationResult,
     num_sum_terms: int | None = None,
     observed: bool = False,
 ) -> float:

--- a/qiskit/algorithms/eigen_solvers/eigen_solver.py
+++ b/qiskit/algorithms/eigen_solvers/eigen_solver.py
@@ -48,7 +48,7 @@ class Eigensolver(ABC):
     @abstractmethod
     def compute_eigenvalues(
         self, operator: OperatorBase, aux_operators: ListOrDict[OperatorBase] | None = None
-    ) -> "EigensolverResult":
+    ) -> EigensolverResult:
         """
         Computes eigenvalues. Operator and aux_operators can be supplied here and
         if not None will override any already set into algorithm so it can be reused with

--- a/qiskit/algorithms/eigensolvers/eigensolver.py
+++ b/qiskit/algorithms/eigensolvers/eigensolver.py
@@ -38,7 +38,7 @@ class Eigensolver(ABC):
         self,
         operator: BaseOperator | PauliSumOp,
         aux_operators: ListOrDict[BaseOperator | PauliSumOp] | None = None,
-    ) -> "EigensolverResult":
+    ) -> EigensolverResult:
         """
         Computes the minimum eigenvalue. The ``operator`` and ``aux_operators`` are supplied here.
         While an ``operator`` is required by algorithms, ``aux_operators`` are optional.

--- a/qiskit/algorithms/minimum_eigen_solvers/minimum_eigen_solver.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/minimum_eigen_solver.py
@@ -50,7 +50,7 @@ class MinimumEigensolver(ABC):
     @abstractmethod
     def compute_minimum_eigenvalue(
         self, operator: OperatorBase, aux_operators: ListOrDict[OperatorBase] | None = None
-    ) -> "MinimumEigensolverResult":
+    ) -> MinimumEigensolverResult:
         """
         Computes minimum eigenvalue. Operator and aux_operators can be supplied here and
         if not None will override any already set into algorithm so it can be reused with

--- a/qiskit/algorithms/minimum_eigensolvers/minimum_eigensolver.py
+++ b/qiskit/algorithms/minimum_eigensolvers/minimum_eigensolver.py
@@ -36,7 +36,7 @@ class MinimumEigensolver(ABC):
         self,
         operator: BaseOperator | PauliSumOp,
         aux_operators: ListOrDict[BaseOperator | PauliSumOp] | None = None,
-    ) -> "MinimumEigensolverResult":
+    ) -> MinimumEigensolverResult:
         """
         Computes the minimum eigenvalue. The ``operator`` and ``aux_operators`` are supplied here.
         While an ``operator`` is required by algorithms, ``aux_operators`` are optional.

--- a/qiskit/algorithms/minimum_eigensolvers/sampling_mes.py
+++ b/qiskit/algorithms/minimum_eigensolvers/sampling_mes.py
@@ -32,7 +32,7 @@ class SamplingMinimumEigensolver(ABC):
         self,
         operator: BaseOperator | PauliSumOp,
         aux_operators: ListOrDict[BaseOperator | PauliSumOp] | None = None,
-    ) -> "SamplingMinimumEigensolverResult":
+    ) -> SamplingMinimumEigensolverResult:
         """Compute the minimum eigenvalue of a diagonal operator.
 
         Args:

--- a/qiskit/algorithms/phase_estimators/ipe.py
+++ b/qiskit/algorithms/phase_estimators/ipe.py
@@ -177,7 +177,7 @@ class IterativePhaseEstimation(PhaseEstimator):
     # pylint: disable=signature-differs
     def estimate(
         self, unitary: QuantumCircuit, state_preparation: QuantumCircuit
-    ) -> "IterativePhaseEstimationResult":
+    ) -> IterativePhaseEstimationResult:
         """
         Estimate the eigenphase of the input unitary and initial-state pair.
 

--- a/qiskit/algorithms/phase_estimators/phase_estimation_scale.py
+++ b/qiskit/algorithms/phase_estimators/phase_estimation_scale.py
@@ -117,7 +117,7 @@ class PhaseEstimationScale:
     @classmethod
     def from_pauli_sum(
         cls, pauli_sum: SummedOp | PauliSumOp | SparsePauliOp | Operator
-    ) -> "PhaseEstimationScale" | float:
+    ) -> PhaseEstimationScale | float:
         """Create a PhaseEstimationScale from a `SummedOp` representing a sum of Pauli Operators.
 
         It is assumed that the ``pauli_sum`` is the sum of ``PauliOp`` objects. The bound on

--- a/qiskit/algorithms/phase_estimators/phase_estimator.py
+++ b/qiskit/algorithms/phase_estimators/phase_estimator.py
@@ -34,7 +34,7 @@ class PhaseEstimator(ABC):
         self,
         unitary: QuantumCircuit,
         state_preparation: QuantumCircuit | None = None,
-    ) -> "PhaseEstimatorResult":
+    ) -> PhaseEstimatorResult:
         """Estimate the phase."""
         raise NotImplementedError
 

--- a/qiskit/algorithms/time_evolvers/variational/solvers/ode/var_qte_ode_solver.py
+++ b/qiskit/algorithms/time_evolvers/variational/solvers/ode/var_qte_ode_solver.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from functools import partial
-from typing import Type
 
 import numpy as np
 from scipy.integrate import OdeSolver, solve_ivp
@@ -31,7 +30,7 @@ class VarQTEOdeSolver:
         self,
         init_params: Sequence[float],
         ode_function: AbstractOdeFunction,
-        ode_solver: Type[OdeSolver] | str = ForwardEulerSolver,
+        ode_solver: type[OdeSolver] | str = ForwardEulerSolver,
         num_timesteps: int | None = None,
     ) -> None:
         """

--- a/qiskit/algorithms/time_evolvers/variational/var_qite.py
+++ b/qiskit/algorithms/time_evolvers/variational/var_qite.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Type, Callable
+from typing import Callable
 
 import numpy as np
 from scipy.integrate import OdeSolver
@@ -78,7 +78,7 @@ class VarQITE(VarQTE, ImaginaryTimeEvolver):
         initial_parameters: Mapping[Parameter, float] | Sequence[float],
         variational_principle: ImaginaryVariationalPrinciple | None = None,
         estimator: BaseEstimator | None = None,
-        ode_solver: Type[OdeSolver] | str = ForwardEulerSolver,
+        ode_solver: type[OdeSolver] | str = ForwardEulerSolver,
         lse_solver: Callable[[np.ndarray, np.ndarray], np.ndarray] | None = None,
         num_timesteps: int | None = None,
         imag_part_tol: float = 1e-7,

--- a/qiskit/algorithms/time_evolvers/variational/var_qrte.py
+++ b/qiskit/algorithms/time_evolvers/variational/var_qrte.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Type, Callable
+from typing import Callable
 
 import numpy as np
 from scipy.integrate import OdeSolver
@@ -79,7 +79,7 @@ class VarQRTE(VarQTE, RealTimeEvolver):
         initial_parameters: Mapping[Parameter, float] | Sequence[float],
         variational_principle: RealVariationalPrinciple | None = None,
         estimator: BaseEstimator | None = None,
-        ode_solver: Type[OdeSolver] | str = ForwardEulerSolver,
+        ode_solver: type[OdeSolver] | str = ForwardEulerSolver,
         lse_solver: Callable[[np.ndarray, np.ndarray], np.ndarray] | None = None,
         num_timesteps: int | None = None,
         imag_part_tol: float = 1e-7,

--- a/qiskit/algorithms/time_evolvers/variational/var_qte.py
+++ b/qiskit/algorithms/time_evolvers/variational/var_qte.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 from abc import ABC
 from collections.abc import Mapping, Callable, Sequence
-from typing import Type
 
 import numpy as np
 from scipy.integrate import OdeSolver
@@ -78,7 +77,7 @@ class VarQTE(ABC):
         initial_parameters: Mapping[Parameter, float] | Sequence[float],
         variational_principle: VariationalPrinciple,
         estimator: BaseEstimator,
-        ode_solver: Type[OdeSolver] | str = ForwardEulerSolver,
+        ode_solver: type[OdeSolver] | str = ForwardEulerSolver,
         lse_solver: Callable[[np.ndarray, np.ndarray], np.ndarray] | None = None,
         num_timesteps: int | None = None,
         imag_part_tol: float = 1e-7,

--- a/qiskit/circuit/controlflow/control_flow.py
+++ b/qiskit/circuit/controlflow/control_flow.py
@@ -32,7 +32,7 @@ class ControlFlowOp(Instruction, ABC):
         pass
 
     @abstractmethod
-    def replace_blocks(self, blocks: Iterable[QuantumCircuit]) -> "ControlFlowOp":
+    def replace_blocks(self, blocks: Iterable[QuantumCircuit]) -> ControlFlowOp:
         """Replace blocks and return new instruction.
         Args:
             blocks: Tuple of QuantumCircuits to replace in instruction.

--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 import copy
-from typing import Optional, Union
 
 from qiskit.circuit.exceptions import CircuitError
 
@@ -33,11 +32,11 @@ class ControlledGate(Gate):
         name: str,
         num_qubits: int,
         params: list,
-        label: Optional[str] = None,
-        num_ctrl_qubits: Optional[int] = 1,
-        definition: Optional["QuantumCircuit"] = None,
-        ctrl_state: Optional[Union[int, str]] = None,
-        base_gate: Optional[Gate] = None,
+        label: str | None = None,
+        num_ctrl_qubits: int | None = 1,
+        definition: QuantumCircuit | None = None,
+        ctrl_state: int | str | None = None,
+        base_gate: Gate | None = None,
     ):
         """Create a new ControlledGate. In the new gate the first ``num_ctrl_qubits``
         of the gate are the controls.
@@ -128,7 +127,7 @@ class ControlledGate(Gate):
             return super().definition
 
     @definition.setter
-    def definition(self, excited_def: "QuantumCircuit"):
+    def definition(self, excited_def: QuantumCircuit):
         """Set controlled gate definition with closed controls.
 
         Args:
@@ -195,7 +194,7 @@ class ControlledGate(Gate):
         return self._ctrl_state
 
     @ctrl_state.setter
-    def ctrl_state(self, ctrl_state: Union[int, str, None]):
+    def ctrl_state(self, ctrl_state: int | str | None):
         """Set the control state of this gate.
 
         Args:
@@ -259,6 +258,6 @@ class ControlledGate(Gate):
             and self.definition == other.definition
         )
 
-    def inverse(self) -> "ControlledGate":
+    def inverse(self) -> ControlledGate:
         """Invert this gate by calling inverse on the base gate."""
         return self.base_gate.inverse().control(self.num_ctrl_qubits, ctrl_state=self.ctrl_state)

--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -85,10 +85,10 @@ class Gate(Instruction):
         unitary_power = unitary @ np.diag(decomposition_power) @ unitary.conj().T
         return UnitaryGate(unitary_power, label=f"{self.name}^{exponent}")
 
-    def __pow__(self, exponent: float) -> "Gate":
+    def __pow__(self, exponent: float) -> Gate:
         return self.power(exponent)
 
-    def _return_repeat(self, exponent: float) -> "Gate":
+    def _return_repeat(self, exponent: float) -> Gate:
         return Gate(name=f"{self.name}*{exponent}", num_qubits=self.num_qubits, params=self.params)
 
     def control(

--- a/qiskit/circuit/instructionset.py
+++ b/qiskit/circuit/instructionset.py
@@ -79,7 +79,7 @@ class InstructionSet:
             self._instructions[i] = instruction.replace(operation=instruction.operation.inverse())
         return self
 
-    def c_if(self, classical: Clbit | ClassicalRegister | int, val: int) -> "InstructionSet":
+    def c_if(self, classical: Clbit | ClassicalRegister | int, val: int) -> InstructionSet:
         """Set a classical equality condition on all the instructions in this set between the
         :obj:`.ClassicalRegister` or :obj:`.Clbit` ``classical`` and value ``val``.
 

--- a/qiskit/circuit/library/arithmetic/piecewise_polynomial_pauli_rotations.py
+++ b/qiskit/circuit/library/arithmetic/piecewise_polynomial_pauli_rotations.py
@@ -13,7 +13,6 @@
 """Piecewise-polynomially-controlled Pauli rotations."""
 
 from __future__ import annotations
-from typing import List, Optional
 import numpy as np
 
 from qiskit.circuit import QuantumRegister, AncillaRegister, QuantumCircuit
@@ -89,9 +88,9 @@ class PiecewisePolynomialPauliRotations(FunctionalPauliRotations):
 
     def __init__(
         self,
-        num_state_qubits: Optional[int] = None,
-        breakpoints: Optional[List[int]] = None,
-        coeffs: Optional[List[List[float]]] = None,
+        num_state_qubits: int | None = None,
+        breakpoints: list[int] | None = None,
+        coeffs: list[list[float]] | None = None,
         basis: str = "Y",
         name: str = "pw_poly",
     ) -> None:
@@ -120,7 +119,7 @@ class PiecewisePolynomialPauliRotations(FunctionalPauliRotations):
         super().__init__(num_state_qubits=num_state_qubits, basis=basis, name=name)
 
     @property
-    def breakpoints(self) -> List[int]:
+    def breakpoints(self) -> list[int]:
         """The breakpoints of the piecewise polynomial function.
 
         The function is polynomial in the intervals ``[point_i, point_{i+1}]`` where the last
@@ -139,7 +138,7 @@ class PiecewisePolynomialPauliRotations(FunctionalPauliRotations):
         return self._breakpoints
 
     @breakpoints.setter
-    def breakpoints(self, breakpoints: List[int]) -> None:
+    def breakpoints(self, breakpoints: list[int]) -> None:
         """Set the breakpoints.
 
         Args:
@@ -152,7 +151,7 @@ class PiecewisePolynomialPauliRotations(FunctionalPauliRotations):
             self._reset_registers(self.num_state_qubits)
 
     @property
-    def coeffs(self) -> List[List[float]]:
+    def coeffs(self) -> list[list[float]]:
         """The coefficients of the polynomials.
 
         Returns:
@@ -161,7 +160,7 @@ class PiecewisePolynomialPauliRotations(FunctionalPauliRotations):
         return self._coeffs
 
     @coeffs.setter
-    def coeffs(self, coeffs: List[List[float]]) -> None:
+    def coeffs(self, coeffs: list[list[float]]) -> None:
         """Set the polynomials.
 
         Args:
@@ -180,7 +179,7 @@ class PiecewisePolynomialPauliRotations(FunctionalPauliRotations):
             self._reset_registers(self.num_state_qubits)
 
     @property
-    def mapped_coeffs(self) -> List[List[float]]:
+    def mapped_coeffs(self) -> list[list[float]]:
         """The coefficients mapped to the internal representation, since we only compare
         x>=breakpoint.
 
@@ -247,7 +246,7 @@ class PiecewisePolynomialPauliRotations(FunctionalPauliRotations):
 
         return valid
 
-    def _reset_registers(self, num_state_qubits: Optional[int]) -> None:
+    def _reset_registers(self, num_state_qubits: int | None) -> None:
         """Reset the registers."""
         self.qregs = []
 

--- a/qiskit/circuit/library/boolean_logic/quantum_or.py
+++ b/qiskit/circuit/library/boolean_logic/quantum_or.py
@@ -13,7 +13,6 @@
 
 """Implementations of boolean logic quantum circuits."""
 from __future__ import annotations
-from typing import List, Optional
 
 from qiskit.circuit import QuantumRegister, QuantumCircuit, AncillaRegister
 from qiskit.circuit.library.standard_gates import MCXGate
@@ -53,7 +52,7 @@ class OR(QuantumCircuit):
     def __init__(
         self,
         num_variable_qubits: int,
-        flags: Optional[List[int]] = None,
+        flags: list[int] | None = None,
         mcx_mode: str = "noancilla",
     ) -> None:
         """Create a new logical OR circuit.

--- a/qiskit/circuit/library/grover_operator.py
+++ b/qiskit/circuit/library/grover_operator.py
@@ -13,7 +13,6 @@
 """The Grover operator."""
 
 from __future__ import annotations
-from typing import List, Optional, Union
 import numpy
 
 from qiskit.circuit import QuantumCircuit, QuantumRegister, AncillaRegister
@@ -162,10 +161,10 @@ class GroverOperator(QuantumCircuit):
 
     def __init__(
         self,
-        oracle: Union[QuantumCircuit, Statevector],
-        state_preparation: Optional[QuantumCircuit] = None,
-        zero_reflection: Optional[Union[QuantumCircuit, DensityMatrix, Operator]] = None,
-        reflection_qubits: Optional[List[int]] = None,
+        oracle: QuantumCircuit | Statevector,
+        state_preparation: QuantumCircuit | None = None,
+        zero_reflection: QuantumCircuit | DensityMatrix | Operator | None = None,
+        reflection_qubits: list[int] | None = None,
         insert_barriers: bool = False,
         mcx_mode: str = "noancilla",
         name: str = "Q",
@@ -287,7 +286,7 @@ class GroverOperator(QuantumCircuit):
 
 # TODO use the oracle compiler or the bit string oracle
 def _zero_reflection(
-    num_state_qubits: int, qubits: List[int], mcx_mode: Optional[str] = None
+    num_state_qubits: int, qubits: list[int], mcx_mode: str | None = None
 ) -> QuantumCircuit:
     qr_state = QuantumRegister(num_state_qubits, "state")
     reflection = QuantumCircuit(qr_state, name="S_0")

--- a/qiskit/circuit/library/n_local/n_local.py
+++ b/qiskit/circuit/library/n_local/n_local.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import typing
-from typing import Union, Optional, Any, Sequence, Callable, Mapping
+from typing import Any, Sequence, Callable, Mapping
 from itertools import combinations
 
 import numpy
@@ -270,17 +270,17 @@ class NLocal(BlueprintCircuit):
     @property
     def entanglement(
         self,
-    ) -> Union[
-        str,
-        list[str],
-        list[list[str]],
-        list[int],
-        list[list[int]],
-        list[list[list[int]]],
-        list[list[list[list[int]]]],
-        Callable[[int], str],
-        Callable[[int], list[list[int]]],
-    ]:
+    ) -> (
+        str
+        | list[str]
+        | list[list[str]]
+        | list[int]
+        | list[list[int]]
+        | list[list[list[int]]]
+        | list[list[list[list[int]]]]
+        | Callable[[int], str]
+        | Callable[[int], list[list[int]]]
+    ):
         """Get the entanglement strategy.
 
         Returns:
@@ -292,19 +292,18 @@ class NLocal(BlueprintCircuit):
     @entanglement.setter
     def entanglement(
         self,
-        entanglement: Optional[
-            Union[
-                str,
-                list[str],
-                list[list[str]],
-                list[int],
-                list[list[int]],
-                list[list[list[int]]],
-                list[list[list[list[int]]]],
-                Callable[[int], str],
-                Callable[[int], list[list[int]]],
-            ]
-        ],
+        entanglement: None
+        | (
+            str
+            | list[str]
+            | list[list[str]]
+            | list[int]
+            | list[list[int]]
+            | list[list[list[int]]]
+            | list[list[list[list[int]]]]
+            | Callable[[int], str]
+            | Callable[[int], list[list[int]]]
+        ),
     ) -> None:
         """Set the entanglement strategy.
 
@@ -711,10 +710,10 @@ class NLocal(BlueprintCircuit):
 
     def add_layer(
         self,
-        other: Union["NLocal", qiskit.circuit.Instruction, QuantumCircuit],
+        other: NLocal | qiskit.circuit.Instruction | QuantumCircuit,
         entanglement: list[int] | str | list[list[int]] | None = None,
         front: bool = False,
-    ) -> "NLocal":
+    ) -> NLocal:
         """Append another layer to the NLocal.
 
         Args:

--- a/qiskit/circuit/library/n_local/two_local.py
+++ b/qiskit/circuit/library/n_local/two_local.py
@@ -13,7 +13,7 @@
 """The two-local gate circuit."""
 
 from __future__ import annotations
-from typing import Union, Optional, List, Callable, Any, Sequence
+from typing import Callable, Any, Sequence
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.circuit import Gate, Instruction, Parameter
@@ -158,20 +158,18 @@ class TwoLocal(NLocal):
 
     def __init__(
         self,
-        num_qubits: Optional[int] = None,
-        rotation_blocks: Optional[
-            Union[str, List[str], type, List[type], QuantumCircuit, List[QuantumCircuit]]
-        ] = None,
-        entanglement_blocks: Optional[
-            Union[str, List[str], type, List[type], QuantumCircuit, List[QuantumCircuit]]
-        ] = None,
-        entanglement: Union[str, List[List[int]], Callable[[int], List[int]]] = "full",
+        num_qubits: int | None = None,
+        rotation_blocks: None
+        | (str | list[str] | type | list[type] | QuantumCircuit | list[QuantumCircuit]) = None,
+        entanglement_blocks: None
+        | (str | list[str] | type | list[type] | QuantumCircuit | list[QuantumCircuit]) = None,
+        entanglement: str | list[list[int]] | Callable[[int], list[int]] = "full",
         reps: int = 3,
         skip_unentangled_qubits: bool = False,
         skip_final_rotation_layer: bool = False,
         parameter_prefix: str = "θ",
         insert_barriers: bool = False,
-        initial_state: Optional[Any] = None,
+        initial_state: Any | None = None,
         name: str = "TwoLocal",
     ) -> None:
         """Construct a new two-local circuit.
@@ -224,7 +222,7 @@ class TwoLocal(NLocal):
             name=name,
         )
 
-    def _convert_to_block(self, layer: Union[str, type, Gate, QuantumCircuit]) -> QuantumCircuit:
+    def _convert_to_block(self, layer: str | type | Gate | QuantumCircuit) -> QuantumCircuit:
         """For a layer provided as str (e.g. ``'ry'``) or type (e.g. :class:`.RYGate`) this function
          returns the
          according layer type along with the number of parameters (e.g. ``(RYGate, 1)``).

--- a/qiskit/circuit/library/pauli_evolution.py
+++ b/qiskit/circuit/library/pauli_evolution.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-from typing import Union, Optional
 import numpy as np
 
 from qiskit.circuit.gate import Gate
@@ -80,9 +79,9 @@ class PauliEvolutionGate(Gate):
     def __init__(
         self,
         operator,
-        time: Union[int, float, ParameterExpression] = 1.0,
-        label: Optional[str] = None,
-        synthesis: Optional[EvolutionSynthesis] = None,
+        time: int | float | ParameterExpression = 1.0,
+        label: str | None = None,
+        synthesis: EvolutionSynthesis | None = None,
     ) -> None:
         """
         Args:
@@ -115,7 +114,7 @@ class PauliEvolutionGate(Gate):
         self.synthesis = synthesis
 
     @property
-    def time(self) -> Union[float, ParameterExpression]:
+    def time(self) -> float | ParameterExpression:
         """Return the evolution time as stored in the gate parameters.
 
         Returns:
@@ -124,7 +123,7 @@ class PauliEvolutionGate(Gate):
         return self.params[0]
 
     @time.setter
-    def time(self, time: Union[float, ParameterExpression]) -> None:
+    def time(self, time: float | ParameterExpression) -> None:
         """Set the evolution time.
 
         Args:
@@ -137,8 +136,8 @@ class PauliEvolutionGate(Gate):
         self.definition = self.synthesis.synthesize(self)
 
     def validate_parameter(
-        self, parameter: Union[int, float, ParameterExpression]
-    ) -> Union[float, ParameterExpression]:
+        self, parameter: int | float | ParameterExpression
+    ) -> float | ParameterExpression:
         """Gate parameters should be int, float, or ParameterExpression"""
         if isinstance(parameter, int):
             parameter = float(parameter)

--- a/qiskit/circuit/library/phase_oracle.py
+++ b/qiskit/circuit/library/phase_oracle.py
@@ -15,7 +15,7 @@
 # Needed to avoid type hints from erroring when `classicalfunction` might not be available.
 from __future__ import annotations
 
-from typing import Union, Callable, Optional, TYPE_CHECKING
+from typing import Callable, TYPE_CHECKING
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.utils import optionals as _optionals
@@ -50,8 +50,8 @@ class PhaseOracle(QuantumCircuit):
 
     def __init__(
         self,
-        expression: Union[str, ClassicalElement],
-        synthesizer: Optional[Callable[[BooleanExpression], QuantumCircuit]] = None,
+        expression: str | ClassicalElement,
+        synthesizer: Callable[[BooleanExpression], QuantumCircuit] | None = None,
         var_order: list = None,
     ) -> None:
         """Creates a PhaseOracle object

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -12,7 +12,6 @@
 
 """X, CX, CCX and multi-controlled X gates."""
 from __future__ import annotations
-from typing import Optional, Union, Type
 from math import ceil, pi
 import numpy
 from qiskit.circuit.controlledgate import ControlledGate
@@ -72,7 +71,7 @@ class XGate(Gate):
         |1\rangle \rightarrow |0\rangle
     """
 
-    def __init__(self, label: Optional[str] = None):
+    def __init__(self, label: str | None = None):
         """Create new X gate."""
         super().__init__("x", 1, [], label=label)
 
@@ -95,8 +94,8 @@ class XGate(Gate):
     def control(
         self,
         num_ctrl_qubits: int = 1,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: str | int | None = None,
     ):
         """Return a (multi-)controlled-X gate.
 
@@ -187,7 +186,7 @@ class CXGate(ControlledGate):
         `|a, b\rangle \rightarrow |a, a \oplus b\rangle`
     """
 
-    def __init__(self, label: Optional[str] = None, ctrl_state: Optional[Union[str, int]] = None):
+    def __init__(self, label: str | None = None, ctrl_state: str | int | None = None):
         """Create new CX gate."""
         super().__init__(
             "cx", 2, [], num_ctrl_qubits=1, label=label, ctrl_state=ctrl_state, base_gate=XGate()
@@ -221,8 +220,8 @@ class CXGate(ControlledGate):
     def control(
         self,
         num_ctrl_qubits: int = 1,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: str | int | None = None,
     ):
         """Return a controlled-X gate with more control lines.
 
@@ -325,7 +324,7 @@ class CCXGate(ControlledGate):
 
     """
 
-    def __init__(self, label: Optional[str] = None, ctrl_state: Optional[Union[str, int]] = None):
+    def __init__(self, label: str | None = None, ctrl_state: str | int | None = None):
         """Create new CCX gate."""
         super().__init__(
             "ccx", 3, [], num_ctrl_qubits=2, label=label, ctrl_state=ctrl_state, base_gate=XGate()
@@ -377,8 +376,8 @@ class CCXGate(ControlledGate):
     def control(
         self,
         num_ctrl_qubits: int = 1,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: str | int | None = None,
     ):
         """Controlled version of this gate.
 
@@ -427,7 +426,7 @@ class RCCXGate(Gate):
     with the :meth:`~qiskit.circuit.QuantumCircuit.rccx` method.
     """
 
-    def __init__(self, label: Optional[str] = None):
+    def __init__(self, label: str | None = None):
         """Create a new simplified CCX gate."""
         super().__init__("rccx", 3, [], label=label)
 
@@ -494,8 +493,8 @@ class C3SXGate(ControlledGate):
 
     def __init__(
         self,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: str | int | None = None,
     ):
         """Create a new 3-qubit controlled sqrt-X gate.
 
@@ -591,8 +590,8 @@ class C3XGate(ControlledGate):
 
     def __init__(
         self,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: str | int | None = None,
     ):
         """Create a new 3-qubit controlled X gate."""
         super().__init__(
@@ -675,8 +674,8 @@ class C3XGate(ControlledGate):
     def control(
         self,
         num_ctrl_qubits: int = 1,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: str | int | None = None,
     ):
         """Controlled version of this gate.
 
@@ -723,7 +722,7 @@ class RC3XGate(Gate):
     with the :meth:`~qiskit.circuit.QuantumCircuit.rcccx` method.
     """
 
-    def __init__(self, label: Optional[str] = None):
+    def __init__(self, label: str | None = None):
         """Create a new RC3X gate."""
         super().__init__("rcccx", 4, [], label=label)
 
@@ -816,7 +815,7 @@ class C4XGate(ControlledGate):
         [2] Maslov, 2015. https://arxiv.org/abs/1508.03273
     """
 
-    def __init__(self, label: Optional[str] = None, ctrl_state: Optional[Union[str, int]] = None):
+    def __init__(self, label: str | None = None, ctrl_state: str | int | None = None):
         """Create a new 4-qubit controlled X gate."""
         super().__init__(
             "mcx", 5, [], num_ctrl_qubits=4, label=label, ctrl_state=ctrl_state, base_gate=XGate()
@@ -875,8 +874,8 @@ class C4XGate(ControlledGate):
     def control(
         self,
         num_ctrl_qubits: int = 1,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: str | int | None = None,
     ):
         """Controlled version of this gate.
 
@@ -918,9 +917,9 @@ class MCXGate(ControlledGate):
 
     def __new__(
         cls,
-        num_ctrl_qubits: Optional[int] = None,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        num_ctrl_qubits: int | None = None,
+        label: str | None = None,
+        ctrl_state: str | int | None = None,
     ):
         """Create a new MCX instance.
 
@@ -929,7 +928,7 @@ class MCXGate(ControlledGate):
         """
         # The CXGate and CCXGate will be implemented for all modes of the MCX, and
         # the C3XGate and C4XGate will be implemented in the MCXGrayCode class.
-        explicit: dict[int, Type[ControlledGate]] = {1: CXGate, 2: CCXGate}
+        explicit: dict[int, type[ControlledGate]] = {1: CXGate, 2: CCXGate}
         if num_ctrl_qubits in explicit:
             gate_class = explicit[num_ctrl_qubits]
             gate = gate_class.__new__(gate_class, label=label, ctrl_state=ctrl_state)
@@ -941,8 +940,8 @@ class MCXGate(ControlledGate):
     def __init__(
         self,
         num_ctrl_qubits: int,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: str | int | None = None,
         _name="mcx",
     ):
         """Create new MCX gate."""
@@ -994,8 +993,8 @@ class MCXGate(ControlledGate):
     def control(
         self,
         num_ctrl_qubits: int = 1,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: str | int | None = None,
     ):
         """Return a multi-controlled-X gate with more control lines.
 
@@ -1026,9 +1025,9 @@ class MCXGrayCode(MCXGate):
 
     def __new__(
         cls,
-        num_ctrl_qubits: Optional[int] = None,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        num_ctrl_qubits: int | None = None,
+        label: str | None = None,
+        ctrl_state: str | int | None = None,
     ):
         """Create a new MCXGrayCode instance"""
         # if 1 to 4 control qubits, create explicit gates
@@ -1044,8 +1043,8 @@ class MCXGrayCode(MCXGate):
     def __init__(
         self,
         num_ctrl_qubits: int,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: str | int | None = None,
     ):
         super().__init__(num_ctrl_qubits, label=label, ctrl_state=ctrl_state, _name="mcx_gray")
 
@@ -1078,8 +1077,8 @@ class MCXRecursive(MCXGate):
     def __init__(
         self,
         num_ctrl_qubits: int,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: str | int | None = None,
     ):
         super().__init__(num_ctrl_qubits, label=label, ctrl_state=ctrl_state, _name="mcx_recursive")
 
@@ -1139,10 +1138,10 @@ class MCXVChain(MCXGate):
 
     def __new__(
         cls,
-        num_ctrl_qubits: Optional[int] = None,
+        num_ctrl_qubits: int | None = None,
         dirty_ancillas: bool = False,  # pylint: disable=unused-argument
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: str | int | None = None,
     ):
         """Create a new MCX instance.
 
@@ -1154,8 +1153,8 @@ class MCXVChain(MCXGate):
         self,
         num_ctrl_qubits: int,
         dirty_ancillas: bool = False,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: str | int | None = None,
     ):
         super().__init__(num_ctrl_qubits, label=label, ctrl_state=ctrl_state, _name="mcx_vchain")
         self._dirty_ancillas = dirty_ancillas

--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -64,7 +64,7 @@ class ParameterExpression:
             self._name_map = {p.name: p for p in self._parameters}
         return self._name_map
 
-    def conjugate(self) -> "ParameterExpression":
+    def conjugate(self) -> ParameterExpression:
         """Return the conjugate."""
         if _optionals.HAS_SYMENGINE:
             import symengine
@@ -76,7 +76,7 @@ class ParameterExpression:
             conjugated = ParameterExpression(self._parameter_symbols, self._symbol_expr.conjugate())
         return conjugated
 
-    def assign(self, parameter, value: ParameterValueType) -> "ParameterExpression":
+    def assign(self, parameter, value: ParameterValueType) -> ParameterExpression:
         """
         Assign one parameter to a value, which can either be numeric or another parameter
         expression.
@@ -94,7 +94,7 @@ class ParameterExpression:
 
     def bind(
         self, parameter_values: dict, allow_unknown_parameters: bool = False
-    ) -> "ParameterExpression":
+    ) -> ParameterExpression:
         """Binds the provided set of parameters to their corresponding values.
 
         Args:
@@ -150,7 +150,7 @@ class ParameterExpression:
 
     def subs(
         self, parameter_map: dict, allow_unknown_parameters: bool = False
-    ) -> "ParameterExpression":
+    ) -> ParameterExpression:
         """Returns a new Expression with replacement Parameters.
 
         Args:
@@ -243,7 +243,7 @@ class ParameterExpression:
 
     def _apply_operation(
         self, operation: Callable, other: ParameterValueType, reflected: bool = False
-    ) -> "ParameterExpression":
+    ) -> ParameterExpression:
         """Base method implementing math operations between Parameters and
         either a constant or a second ParameterExpression.
 
@@ -287,7 +287,7 @@ class ParameterExpression:
 
         return out_expr
 
-    def gradient(self, param) -> Union["ParameterExpression", complex]:
+    def gradient(self, param) -> ParameterExpression | complex:
         """Get the derivative of a parameter expression w.r.t. a specified parameter expression.
 
         Args:

--- a/qiskit/circuit/tools/pi_check.py
+++ b/qiskit/circuit/tools/pi_check.py
@@ -104,7 +104,7 @@ def pi_check(inpt, eps=1e-9, output="text", ndigits=None):
             if power[0].shape[0]:
                 if output == "qasm":
                     if ndigits is None:
-                        str_out = "{}".format(single_inpt)
+                        str_out = f"{single_inpt}"
                     else:
                         str_out = "{:.{}g}".format(single_inpt, ndigits)
                 elif output == "latex":
@@ -119,7 +119,7 @@ def pi_check(inpt, eps=1e-9, output="text", ndigits=None):
         # multiple or power of pi, since no fractions will exceed MAX_FRAC * pi
         if abs(single_inpt) >= (MAX_FRAC * np.pi):
             if ndigits is None:
-                str_out = "{}".format(single_inpt)
+                str_out = f"{single_inpt}"
             else:
                 str_out = "{:.{}g}".format(single_inpt, ndigits)
             return str_out
@@ -169,7 +169,7 @@ def pi_check(inpt, eps=1e-9, output="text", ndigits=None):
 
         # Nothing found
         if ndigits is None:
-            str_out = "{}".format(single_inpt)
+            str_out = f"{single_inpt}"
         else:
             str_out = "{:.{}g}".format(single_inpt, ndigits)
         return str_out

--- a/qiskit/opflow/expectations/aer_pauli_expectation.py
+++ b/qiskit/opflow/expectations/aer_pauli_expectation.py
@@ -60,7 +60,7 @@ class AerPauliExpectation(ExpectationBase):
 
         if isinstance(operator, OperatorStateFn) and operator.is_measurement:
             if isinstance(operator.primitive, ListOp):
-                is_herm = all((op.is_hermitian() for op in operator.primitive.oplist))
+                is_herm = all(op.is_hermitian() for op in operator.primitive.oplist)
             else:
                 is_herm = operator.primitive.is_hermitian()
 

--- a/qiskit/passmanager/flow_controllers.py
+++ b/qiskit/passmanager/flow_controllers.py
@@ -81,7 +81,7 @@ class FlowController:
     @classmethod
     def controller_factory(
         cls,
-        passes: Sequence[GenericPass | "FlowController"],
+        passes: Sequence[GenericPass | FlowController],
         options: dict,
         **partial_controller,
     ):

--- a/qiskit/passmanager/passmanager.py
+++ b/qiskit/passmanager/passmanager.py
@@ -147,7 +147,9 @@ class BasePassManager(ABC):
                 return new_passmanager
             except PassManagerError as ex:
                 raise TypeError(
-                    "unsupported operand type + for %s and %s" % (self.__class__, other.__class__)
+                    "unsupported operand type + for {} and {}".format(
+                        self.__class__, other.__class__
+                    )
                 ) from ex
 
     def _normalize_passes(

--- a/qiskit/primitives/backend_sampler.py
+++ b/qiskit/primitives/backend_sampler.py
@@ -140,7 +140,7 @@ class BackendSampler(BaseSampler[PrimitiveJob[SamplerResult]]):
         bound_circuits = [
             transpiled_circuits[i]
             if len(value) == 0
-            else transpiled_circuits[i].bind_parameters((dict(zip(self._parameters[i], value))))
+            else transpiled_circuits[i].bind_parameters(dict(zip(self._parameters[i], value)))
             for i, value in zip(circuits, parameter_values)
         ]
         bound_circuits = self._bound_pass_manager_run(bound_circuits)

--- a/qiskit/primitives/base/estimator_result.py
+++ b/qiskit/primitives/base/estimator_result.py
@@ -42,5 +42,5 @@ class EstimatorResult(BasePrimitiveResult):
         metadata (list[dict]): List of the metadata.
     """
 
-    values: "np.ndarray[Any, np.dtype[np.float64]]"
+    values: np.ndarray[Any, np.dtype[np.float64]]
     metadata: list[dict[str, Any]]

--- a/qiskit/providers/backend_compat.py
+++ b/qiskit/providers/backend_compat.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import List, Iterable, Any, Dict, Optional
+from typing import Iterable, Any
 
 from qiskit.exceptions import QiskitError
 
@@ -34,7 +34,7 @@ def convert_to_target(
     configuration: BackendConfiguration,
     properties: BackendProperties = None,
     defaults: PulseDefaults = None,
-    custom_name_mapping: Optional[Dict[str, Any]] = None,
+    custom_name_mapping: dict[str, Any] | None = None,
     add_delay: bool = False,
     filter_faulty: bool = False,
 ):
@@ -72,7 +72,7 @@ def convert_to_target(
         qubit_properties = qubit_props_list_from_props(properties=properties)
         target = Target(num_qubits=configuration.n_qubits, qubit_properties=qubit_properties)
         # Parse instructions
-        gates: Dict[str, Any] = {}
+        gates: dict[str, Any] = {}
         for gate in properties.gates:
             name = gate.gate
             if name in name_mapping:
@@ -190,11 +190,11 @@ def convert_to_target(
 
 def qubit_props_list_from_props(
     properties: BackendProperties,
-) -> List[QubitProperties]:
+) -> list[QubitProperties]:
     """Uses BackendProperties to construct
     and return a list of QubitProperties.
     """
-    qubit_props: List[QubitProperties] = []
+    qubit_props: list[QubitProperties] = []
     for qubit, _ in enumerate(properties.qubits):
         try:
             t_1 = properties.t1(qubit)
@@ -246,7 +246,7 @@ class BackendV2Converter(BackendV2):
     def __init__(
         self,
         backend: BackendV1,
-        name_mapping: Optional[Dict[str, Any]] = None,
+        name_mapping: dict[str, Any] | None = None,
         add_delay: bool = False,
         filter_faulty: bool = False,
     ):
@@ -321,7 +321,7 @@ class BackendV2Converter(BackendV2):
         return self._config.dtm
 
     @property
-    def meas_map(self) -> List[List[int]]:
+    def meas_map(self) -> list[list[int]]:
         return self._config.meas_map
 
     def drive_channel(self, qubit: int):

--- a/qiskit/pulse/builder.py
+++ b/qiskit/pulse/builder.py
@@ -2494,7 +2494,7 @@ def measure(
     # just a macro to automate combination of stimulus and acquisition.
     # prepare unique reference name based on qubit and memory slot index.
     qubits_repr = "&".join(map(str, qubits))
-    mslots_repr = "&".join((str(r.index) for r in registers))
+    mslots_repr = "&".join(str(r.index) for r in registers)
     _active_builder().call_subroutine(measure_sched, name=f"measure_{qubits_repr}..{mslots_repr}")
 
     if len(qubits) == 1:

--- a/qiskit/pulse/macros.py
+++ b/qiskit/pulse/macros.py
@@ -13,7 +13,7 @@
 """Module for common pulse programming macros."""
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from qiskit.pulse import channels, exceptions, instructions, utils
 from qiskit.pulse.instruction_schedule_map import InstructionScheduleMap
@@ -26,11 +26,11 @@ if TYPE_CHECKING:
 
 
 def measure(
-    qubits: List[int],
+    qubits: list[int],
     backend=None,
-    inst_map: Optional[InstructionScheduleMap] = None,
-    meas_map: Optional[Union[List[List[int]], Dict[int, List[int]]]] = None,
-    qubit_mem_slots: Optional[Dict[int, int]] = None,
+    inst_map: InstructionScheduleMap | None = None,
+    meas_map: list[list[int]] | dict[int, list[int]] | None = None,
+    qubit_mem_slots: dict[int, int] | None = None,
     measure_name: str = "measure",
 ) -> Schedule:
     """Return a schedule which measures the requested qubits according to the given
@@ -64,7 +64,6 @@ def measure(
 
     # backend is V2.
     if isinstance(backend, BackendV2):
-
         return _measure_v2(
             qubits=qubits,
             target=backend.target,
@@ -89,10 +88,10 @@ def measure(
 
 
 def _measure_v1(
-    qubits: List[int],
+    qubits: list[int],
     inst_map: InstructionScheduleMap,
-    meas_map: Union[List[List[int]], Dict[int, List[int]]],
-    qubit_mem_slots: Optional[Dict[int, int]] = None,
+    meas_map: list[list[int]] | dict[int, list[int]],
+    qubit_mem_slots: dict[int, int] | None = None,
     measure_name: str = "measure",
 ) -> Schedule:
     """Return a schedule which measures the requested qubits according to the given
@@ -150,10 +149,10 @@ def _measure_v1(
 
 
 def _measure_v2(
-    qubits: List[int],
+    qubits: list[int],
     target: Target,
-    meas_map: Union[List[List[int]], Dict[int, List[int]]],
-    qubit_mem_slots: Dict[int, int],
+    meas_map: list[list[int]] | dict[int, list[int]],
+    qubit_mem_slots: dict[int, int],
     measure_name: str = "measure",
 ) -> Schedule:
     """Return a schedule which measures the requested qubits according to the given
@@ -225,7 +224,7 @@ def measure_all(backend) -> Schedule:
 
 
 def _schedule_remapping_memory_slot(
-    schedule: Schedule, qubit_mem_slots: Dict[int, int]
+    schedule: Schedule, qubit_mem_slots: dict[int, int]
 ) -> Schedule:
     """
     A helper function to overwrite MemorySlot index of :class:`.Acquire` instruction.

--- a/qiskit/qasm3/__init__.py
+++ b/qiskit/qasm3/__init__.py
@@ -224,7 +224,7 @@ def load(filename: str):
 
     import qiskit_qasm3_import
 
-    with open(filename, "r") as fptr:
+    with open(filename) as fptr:
         program = fptr.read()
     try:
         return qiskit_qasm3_import.parse(program)

--- a/qiskit/qpy/binary_io/value.py
+++ b/qiskit/qpy/binary_io/value.py
@@ -67,7 +67,7 @@ def _write_parameter_expression(file_obj, obj):
         # serialize value
         if value == symbol._symbol_expr:
             value_key = symbol_key
-            value_data = bytes()
+            value_data = b""
         else:
             value_key, value_data = dumps_value(value)
 

--- a/qiskit/quantum_info/analysis/z2_symmetries.py
+++ b/qiskit/quantum_info/analysis/z2_symmetries.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import itertools
 from collections.abc import Iterable
 from copy import deepcopy
-from typing import Union, cast
+from typing import cast
 
 import numpy as np
 
@@ -320,7 +320,7 @@ class Z2Symmetries:
 
         return operator
 
-    def taper_clifford(self, operator: SparsePauliOp) -> Union[SparsePauliOp, list[SparsePauliOp]]:
+    def taper_clifford(self, operator: SparsePauliOp) -> SparsePauliOp | list[SparsePauliOp]:
         """Operate the second part of the tapering.
         This function assumes that the input operators have already been transformed using
         :meth:`convert_clifford`. The redundant qubits due to the symmetries are dropped and
@@ -334,7 +334,7 @@ class Z2Symmetries:
 
         """
 
-        tapered_ops: Union[SparsePauliOp, list[SparsePauliOp]]
+        tapered_ops: SparsePauliOp | list[SparsePauliOp]
         if self.is_empty():
             tapered_ops = operator
         else:
@@ -351,7 +351,7 @@ class Z2Symmetries:
 
         return tapered_ops
 
-    def taper(self, operator: SparsePauliOp) -> Union[SparsePauliOp, list[SparsePauliOp]]:
+    def taper(self, operator: SparsePauliOp) -> SparsePauliOp | list[SparsePauliOp]:
         """
         Taper an operator based on the z2_symmetries info and sector defined by `tapering_values`.
         Returns operator if the symmetry object is empty.

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from numbers import Number
-from typing import Dict, Optional
 from copy import deepcopy
 
 import numpy as np
@@ -185,7 +184,7 @@ class SparsePauliOp(LinearOp):
             )
         )
 
-    def equiv(self, other, atol: Optional[float] = None):
+    def equiv(self, other, atol: float | None = None):
         """Check if two SparsePauliOp operators are equivalent.
 
         Args:
@@ -202,7 +201,7 @@ class SparsePauliOp(LinearOp):
         return np.allclose((self - other).simplify().coeffs, 0.0, atol=atol)
 
     @property
-    def settings(self) -> Dict:
+    def settings(self) -> dict:
         """Return settings."""
         return {"data": self._pauli_list, "coeffs": self._coeffs}
 

--- a/qiskit/synthesis/discrete_basis/gate_sequence.py
+++ b/qiskit/synthesis/discrete_basis/gate_sequence.py
@@ -66,7 +66,7 @@ class GateSequence:
         # restore name
         self.name = " ".join(self.labels)
 
-    def __eq__(self, other: "GateSequence") -> bool:
+    def __eq__(self, other: GateSequence) -> bool:
         """Check if this GateSequence is the same as the other GateSequence.
 
         Args:
@@ -129,7 +129,7 @@ class GateSequence:
 
         return dag
 
-    def append(self, gate: Gate) -> "GateSequence":
+    def append(self, gate: Gate) -> GateSequence:
         """Append gate to the sequence of gates.
 
         Args:
@@ -163,7 +163,7 @@ class GateSequence:
 
         return self
 
-    def adjoint(self) -> "GateSequence":
+    def adjoint(self) -> GateSequence:
         """Get the complex conjugate."""
         # We're initializing an empty GateSequence and set the state manually, as we can
         # efficiently infer the adjoint values from the current value instead of recomputing them.
@@ -177,7 +177,7 @@ class GateSequence:
 
         return adjoint
 
-    def copy(self) -> "GateSequence":
+    def copy(self) -> GateSequence:
         """Create copy of the sequence of gates.
 
         Returns:
@@ -245,7 +245,7 @@ class GateSequence:
         return out
 
     @classmethod
-    def from_matrix(cls, matrix: np.ndarray) -> "GateSequence":
+    def from_matrix(cls, matrix: np.ndarray) -> GateSequence:
         """Initialize the gate sequence from a matrix, without a gate sequence.
 
         Args:
@@ -268,7 +268,7 @@ class GateSequence:
         instance.gates = []
         return instance
 
-    def dot(self, other: "GateSequence") -> "GateSequence":
+    def dot(self, other: GateSequence) -> GateSequence:
         """Compute the dot-product with another gate sequence.
 
         Args:

--- a/qiskit/synthesis/discrete_basis/solovay_kitaev.py
+++ b/qiskit/synthesis/discrete_basis/solovay_kitaev.py
@@ -13,6 +13,7 @@
 """Synthesize a single qubit gate to a discrete basis set."""
 
 from __future__ import annotations
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -21,6 +22,10 @@ from qiskit.circuit.gate import Gate
 from .gate_sequence import GateSequence
 from .commutator_decompose import commutator_decompose
 from .generate_basis_approximations import generate_basic_approximations, _1q_gates, _1q_inverses
+
+if TYPE_CHECKING:
+    from qiskit import QuantumCircuit
+    from qiskit.dagcircuit import DAGCircuit
 
 
 class SolovayKitaevDecomposition:
@@ -91,7 +96,7 @@ class SolovayKitaevDecomposition:
         recursion_degree: int,
         return_dag: bool = False,
         check_input: bool = True,
-    ) -> "QuantumCircuit" | "DAGCircuit":
+    ) -> QuantumCircuit | DAGCircuit:
         r"""Run the algorithm.
 
         Args:

--- a/qiskit/transpiler/instruction_durations.py
+++ b/qiskit/transpiler/instruction_durations.py
@@ -24,7 +24,7 @@ from qiskit.utils.deprecation import deprecate_arg
 from qiskit.utils.units import apply_prefix
 
 
-def _is_deprecated_qubits_argument(qubits: Union[int, list[int], Qubit, list[Qubit]]) -> bool:
+def _is_deprecated_qubits_argument(qubits: int | list[int] | Qubit | list[Qubit]) -> bool:
     if isinstance(qubits, (int, Qubit)):
         qubits = [qubits]
     return isinstance(qubits[0], Qubit)
@@ -43,7 +43,7 @@ class InstructionDurations:
     """
 
     def __init__(
-        self, instruction_durations: "InstructionDurationsType" | None = None, dt: float = None
+        self, instruction_durations: InstructionDurationsType | None = None, dt: float = None
     ):
         self.duration_by_name: dict[str, tuple[float, str]] = {}
         self.duration_by_name_qubits: dict[tuple[str, tuple[int, ...]], tuple[float, str]] = {}
@@ -103,7 +103,7 @@ class InstructionDurations:
 
         return InstructionDurations(instruction_durations, dt=dt)
 
-    def update(self, inst_durations: "InstructionDurationsType" | None, dt: float = None):
+    def update(self, inst_durations: InstructionDurationsType | None, dt: float = None):
         """Update self with inst_durations (inst_durations overwrite self).
 
         Args:

--- a/qiskit/transpiler/passes/layout/disjoint_utils.py
+++ b/qiskit/transpiler/passes/layout/disjoint_utils.py
@@ -13,7 +13,7 @@
 """This module contains common utils for disjoint coupling maps."""
 from __future__ import annotations
 from collections import defaultdict
-from typing import List, Callable, TypeVar, Dict, Union
+from typing import Callable, TypeVar
 import uuid
 
 import rustworkx as rx
@@ -32,9 +32,9 @@ T = TypeVar("T")
 
 def run_pass_over_connected_components(
     dag: DAGCircuit,
-    components_source: Union[Target, CouplingMap],
+    components_source: Target | CouplingMap,
     run_func: Callable[[DAGCircuit, CouplingMap], T],
-) -> List[T]:
+) -> list[T]:
     """Run a transpiler pass inner function over mapped components."""
     if isinstance(components_source, Target):
         coupling_map = components_source.build_coupling_map(filter_idle_qubits=True)
@@ -74,8 +74,8 @@ def run_pass_over_connected_components(
 
 
 def map_components(
-    dag_components: List[DAGCircuit], cmap_components: List[CouplingMap]
-) -> Dict[int, List[int]]:
+    dag_components: list[DAGCircuit], cmap_components: list[CouplingMap]
+) -> dict[int, list[int]]:
     """Returns a map where the key is the index of each connected component in cmap_components and
     the value is a list of indices from dag_components which should be placed onto it."""
     free_qubits = {index: len(cmap.graph) for index, cmap in enumerate(cmap_components)}
@@ -138,9 +138,7 @@ def combine_barriers(dag: DAGCircuit, retain_uuid: bool = True):
                 node.op.label = None
 
 
-def require_layout_isolated_to_component(
-    dag: DAGCircuit, components_source: Union[Target, CouplingMap]
-):
+def require_layout_isolated_to_component(dag: DAGCircuit, components_source: Target | CouplingMap):
     """
     Check that the layout of the dag does not require connectivity across connected components
     in the CouplingMap
@@ -168,7 +166,7 @@ def require_layout_isolated_to_component(
             raise TranspilerError("Chosen layout is not valid for the target disjoint connectivity")
 
 
-def separate_dag(dag: DAGCircuit) -> List[DAGCircuit]:
+def separate_dag(dag: DAGCircuit) -> list[DAGCircuit]:
     """Separate a dag circuit into it's connected components."""
     # Split barriers into single qubit barriers before splitting connected components
     split_barriers(dag)
@@ -176,7 +174,7 @@ def separate_dag(dag: DAGCircuit) -> List[DAGCircuit]:
     connected_components = rx.weakly_connected_components(im_graph)
     component_qubits = []
     for component in connected_components:
-        component_qubits.append(set(qubit_map[x] for x in component))
+        component_qubits.append({qubit_map[x] for x in component})
 
     qubits = set(dag.qubits)
 

--- a/qiskit/transpiler/passes/routing/algorithms/bip_model.py
+++ b/qiskit/transpiler/passes/routing/algorithms/bip_model.py
@@ -416,7 +416,7 @@ class BIPMappingModel:
             return 1.0 - self.default_cx_error_rate
 
     @staticmethod
-    @lru_cache()
+    @lru_cache
     def _gate_fidelities(node):
         matrix = node.op.to_matrix()
         target = TwoQubitWeylDecomposition(matrix)
@@ -424,7 +424,7 @@ class BIPMappingModel:
         return [trace_to_fid(traces[i]) for i in range(4)]
 
     @staticmethod
-    @lru_cache()
+    @lru_cache
     def _mirrored_gate_fidelities(node):
         matrix = node.op.to_matrix()
         swap = SwapGate().to_matrix()

--- a/qiskit/transpiler/passes/routing/algorithms/types.py
+++ b/qiskit/transpiler/passes/routing/algorithms/types.py
@@ -35,12 +35,10 @@ PermuteElement = TypeVar("PermuteElement")
 Permutation = Dict[PermuteElement, PermuteElement]
 Swap = Tuple[PermuteElement, PermuteElement]
 
+
 # Represents a circuit for permuting to a mapping.
-PermutationCircuit = NamedTuple(
-    "PermutationCircuit",
-    [
-        ("circuit", DAGCircuit),
-        ("inputmap", Dict[Union[int, Qubit], Qubit])
-        # A mapping from architecture nodes to circuit registers.
-    ],
-)
+class PermutationCircuit(NamedTuple):
+    """Mapping from architecture nodes to circuit registers."""
+
+    circuit: DAGCircuit
+    inputmap: Dict[Union[int, Qubit], Qubit]

--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_gate_router.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_gate_router.py
@@ -339,7 +339,7 @@ class Commuting2qGateRouter(TransformationPass):
             # Apply SWAP gates
             if i < max_distance:
                 for swap in swap_strategy.swap_layer(i):
-                    (j, k) = [trivial_layout.get_physical_bits()[vertex] for vertex in swap]
+                    (j, k) = (trivial_layout.get_physical_bits()[vertex] for vertex in swap)
 
                     circuit_with_swap.swap(j, k)
                     current_layout.swap(j, k)

--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/swap_strategy.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/swap_strategy.py
@@ -86,7 +86,7 @@ class SwapStrategy:
                 raise QiskitError(f"The {i}th swap layer contains a qubit with multiple swaps.")
 
     @classmethod
-    def from_line(cls, line: list[int], num_swap_layers: int | None = None) -> "SwapStrategy":
+    def from_line(cls, line: list[int], num_swap_layers: int | None = None) -> SwapStrategy:
         """Creates a swap strategy for a line graph with the specified number of SWAP layers.
 
         This SWAP strategy will use the full line if instructed to do so (i.e. num_variables

--- a/qiskit/transpiler/passes/scheduling/alignments/align_measures.py
+++ b/qiskit/transpiler/passes/scheduling/alignments/align_measures.py
@@ -16,7 +16,6 @@ import itertools
 import warnings
 from collections import defaultdict
 from collections.abc import Iterable
-from typing import Type
 
 from qiskit.circuit.quantumcircuit import ClbitSpecifier, QubitSpecifier
 
@@ -211,7 +210,7 @@ class AlignMeasures(TransformationPass):
 def _check_alignment_required(
     dag: DAGCircuit,
     alignment: int,
-    instructions: Type | list[Type],
+    instructions: type | list[type],
 ) -> bool:
     """Check DAG nodes and return a boolean representing if instruction scheduling is necessary.
 

--- a/qiskit/transpiler/synthesis/aqc/approximate.py
+++ b/qiskit/transpiler/synthesis/aqc/approximate.py
@@ -12,7 +12,7 @@
 """Base classes for an approximate circuit definition."""
 from __future__ import annotations
 from abc import ABC, abstractmethod
-from typing import Optional, SupportsFloat
+from typing import SupportsFloat
 import numpy as np
 
 from qiskit import QuantumCircuit
@@ -21,7 +21,7 @@ from qiskit import QuantumCircuit
 class ApproximateCircuit(QuantumCircuit, ABC):
     """A base class that represents an approximate circuit."""
 
-    def __init__(self, num_qubits: int, name: Optional[str] = None) -> None:
+    def __init__(self, num_qubits: int, name: str | None = None) -> None:
         """
         Args:
             num_qubits: number of qubit this circuit will span.

--- a/qiskit/transpiler/synthesis/aqc/cnot_unit_circuit.py
+++ b/qiskit/transpiler/synthesis/aqc/cnot_unit_circuit.py
@@ -14,7 +14,6 @@ This is the Parametric Circuit class: anything that you need for a circuit
 to be parametrized and used for approximate compiling optimization.
 """
 from __future__ import annotations
-from typing import Optional
 
 import numpy as np
 
@@ -28,8 +27,8 @@ class CNOTUnitCircuit(ApproximateCircuit):
         self,
         num_qubits: int,
         cnots: np.ndarray,
-        tol: Optional[float] = 0.0,
-        name: Optional[str] = None,
+        tol: float | None = 0.0,
+        name: str | None = None,
     ) -> None:
         """
         Args:

--- a/qiskit/transpiler/synthesis/aqc/fast_gradient/fast_grad_utils.py
+++ b/qiskit/transpiler/synthesis/aqc/fast_gradient/fast_grad_utils.py
@@ -14,7 +14,6 @@
 Utility functions in the fast gradient implementation.
 """
 from __future__ import annotations
-from typing import Union
 import numpy as np
 
 
@@ -36,7 +35,7 @@ def is_permutation(x: np.ndarray) -> bool:
     )
 
 
-def reverse_bits(x: Union[int, np.ndarray], nbits: int, enable: bool) -> Union[int, np.ndarray]:
+def reverse_bits(x: int | np.ndarray, nbits: int, enable: bool) -> int | np.ndarray:
     """
     Reverses the bit order in a number of ``nbits`` length.
     If ``x`` is an array, then operation is applied to every entry.

--- a/qiskit/transpiler/synthesis/aqc/fast_gradient/layer.py
+++ b/qiskit/transpiler/synthesis/aqc/fast_gradient/layer.py
@@ -15,7 +15,6 @@ Layer classes for the fast gradient implementation.
 """
 from __future__ import annotations
 from abc import abstractmethod, ABC
-from typing import Optional
 import numpy as np
 from .fast_grad_utils import (
     bit_permutation_1q,
@@ -62,7 +61,7 @@ class Layer1Q(LayerBase):
     interleaves with the identity ones.
     """
 
-    def __init__(self, num_qubits: int, k: int, g2x2: Optional[np.ndarray] = None):
+    def __init__(self, num_qubits: int, k: int, g2x2: np.ndarray | None = None):
         """
         Args:
             num_qubits: number of qubits.
@@ -102,7 +101,7 @@ class Layer2Q(LayerBase):
     interleaves with the identity ones.
     """
 
-    def __init__(self, num_qubits: int, j: int, k: int, g4x4: Optional[np.ndarray] = None):
+    def __init__(self, num_qubits: int, j: int, k: int, g4x4: np.ndarray | None = None):
         """
         Args:
             num_qubits: number of qubits.

--- a/qiskit/utils/deprecation.py
+++ b/qiskit/utils/deprecation.py
@@ -17,13 +17,13 @@ from __future__ import annotations
 import functools
 import inspect
 import warnings
-from typing import Any, Callable, Dict, Optional, Type, Tuple, Union
+from typing import Any, Callable
 
 
 def deprecate_func(
     *,
     since: str,
-    additional_msg: Optional[str] = None,
+    additional_msg: str | None = None,
     pending: bool = False,
     package_name: str = "qiskit-terra",
     removal_timeline: str = "no earlier than 3 months after the release date",
@@ -104,12 +104,12 @@ def deprecate_arg(
     name: str,
     *,
     since: str,
-    additional_msg: Optional[str] = None,
-    deprecation_description: Optional[str] = None,
+    additional_msg: str | None = None,
+    deprecation_description: str | None = None,
     pending: bool = False,
     package_name: str = "qiskit-terra",
-    new_alias: Optional[str] = None,
-    predicate: Optional[Callable[[Any], bool]] = None,
+    new_alias: str | None = None,
+    predicate: Callable[[Any], bool] | None = None,
     removal_timeline: str = "no earlier than 3 months after the release date",
 ):
     """Decorator to indicate an argument has been deprecated in some way.
@@ -204,10 +204,10 @@ def deprecate_arg(
 
 
 def deprecate_arguments(
-    kwarg_map: Dict[str, Optional[str]],
-    category: Type[Warning] = DeprecationWarning,
+    kwarg_map: dict[str, str | None],
+    category: type[Warning] = DeprecationWarning,
     *,
-    since: Optional[str] = None,
+    since: str | None = None,
 ):
     """Deprecated. Instead, use `@deprecate_arg`.
 
@@ -278,9 +278,9 @@ def deprecate_arguments(
 def deprecate_function(
     msg: str,
     stacklevel: int = 2,
-    category: Type[Warning] = DeprecationWarning,
+    category: type[Warning] = DeprecationWarning,
     *,
-    since: Optional[str] = None,
+    since: str | None = None,
 ):
     """Deprecated. Instead, use `@deprecate_func`.
 
@@ -313,15 +313,15 @@ def deprecate_function(
 
 def _maybe_warn_and_rename_kwarg(
     args: tuple[Any, ...],
-    kwargs: Dict[str, Any],
+    kwargs: dict[str, Any],
     *,
     func_name: str,
     original_func_co_varnames: tuple[str, ...],
     old_arg_name: str,
-    new_alias: Optional[str],
+    new_alias: str | None,
     warning_msg: str,
-    category: Type[Warning],
-    predicate: Optional[Callable[[Any], bool]],
+    category: type[Warning],
+    predicate: Callable[[Any], bool] | None,
 ) -> None:
     # In Python 3.10+, we should set `zip(strict=False)` (the default). That is, we want to
     # stop iterating once `args` is done, since some args may have not been explicitly passed as
@@ -353,7 +353,7 @@ def _write_deprecation_msg(
     pending: bool,
     additional_msg: str,
     removal_timeline: str,
-) -> Tuple[str, Union[Type[DeprecationWarning], Type[PendingDeprecationWarning]]]:
+) -> tuple[str, type[DeprecationWarning] | type[PendingDeprecationWarning]]:
     if pending:
         category = PendingDeprecationWarning
         deprecation_status = "pending deprecation"
@@ -412,7 +412,7 @@ _NAPOLEON_META_LINES = frozenset(
 
 
 def add_deprecation_to_docstring(
-    func: Callable, msg: str, *, since: Optional[str], pending: bool
+    func: Callable, msg: str, *, since: str | None, pending: bool
 ) -> None:
     """Dynamically insert the deprecation message into ``func``'s docstring.
 

--- a/qiskit/visualization/timeline/types.py
+++ b/qiskit/visualization/timeline/types.py
@@ -20,16 +20,14 @@ from typing import NamedTuple, List, Union, NewType, Tuple, Dict
 from qiskit import circuit
 
 
-ScheduledGate = NamedTuple(
-    "ScheduledGate",
-    [
-        ("t0", int),
-        ("operand", circuit.Gate),
-        ("duration", int),
-        ("bits", List[Union[circuit.Qubit, circuit.Clbit]]),
-        ("bit_position", int),
-    ],
-)
+class ScheduledGate(NamedTuple):
+    t0: int
+    operand: circuit.Gate
+    duration: int
+    bits: List[Union[circuit.Qubit, circuit.Clbit]]
+    bit_position: int
+
+
 ScheduledGate.__doc__ = "A gate instruction with embedded time."
 ScheduledGate.t0.__doc__ = "Time when the instruction is issued."
 ScheduledGate.operand.__doc__ = "Gate object associated with the gate."
@@ -38,28 +36,36 @@ ScheduledGate.bits.__doc__ = "List of bit associated with the gate."
 ScheduledGate.bit_position.__doc__ = "Position of bit associated with this drawing source."
 
 
-GateLink = NamedTuple(
-    "GateLink", [("t0", int), ("opname", str), ("bits", List[Union[circuit.Qubit, circuit.Clbit]])]
-)
+class GateLink(NamedTuple):
+    t0: int
+    opname: str
+    bits: List[Union[circuit.Qubit, circuit.Clbit]]
+
+
 GateLink.__doc__ = "Dedicated object to represent a relationship between instructions."
 GateLink.t0.__doc__ = "A position where the link is placed."
 GateLink.opname.__doc__ = "Name of gate associated with this link."
 GateLink.bits.__doc__ = "List of bit associated with the instruction."
 
 
-Barrier = NamedTuple(
-    "Barrier",
-    [("t0", int), ("bits", List[Union[circuit.Qubit, circuit.Clbit]]), ("bit_position", int)],
-)
+class Barrier(NamedTuple):
+    t0: int
+    bits: List[Union[circuit.Qubit, circuit.Clbit]]
+    bit_position: int
+
+
 Barrier.__doc__ = "Dedicated object to represent a barrier instruction."
 Barrier.t0.__doc__ = "A position where the barrier is placed."
 Barrier.bits.__doc__ = "List of bit associated with the instruction."
 Barrier.bit_position.__doc__ = "Position of bit associated with this drawing source."
 
 
-HorizontalAxis = NamedTuple(
-    "HorizontalAxis", [("window", Tuple[int, int]), ("axis_map", Dict[int, int]), ("label", str)]
-)
+class HorizontalAxis(NamedTuple):
+    window: Tuple[int, int]
+    axis_map: Dict[int, int]
+    label: str
+
+
 HorizontalAxis.__doc__ = "Data to represent configuration of horizontal axis."
 HorizontalAxis.window.__doc__ = "Left and right edge of graph."
 HorizontalAxis.axis_map.__doc__ = "Mapping of apparent coordinate system and actual location."

--- a/test/python/algorithms/test_observables_evaluator.py
+++ b/test/python/algorithms/test_observables_evaluator.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 import unittest
-from typing import Tuple
 
 from test.python.algorithms import QiskitAlgorithmsTestCase
 import numpy as np
@@ -66,7 +65,7 @@ class TestObservablesEvaluator(QiskitAlgorithmsTestCase):
 
     def _run_test(
         self,
-        expected_result: ListOrDict[Tuple[complex, complex]],
+        expected_result: ListOrDict[tuple[complex, complex]],
         quantum_state: QuantumCircuit,
         decimal: int,
         observables: ListOrDict[BaseOperator | PauliSumOp],

--- a/test/python/algorithms/time_evolvers/classical_methods/test_scipy_real_evolver.py
+++ b/test/python/algorithms/time_evolvers/classical_methods/test_scipy_real_evolver.py
@@ -51,7 +51,7 @@ class TestClassicalRealEvolver(QiskitAlgorithmsTestCase):
             one(1).expand(zero(1)),
             np.pi / 4,
             SparsePauliOp(["XX", "YY"], [0.5, 0.5]),
-            ((one(1).expand(zero(1)) - 1.0j * zero(1).expand(one(1)))) / np.sqrt(2),
+            (one(1).expand(zero(1)) - 1.0j * zero(1).expand(one(1))) / np.sqrt(2),
         ),
         (zero(12), np.pi / 2, SparsePauliOp("X" * 12), -1.0j * (one(12))),
     )

--- a/test/python/algorithms/time_evolvers/variational/test_var_qite.py
+++ b/test/python/algorithms/time_evolvers/variational/test_var_qite.py
@@ -237,7 +237,7 @@ class TestVarQITE(QiskitAlgorithmsTestCase):
         time = 1
         observable = SparsePauliOp(["I", "Z"], np.array([0, t_param]))
 
-        x, y, z = [Parameter(s) for s in "xyz"]
+        x, y, z = (Parameter(s) for s in "xyz")
         ansatz = QuantumCircuit(1)
         ansatz.rz(x, 0)
         ansatz.ry(y, 0)

--- a/test/python/algorithms/time_evolvers/variational/test_var_qrte.py
+++ b/test/python/algorithms/time_evolvers/variational/test_var_qrte.py
@@ -232,7 +232,7 @@ class TestVarQRTE(QiskitAlgorithmsTestCase):
         time = 1
         observable = SparsePauliOp(["I", "Z"], np.array([0, t_param]))
 
-        x, y, z = [Parameter(s) for s in "xyz"]
+        x, y, z = (Parameter(s) for s in "xyz")
         ansatz = QuantumCircuit(1)
         ansatz.rz(x, 0)
         ansatz.ry(y, 0)

--- a/test/python/result/test_mitigators.py
+++ b/test/python/result/test_mitigators.py
@@ -228,7 +228,7 @@ class TestReadoutMitigation(QiskitTestCase):
             self.assertLess(
                 mitigated_error,
                 0.001,
-                "Mitigator {} did not correctly marganalize for qubits 1,2".format(mitigator),
+                f"Mitigator {mitigator} did not correctly marganalize for qubits 1,2",
             )
 
             mitigated_probs_02 = (
@@ -240,7 +240,7 @@ class TestReadoutMitigation(QiskitTestCase):
             self.assertLess(
                 mitigated_error,
                 0.001,
-                "Mitigator {} did not correctly marganalize for qubits 0,2".format(mitigator),
+                f"Mitigator {mitigator} did not correctly marganalize for qubits 0,2",
             )
 
     def test_qubits_parameter(self):
@@ -264,7 +264,7 @@ class TestReadoutMitigation(QiskitTestCase):
             self.assertLess(
                 mitigated_error,
                 0.001,
-                "Mitigator {} did not correctly handle qubit order 0, 1, 2".format(mitigator),
+                f"Mitigator {mitigator} did not correctly handle qubit order 0, 1, 2",
             )
 
             mitigated_probs_210 = (
@@ -276,7 +276,7 @@ class TestReadoutMitigation(QiskitTestCase):
             self.assertLess(
                 mitigated_error,
                 0.001,
-                "Mitigator {} did not correctly handle qubit order 2, 1, 0".format(mitigator),
+                f"Mitigator {mitigator} did not correctly handle qubit order 2, 1, 0",
             )
 
             mitigated_probs_102 = (
@@ -288,7 +288,7 @@ class TestReadoutMitigation(QiskitTestCase):
             self.assertLess(
                 mitigated_error,
                 0.001,
-                "Mitigator {} did not correctly handle qubit order 1, 0, 2".format(mitigator),
+                f"Mitigator {mitigator} did not correctly handle qubit order 1, 0, 2",
             )
 
     def test_repeated_qubits_parameter(self):
@@ -311,7 +311,7 @@ class TestReadoutMitigation(QiskitTestCase):
             self.assertLess(
                 mitigated_error,
                 0.001,
-                "Mitigator {} did not correctly handle qubit order 2,1,0".format(mitigator),
+                f"Mitigator {mitigator} did not correctly handle qubit order 2,1,0",
             )
 
             # checking qubit order 2,1,0 should not "overwrite" the default 0,1,2
@@ -350,7 +350,7 @@ class TestReadoutMitigation(QiskitTestCase):
             self.assertLess(
                 mitigated_error,
                 0.001,
-                "Mitigator {} did not correctly handle qubit subset".format(mitigator),
+                f"Mitigator {mitigator} did not correctly handle qubit subset",
             )
 
             mitigated_probs_6 = (
@@ -362,7 +362,7 @@ class TestReadoutMitigation(QiskitTestCase):
             self.assertLess(
                 mitigated_error,
                 0.001,
-                "Mitigator {} did not correctly handle qubit subset".format(mitigator),
+                f"Mitigator {mitigator} did not correctly handle qubit subset",
             )
             diagonal = str2diag("ZZ")
             ideal_expectation = 0
@@ -373,7 +373,7 @@ class TestReadoutMitigation(QiskitTestCase):
             self.assertLess(
                 mitigated_error,
                 0.1,
-                "Mitigator {} did not improve circuit expectation".format(mitigator),
+                f"Mitigator {mitigator} did not improve circuit expectation",
             )
 
     def test_from_backend(self):

--- a/test/python/transpiler/aqc/fast_gradient/test_layer1q.py
+++ b/test/python/transpiler/aqc/fast_gradient/test_layer1q.py
@@ -61,7 +61,7 @@ class TestLayer1q(QiskitTestCase):
 
                 # T == P^t @ G @ P.
                 err = tut.relative_error(t_mat, iden[perm].T @ g_mat @ iden[perm])
-                self.assertLess(err, eps, "err = {:0.16f}".format(err))
+                self.assertLess(err, eps, f"err = {err:0.16f}")
                 max_rel_err = max(max_rel_err, err)
 
                 # Multiplication by permutation matrix of the left can be
@@ -127,12 +127,12 @@ class TestLayer1q(QiskitTestCase):
                 alt_ttmtt = pmat.finalize(temp_mat=tmp1)
 
                 err1 = tut.relative_error(alt_ttmtt, ttmtt)
-                self.assertLess(err1, _eps, "relative error: {:f}".format(err1))
+                self.assertLess(err1, _eps, f"relative error: {err1:f}")
 
                 prod = np.cfloat(np.trace(ttmtt @ t4))
                 alt_prod = pmat.product_q1(layer=c4, tmp1=tmp1, tmp2=tmp2)
                 err2 = abs(alt_prod - prod) / abs(prod)
-                self.assertLess(err2, _eps, "relative error: {:f}".format(err2))
+                self.assertLess(err2, _eps, f"relative error: {err2:f}")
 
                 max_rel_err = max(max_rel_err, err1, err2)
 

--- a/test/python/transpiler/aqc/fast_gradient/test_layer2q.py
+++ b/test/python/transpiler/aqc/fast_gradient/test_layer2q.py
@@ -64,7 +64,7 @@ class TestLayer2q(QiskitTestCase):
 
                     # T == P^t @ G @ P.
                     err = tut.relative_error(t_mat, iden[perm].T @ g_mat @ iden[perm])
-                    self.assertLess(err, _eps, "err = {:0.16f}".format(err))
+                    self.assertLess(err, _eps, f"err = {err:0.16f}")
                     max_rel_err = max(max_rel_err, err)
 
                     # Multiplication by permutation matrix of the left can be
@@ -135,12 +135,12 @@ class TestLayer2q(QiskitTestCase):
                 alt_ttmtt = pmat.finalize(temp_mat=tmp1)
 
                 err1 = tut.relative_error(alt_ttmtt, ttmtt)
-                self.assertLess(err1, _eps, "relative error: {:f}".format(err1))
+                self.assertLess(err1, _eps, f"relative error: {err1:f}")
 
                 prod = np.cfloat(np.trace(ttmtt @ t4))
                 alt_prod = pmat.product_q2(layer=c4, tmp1=tmp1, tmp2=tmp2)
                 err2 = abs(alt_prod - prod) / abs(prod)
-                self.assertLess(err2, _eps, "relative error: {:f}".format(err2))
+                self.assertLess(err2, _eps, f"relative error: {err2:f}")
 
                 max_rel_err = max(max_rel_err, err1, err2)
 

--- a/test/python/transpiler/test_unitary_synthesis.py
+++ b/test/python/transpiler/test_unitary_synthesis.py
@@ -245,10 +245,10 @@ class TestUnitarySynthesis(QiskitTestCase):
         # the decomposer defaults to the [1, 0] direction but the coupling
         # map specifies a [0, 1] direction. Check that this is respected.
         self.assertTrue(
-            all(((qr[1], qr[0]) == instr.qubits for instr in qc_out.get_instructions("cx")))
+            all((qr[1], qr[0]) == instr.qubits for instr in qc_out.get_instructions("cx"))
         )
         self.assertTrue(
-            all(((qr[0], qr[1]) == instr.qubits for instr in qc_out_nat.get_instructions("cx")))
+            all((qr[0], qr[1]) == instr.qubits for instr in qc_out_nat.get_instructions("cx"))
         )
         self.assertEqual(Operator(qc), Operator(qc_out))
         self.assertEqual(Operator(qc), Operator(qc_out_nat))
@@ -288,10 +288,10 @@ class TestUnitarySynthesis(QiskitTestCase):
         # the decomposer defaults to the [1, 0] direction but the coupling
         # map specifies a [0, 1] direction. Check that this is respected.
         self.assertTrue(
-            all(((qr[1], qr[0]) == instr.qubits for instr in qc_out.get_instructions("cx")))
+            all((qr[1], qr[0]) == instr.qubits for instr in qc_out.get_instructions("cx"))
         )
         self.assertTrue(
-            all(((qr[0], qr[1]) == instr.qubits for instr in qc_out_nat.get_instructions("cx")))
+            all((qr[0], qr[1]) == instr.qubits for instr in qc_out_nat.get_instructions("cx"))
         )
         self.assertEqual(Operator(qc), Operator(qc_out))
         self.assertEqual(Operator(qc), Operator(qc_out_nat))
@@ -331,10 +331,10 @@ class TestUnitarySynthesis(QiskitTestCase):
         # the decomposer defaults to the [1, 0] direction but the coupling
         # map specifies a [0, 1] direction. Check that this is respected.
         self.assertTrue(
-            all(((qr[1], qr[0]) == instr.qubits for instr in qc_out.get_instructions("cx")))
+            all((qr[1], qr[0]) == instr.qubits for instr in qc_out.get_instructions("cx"))
         )
         self.assertTrue(
-            all(((qr[1], qr[0]) == instr.qubits for instr in qc_out_nat.get_instructions("cx")))
+            all((qr[1], qr[0]) == instr.qubits for instr in qc_out_nat.get_instructions("cx"))
         )
         self.assertEqual(Operator(qc), Operator(qc_out))
         self.assertEqual(Operator(qc), Operator(qc_out_nat))
@@ -407,7 +407,7 @@ class TestUnitarySynthesis(QiskitTestCase):
         pm = PassManager([triv_layout_pass, unisynth_pass])
         qc_out = pm.run(qc)
         self.assertTrue(
-            all(((qr[0], qr[1]) == instr.qubits for instr in qc_out.get_instructions("cx")))
+            all((qr[0], qr[1]) == instr.qubits for instr in qc_out.get_instructions("cx"))
         )
 
     def test_two_qubit_natural_direction_true_gate_length_raises(self):
@@ -568,18 +568,14 @@ class TestUnitarySynthesis(QiskitTestCase):
 
         self.assertTrue(
             all(
-                (
-                    (1, 0) == (circ_10_index[instr.qubits[0]], circ_10_index[instr.qubits[1]])
-                    for instr in circ_10.get_instructions("cx")
-                )
+                (1, 0) == (circ_10_index[instr.qubits[0]], circ_10_index[instr.qubits[1]])
+                for instr in circ_10.get_instructions("cx")
             )
         )
         self.assertTrue(
             all(
-                (
-                    (0, 1) == (circ_01_index[instr.qubits[0]], circ_01_index[instr.qubits[1]])
-                    for instr in circ_01.get_instructions("cx")
-                )
+                (0, 1) == (circ_01_index[instr.qubits[0]], circ_01_index[instr.qubits[1]])
+                for instr in circ_01.get_instructions("cx")
             )
         )
 
@@ -624,10 +620,8 @@ class TestUnitarySynthesis(QiskitTestCase):
         tqc_index = {qubit: index for index, qubit in enumerate(tqc.qubits)}
         self.assertTrue(
             all(
-                (
-                    (0, 1) == (tqc_index[instr.qubits[0]], tqc_index[instr.qubits[1]])
-                    for instr in tqc.get_instructions("cx")
-                )
+                (0, 1) == (tqc_index[instr.qubits[0]], tqc_index[instr.qubits[1]])
+                for instr in tqc.get_instructions("cx")
             )
         )
 


### PR DESCRIPTION
### Summary

Now that  python 3.8 is the minimum supported version I ran `pyupgrade` with `--py38-plus` options.
It mostly found a lot of places to simplify type checking although it also removed a few superfluous parentheses for generator expressions.




