### PR TITLE
pylint: enable used-before-assignment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,6 @@ disable = [
     "use-list-literal",
     "use-implicit-booleaness-not-comparison",
     "use-maxsplit-arg",
-    "used-before-assignment",
 ]
 
 enable = [

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -575,9 +575,9 @@ class C3SXGate(ControlledGate):
         # exporter code (low priority), or we would need to modify 'qelib1.inc' which would be
         # needlessly disruptive this late in OQ2's lifecycle.  The current OQ2 exporter _always_
         # outputs the `include 'qelib1.inc' line.  ---Jake, 2022-11-21.
+        old_name = self.name
+        self.name = "c3sqrtx"
         try:
-            old_name = self.name
-            self.name = "c3sqrtx"
             return super().qasm()
         finally:
             self.name = old_name


### PR DESCRIPTION
A very minor fix and enable `used-before-assignment`.

Relates to #9614 
