### PR TITLE
pylint: enable consider-using-from-import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,6 @@ disable = [
     "consider-using-dict-items",
     "consider-using-enumerate",
     "consider-using-f-string",
-    "consider-using-from-import",
     "modified-iterating-list",
     "nested-min-max",
     "no-member",

--- a/test/python/quantum_info/test_synthesis.py
+++ b/test/python/quantum_info/test_synthesis.py
@@ -77,7 +77,7 @@ from qiskit.quantum_info.synthesis.two_qubit_decompose import (
 )
 
 from qiskit.quantum_info.synthesis.ion_decompose import cnot_rxx_decompose
-import qiskit.quantum_info.synthesis.qsd as qsd
+from qiskit.quantum_info.synthesis import qsd
 from qiskit.test import QiskitTestCase
 
 


### PR DESCRIPTION
This gives a tiny readability improvement and slightly removes one more line from the config file

Relates to #9614 


