### PR TITLE
Pylint: enable pointless-exception-statement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,6 @@ disable = [
     "no-value-for-parameter",
     "non-ascii-name",
     "not-context-manager",
-    "pointless-exception-statement",
     "superfluous-parens",
     "unknown-option-value",
     "unexpected-keyword-arg",

--- a/qiskit/pulse/transforms/alignments.py
+++ b/qiskit/pulse/transforms/alignments.py
@@ -409,7 +409,9 @@ class AlignFunc(AlignmentKind):
             _t_center = self.duration * self.func(ind + 1)
             _t0 = int(_t_center - 0.5 * child.duration)
             if _t0 < 0 or _t0 > self.duration:
-                PulseError("Invalid schedule position t=%d is specified at index=%d" % (_t0, ind))
+                raise PulseError(
+                    "Invalid schedule position t=%d is specified at index=%d" % (_t0, ind)
+                )
             aligned.insert(_t0, child, inplace=True)
 
         return aligned

--- a/qiskit/qpy/binary_io/schedules.py
+++ b/qiskit/qpy/binary_io/schedules.py
@@ -421,7 +421,7 @@ def read_schedule_block(file_obj, version, metadata_deserializer=None):
         QiskitError: QPY version is earlier than block support.
     """
     if version < 5:
-        QiskitError(f"QPY version {version} does not support ScheduleBlock.")
+        raise QiskitError(f"QPY version {version} does not support ScheduleBlock.")
 
     data = formats.SCHEDULE_BLOCK_HEADER._make(
         struct.unpack(

--- a/qiskit/quantum_info/operators/scalar_op.py
+++ b/qiskit/quantum_info/operators/scalar_op.py
@@ -47,7 +47,7 @@ class ScalarOp(LinearOp):
             QiskitError: If the optional coefficient is invalid.
         """
         if not isinstance(coeff, Number):
-            QiskitError(f"coeff {coeff} must be a number.")
+            raise QiskitError(f"coeff {coeff} must be a number.")
         self._coeff = coeff
         super().__init__(input_dims=dims, output_dims=dims)
 

--- a/qiskit/visualization/pulse_v2/plotters/matplotlib.py
+++ b/qiskit/visualization/pulse_v2/plotters/matplotlib.py
@@ -118,7 +118,7 @@ class Mpl2DPlotter(BasePlotter):
                     )
                     self.ax.add_patch(box)
                 else:
-                    VisualizationError(
+                    raise VisualizationError(
                         "Data {name} is not supported "
                         "by {plotter}".format(name=data, plotter=self.__class__.__name__)
                     )

--- a/qiskit/visualization/timeline/layouts.py
+++ b/qiskit/visualization/timeline/layouts.py
@@ -79,7 +79,7 @@ def qreg_creg_ascending(bits: List[types.Bits]) -> List[types.Bits]:
         elif isinstance(bit, circuit.Clbit):
             cregs.append(bit)
         else:
-            VisualizationError(f"Unknown bit {bit} is provided.")
+            raise VisualizationError(f"Unknown bit {bit} is provided.")
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -109,7 +109,7 @@ def qreg_creg_descending(bits: List[types.Bits]) -> List[types.Bits]:
         elif isinstance(bit, circuit.Clbit):
             cregs.append(bit)
         else:
-            VisualizationError(f"Unknown bit {bit} is provided.")
+            raise VisualizationError(f"Unknown bit {bit} is provided.")
 
     qregs = sorted(qregs, key=lambda x: x.index, reverse=True)
     cregs = sorted(cregs, key=lambda x: x.index, reverse=True)

--- a/qiskit/visualization/timeline/plotters/matplotlib.py
+++ b/qiskit/visualization/timeline/plotters/matplotlib.py
@@ -131,7 +131,7 @@ class MplPlotter(BasePlotter):
                 self.ax.plot(xvals.repeat(len(offsets)), offsets, **data.styles)
 
             else:
-                VisualizationError(
+                raise VisualizationError(
                     "Data {name} is not supported by {plotter}"
                     "".format(name=data, plotter=self.__class__.__name__)
                 )


### PR DESCRIPTION
Turn on `pointless-exception-statement` pylint warning.
It turns out we had a  half-dozen instances where we were indeed creating  an  exception without raising it, so I fixed them.
Obviously, those exception cases did not have test coverage and I have not created tests to cover them here.

Relates to #9614 