### PR TITLE
ruff enable ICN

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,10 @@ select = [
   "F632",
   "F634",
   "F823",
+  "ICN",
 ]
+[tool.ruff.flake8-import-conventions.extend-aliases]
+rustworkx = "rx"
 
 [tool.pylint.main]
 extension-pkg-allow-list = [

--- a/qiskit/algorithms/amplitude_estimators/estimation_problem.py
+++ b/qiskit/algorithms/amplitude_estimators/estimation_problem.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import warnings
 from collections.abc import Callable
 
-import numpy
+import numpy as np
 
 from qiskit.circuit import QuantumCircuit, QuantumRegister
 from qiskit.circuit.library import GroverOperator
@@ -270,5 +270,5 @@ def _rescale_amplitudes(circuit: QuantumCircuit, scaling_factor: float) -> Quant
     qr = QuantumRegister(1, "scaling")
     rescaled = QuantumCircuit(*circuit.qregs, qr)
     rescaled.compose(circuit, circuit.qubits, inplace=True)
-    rescaled.ry(2 * numpy.arcsin(scaling_factor), qr)
+    rescaled.ry(2 * np.arcsin(scaling_factor), qr)
     return rescaled

--- a/qiskit/algorithms/phase_estimators/ipe.py
+++ b/qiskit/algorithms/phase_estimators/ipe.py
@@ -15,7 +15,7 @@
 
 from __future__ import annotations
 
-import numpy
+import numpy as np
 
 import qiskit
 from qiskit.circuit import QuantumCircuit, QuantumRegister
@@ -140,9 +140,8 @@ class IterativePhaseEstimation(PhaseEstimator):
             omega_coef /= 2
 
             if self._sampler is not None:
-
                 qc = self.construct_circuit(
-                    unitary, state_preparation, k, -2 * numpy.pi * omega_coef, True
+                    unitary, state_preparation, k, -2 * np.pi * omega_coef, True
                 )
                 try:
                     sampler_job = self._sampler.run([qc])
@@ -153,21 +152,21 @@ class IterativePhaseEstimation(PhaseEstimator):
 
             elif self._quantum_instance.is_statevector:
                 qc = self.construct_circuit(
-                    unitary, state_preparation, k, -2 * numpy.pi * omega_coef, measurement=False
+                    unitary, state_preparation, k, -2 * np.pi * omega_coef, measurement=False
                 )
                 result = self._quantum_instance.execute(qc)
                 complete_state_vec = result.get_statevector(qc)
                 ancilla_density_mat = qiskit.quantum_info.partial_trace(
                     complete_state_vec, range(unitary.num_qubits)
                 )
-                ancilla_density_mat_diag = numpy.diag(ancilla_density_mat)
+                ancilla_density_mat_diag = np.diag(ancilla_density_mat)
                 max_amplitude = max(
                     ancilla_density_mat_diag.min(), ancilla_density_mat_diag.max(), key=abs
                 )
-                x = numpy.where(ancilla_density_mat_diag == max_amplitude)[0][0]
+                x = np.where(ancilla_density_mat_diag == max_amplitude)[0][0]
             else:
                 qc = self.construct_circuit(
-                    unitary, state_preparation, k, -2 * numpy.pi * omega_coef, measurement=True
+                    unitary, state_preparation, k, -2 * np.pi * omega_coef, measurement=True
                 )
                 measurements = self._quantum_instance.execute(qc).get_counts(qc)
                 x = 1 if measurements.get("1", 0) > measurements.get("0", 0) else 0

--- a/qiskit/algorithms/phase_estimators/phase_estimation.py
+++ b/qiskit/algorithms/phase_estimators/phase_estimation.py
@@ -15,7 +15,7 @@
 
 from __future__ import annotations
 
-import numpy
+import numpy as np
 
 from qiskit.circuit import QuantumCircuit
 import qiskit
@@ -157,7 +157,7 @@ class PhaseEstimation(PhaseEstimator):
 
     def _compute_phases(
         self, num_unitary_qubits: int, circuit_result: Result
-    ) -> numpy.ndarray | qiskit.result.Counts:
+    ) -> np.ndarray | qiskit.result.Counts:
         """Compute frequencies/counts of phases from the result of running the QPE circuit.
 
         How the frequencies are computed depends on whether the backend computes amplitude or
@@ -182,7 +182,7 @@ class PhaseEstimation(PhaseEstimator):
             circuit_result: the result object returned by the backend that ran the QPE circuit.
 
         Returns:
-            Either a dict or numpy.ndarray representing the frequencies of the phases.
+            Either a dict or np.ndarray representing the frequencies of the phases.
 
         """
         if self._quantum_instance.is_statevector:

--- a/qiskit/algorithms/phase_estimators/phase_estimation_result.py
+++ b/qiskit/algorithms/phase_estimators/phase_estimation_result.py
@@ -12,7 +12,7 @@
 
 """Result of running PhaseEstimation"""
 from __future__ import annotations
-import numpy
+import numpy as np
 
 from qiskit.utils.deprecation import deprecate_func
 from qiskit.result import Result
@@ -35,7 +35,7 @@ class PhaseEstimationResult(PhaseEstimatorResult):
         self,
         num_evaluation_qubits: int,
         circuit_result: Result,
-        phases: numpy.ndarray | dict[str, float],
+        phases: np.ndarray | dict[str, float],
     ) -> None:
         """
         Args:
@@ -51,7 +51,7 @@ class PhaseEstimationResult(PhaseEstimatorResult):
         self._circuit_result = circuit_result
 
     @property
-    def phases(self) -> numpy.ndarray | dict:
+    def phases(self) -> np.ndarray | dict:
         """Return all phases and their frequencies computed by QPE.
 
         This is an array or dict whose values correspond to weights on bit strings.
@@ -90,9 +90,9 @@ class PhaseEstimationResult(PhaseEstimatorResult):
         if isinstance(self.phases, dict):
             binary_phase_string = max(self.phases, key=self.phases.get)
         else:
-            # numpy.argmax ignores complex part of number. But, we take abs anyway
-            idx = numpy.argmax(abs(self.phases))
-            binary_phase_string = numpy.binary_repr(idx, self._num_evaluation_qubits)[::-1]
+            # np.argmax ignores complex part of number. But, we take abs anyway
+            idx = np.argmax(abs(self.phases))
+            binary_phase_string = np.binary_repr(idx, self._num_evaluation_qubits)[::-1]
         phase = _bit_string_to_phase(binary_phase_string)
         return phase
 
@@ -132,7 +132,7 @@ class PhaseEstimationResult(PhaseEstimatorResult):
                     # Each index corresponds to a computational basis state with the LSB rightmost.
                     # But, we chose to apply the unitaries such that the phase is recorded
                     # in reverse order. So, we reverse the bitstrings here.
-                    binary_phase_string = numpy.binary_repr(idx, self._num_evaluation_qubits)[::-1]
+                    binary_phase_string = np.binary_repr(idx, self._num_evaluation_qubits)[::-1]
                     if as_float:
                         _key: str | float = _bit_string_to_phase(binary_phase_string)
                     else:

--- a/qiskit/circuit/_utils.py
+++ b/qiskit/circuit/_utils.py
@@ -13,7 +13,7 @@
 This module contains utility functions for circuits.
 """
 
-import numpy
+import numpy as np
 from qiskit.exceptions import QiskitError
 from qiskit.circuit.exceptions import CircuitError
 
@@ -43,9 +43,9 @@ def _compute_control_matrix(base_mat, num_ctrl_qubits, ctrl_state=None):
     Raises:
         QiskitError: unrecognized mode or invalid ctrl_state
     """
-    num_target = int(numpy.log2(base_mat.shape[0]))
+    num_target = int(np.log2(base_mat.shape[0]))
     ctrl_dim = 2**num_ctrl_qubits
-    ctrl_grnd = numpy.repeat([[1], [0]], [1, ctrl_dim - 1])
+    ctrl_grnd = np.repeat([[1], [0]], [1, ctrl_dim - 1])
     if ctrl_state is None:
         ctrl_state = ctrl_dim - 1
     elif isinstance(ctrl_state, str):
@@ -55,8 +55,8 @@ def _compute_control_matrix(base_mat, num_ctrl_qubits, ctrl_state=None):
             raise QiskitError("Invalid control state value specified.")
     else:
         raise QiskitError("Invalid control state type specified.")
-    ctrl_proj = numpy.diag(numpy.roll(ctrl_grnd, ctrl_state))
-    full_mat = numpy.kron(numpy.eye(2**num_target), numpy.eye(ctrl_dim) - ctrl_proj) + numpy.kron(
+    ctrl_proj = np.diag(np.roll(ctrl_grnd, ctrl_state))
+    full_mat = np.kron(np.eye(2**num_target), np.eye(ctrl_dim) - ctrl_proj) + np.kron(
         base_mat, ctrl_proj
     )
     return full_mat

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -35,7 +35,7 @@ import copy
 from itertools import zip_longest
 from typing import List
 
-import numpy
+import numpy as np
 
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit.quantumregister import QuantumRegister
@@ -131,9 +131,9 @@ class Instruction(Operation):
                 pass
 
             try:
-                self_asarray = numpy.asarray(self_param)
-                other_asarray = numpy.asarray(other_param)
-                if numpy.shape(self_asarray) == numpy.shape(other_asarray) and numpy.allclose(
+                self_asarray = np.asarray(self_param)
+                other_asarray = np.asarray(other_param)
+                if np.shape(self_asarray) == np.shape(other_asarray) and np.allclose(
                     self_param, other_param, atol=_CUTOFF_PRECISION, rtol=0
                 ):
                     continue
@@ -141,7 +141,7 @@ class Instruction(Operation):
                 pass
 
             try:
-                if numpy.isclose(
+                if np.isclose(
                     float(self_param), float(other_param), atol=_CUTOFF_PRECISION, rtol=0
                 ):
                     continue
@@ -188,14 +188,14 @@ class Instruction(Operation):
                 other_param, ParameterExpression
             ):
                 continue
-            if isinstance(self_param, numpy.ndarray) and isinstance(other_param, numpy.ndarray):
-                if numpy.shape(self_param) == numpy.shape(other_param) and numpy.allclose(
+            if isinstance(self_param, np.ndarray) and isinstance(other_param, np.ndarray):
+                if np.shape(self_param) == np.shape(other_param) and np.allclose(
                     self_param, other_param, atol=_CUTOFF_PRECISION
                 ):
                     continue
             else:
                 try:
-                    if numpy.isclose(self_param, other_param, atol=_CUTOFF_PRECISION):
+                    if np.isclose(self_param, other_param, atol=_CUTOFF_PRECISION):
                         continue
                 except TypeError:
                     pass

--- a/qiskit/circuit/library/generalized_gates/rv.py
+++ b/qiskit/circuit/library/generalized_gates/rv.py
@@ -12,7 +12,7 @@
 
 """Rotation around an arbitrary axis on the Bloch sphere."""
 
-import numpy
+import numpy as np
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.exceptions import CircuitError
 
@@ -77,15 +77,15 @@ class RVGate(Gate):
         return RVGate(-vx, -vy, -vz)
 
     def to_matrix(self):
-        """Return a numpy.array for the R(v) gate."""
-        v = numpy.asarray(self.params, dtype=float)
-        angle = numpy.sqrt(v.dot(v))
+        """Return a np.array for the R(v) gate."""
+        v = np.asarray(self.params, dtype=float)
+        angle = np.sqrt(v.dot(v))
         if angle == 0:
-            return numpy.array([[1, 0], [0, 1]])
+            return np.array([[1, 0], [0, 1]])
         nx, ny, nz = v / angle
-        sin = numpy.sin(angle / 2)
-        cos = numpy.cos(angle / 2)
-        return numpy.array(
+        sin = np.sin(angle / 2)
+        cos = np.cos(angle / 2)
+        return np.array(
             [
                 [cos - 1j * nz * sin, (-ny - 1j * nx) * sin],
                 [(ny - 1j * nx) * sin, cos + 1j * nz * sin],

--- a/qiskit/circuit/library/grover_operator.py
+++ b/qiskit/circuit/library/grover_operator.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 from typing import List, Optional, Union
-import numpy
+import numpy as np
 
 from qiskit.circuit import QuantumCircuit, QuantumRegister, AncillaRegister
 from qiskit.exceptions import QiskitError
@@ -244,7 +244,7 @@ class GroverOperator(QuantumCircuit):
     def _build(self):
         num_state_qubits = self.oracle.num_qubits - self.oracle.num_ancillas
         circuit = QuantumCircuit(QuantumRegister(num_state_qubits, name="state"), name="Q")
-        num_ancillas = numpy.max(
+        num_ancillas = np.max(
             [
                 self.oracle.num_ancillas,
                 self.zero_reflection.num_ancillas,
@@ -274,7 +274,7 @@ class GroverOperator(QuantumCircuit):
         )
 
         # minus sign
-        circuit.global_phase = numpy.pi
+        circuit.global_phase = np.pi
 
         self.add_register(*circuit.qregs)
         try:

--- a/qiskit/circuit/library/n_local/n_local.py
+++ b/qiskit/circuit/library/n_local/n_local.py
@@ -18,7 +18,7 @@ import typing
 from typing import Union, Optional, Any, Sequence, Callable, Mapping
 from itertools import combinations
 
-import numpy
+import numpy as np
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit import Instruction, Parameter, ParameterVector, ParameterExpression
@@ -236,7 +236,7 @@ class NLocal(BlueprintCircuit):
             blocks: The new blocks for the rotation layers.
         """
         # cannot check for the attribute ``'__len__'`` because a circuit also has this attribute
-        if not isinstance(blocks, (list, numpy.ndarray)):
+        if not isinstance(blocks, (list, np.ndarray)):
             blocks = [blocks]
 
         self._invalidate()
@@ -261,7 +261,7 @@ class NLocal(BlueprintCircuit):
             blocks: The new blocks for the entanglement layers.
         """
         # cannot check for the attribute ``'__len__'`` because a circuit also has this attribute
-        if not isinstance(blocks, (list, numpy.ndarray)):
+        if not isinstance(blocks, (list, np.ndarray)):
             blocks = [blocks]
 
         self._invalidate()
@@ -608,7 +608,7 @@ class NLocal(BlueprintCircuit):
             return get_entangler_map(n, self.num_qubits, entanglement[i % num_i], offset=i)
 
         # entanglement is List[int]
-        if all(isinstance(en, (int, numpy.integer)) for en in entanglement):
+        if all(isinstance(en, (int, np.integer)) for en in entanglement):
             return [[int(en) for en in entanglement]]
 
         # check if entanglement is List[List]
@@ -623,7 +623,7 @@ class NLocal(BlueprintCircuit):
             )
 
         # entanglement is List[List[int]]
-        if all(isinstance(e2, (int, numpy.int32, numpy.int64)) for en in entanglement for e2 in en):
+        if all(isinstance(e2, (int, np.int32, np.int64)) for en in entanglement for e2 in en):
             for ind, en in enumerate(entanglement):
                 entanglement[ind] = tuple(map(int, en))
             return entanglement
@@ -634,7 +634,7 @@ class NLocal(BlueprintCircuit):
 
         # entanglement is List[List[List[int]]]
         if all(
-            isinstance(e3, (int, numpy.int32, numpy.int64))
+            isinstance(e3, (int, np.int32, np.int64))
             for en in entanglement
             for e2 in en
             for e3 in e2
@@ -650,7 +650,7 @@ class NLocal(BlueprintCircuit):
 
         # entanglement is List[List[List[List[int]]]]
         if all(
-            isinstance(e4, (int, numpy.int32, numpy.int64))
+            isinstance(e4, (int, np.int32, np.int64))
             for en in entanglement
             for e2 in en
             for e3 in e2

--- a/qiskit/circuit/library/standard_gates/global_phase.py
+++ b/qiskit/circuit/library/standard_gates/global_phase.py
@@ -13,7 +13,7 @@
 """Global Phase Gate"""
 
 from typing import Optional
-import numpy
+import numpy as np
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.quantumcircuit import QuantumCircuit
@@ -56,6 +56,6 @@ class GlobalPhaseGate(Gate):
         return GlobalPhaseGate(-self.params[0])
 
     def __array__(self, dtype=complex):
-        """Return a numpy.array for the global_phase gate."""
+        """Return a np.array for the global_phase gate."""
         theta = self.params[0]
-        return numpy.array([[numpy.exp(1j * theta)]], dtype=dtype)
+        return np.array([[np.exp(1j * theta)]], dtype=dtype)

--- a/qiskit/circuit/library/standard_gates/h.py
+++ b/qiskit/circuit/library/standard_gates/h.py
@@ -13,7 +13,7 @@
 """Hadamard gate."""
 from math import sqrt, pi
 from typing import Optional, Union
-import numpy
+import numpy as np
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
@@ -100,8 +100,8 @@ class HGate(Gate):
         return HGate()  # self-inverse
 
     def __array__(self, dtype=None):
-        """Return a Numpy.array for the H gate."""
-        return numpy.array([[1, 1], [1, -1]], dtype=dtype) / numpy.sqrt(2)
+        """Return a np.array for the H gate."""
+        return np.array([[1, 1], [1, -1]], dtype=dtype) / np.sqrt(2)
 
 
 class CHGate(ControlledGate):
@@ -162,11 +162,11 @@ class CHGate(ControlledGate):
     """
     # Define class constants. This saves future allocation time.
     _sqrt2o2 = 1 / sqrt(2)
-    _matrix1 = numpy.array(
+    _matrix1 = np.array(
         [[1, 0, 0, 0], [0, _sqrt2o2, 0, _sqrt2o2], [0, 0, 1, 0], [0, _sqrt2o2, 0, -_sqrt2o2]],
         dtype=complex,
     )
-    _matrix0 = numpy.array(
+    _matrix0 = np.array(
         [[_sqrt2o2, 0, _sqrt2o2, 0], [0, 1, 0, 0], [_sqrt2o2, 0, -_sqrt2o2, 0], [0, 0, 0, 1]],
         dtype=complex,
     )
@@ -214,8 +214,8 @@ class CHGate(ControlledGate):
         return CHGate(ctrl_state=self.ctrl_state)  # self-inverse
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the CH gate."""
+        """Return a np.array for the CH gate."""
         mat = self._matrix1 if self.ctrl_state else self._matrix0
         if dtype:
-            return numpy.asarray(mat, dtype=dtype)
+            return np.asarray(mat, dtype=dtype)
         return mat

--- a/qiskit/circuit/library/standard_gates/i.py
+++ b/qiskit/circuit/library/standard_gates/i.py
@@ -13,7 +13,7 @@
 """Identity gate."""
 
 from typing import Optional
-import numpy
+import numpy as np
 from qiskit.circuit.gate import Gate
 
 
@@ -53,8 +53,8 @@ class IGate(Gate):
         return IGate()  # self-inverse
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the identity gate."""
-        return numpy.array([[1, 0], [0, 1]], dtype=dtype)
+        """Return a np.array for the identity gate."""
+        return np.array([[1, 0], [0, 1]], dtype=dtype)
 
     def power(self, exponent: float):
         """Raise gate to a power."""

--- a/qiskit/circuit/library/standard_gates/p.py
+++ b/qiskit/circuit/library/standard_gates/p.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 from cmath import exp
-import numpy
+import numpy as np
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
@@ -122,9 +122,9 @@ class PhaseGate(Gate):
         return PhaseGate(-self.params[0])
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the Phase gate."""
+        """Return a np.array for the Phase gate."""
         lam = float(self.params[0])
-        return numpy.array([[1, 0], [0, exp(1j * lam)]], dtype=dtype)
+        return np.array([[1, 0], [0, exp(1j * lam)]], dtype=dtype)
 
     def power(self, exponent: float):
         """Raise gate to a power."""
@@ -242,13 +242,13 @@ class CPhaseGate(ControlledGate):
         return CPhaseGate(-self.params[0], ctrl_state=self.ctrl_state)
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the CPhase gate."""
+        """Return a np.array for the CPhase gate."""
         eith = exp(1j * float(self.params[0]))
         if self.ctrl_state:
-            return numpy.array(
+            return np.array(
                 [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, eith]], dtype=dtype
             )
-        return numpy.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, eith, 0], [0, 0, 0, 1]], dtype=dtype)
+        return np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, eith, 0], [0, 0, 0, 1]], dtype=dtype)
 
     def power(self, exponent: float):
         """Raise gate to a power."""

--- a/qiskit/circuit/library/standard_gates/r.py
+++ b/qiskit/circuit/library/standard_gates/r.py
@@ -16,7 +16,7 @@ import math
 from cmath import exp
 from math import pi
 from typing import Optional
-import numpy
+import numpy as np
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.parameterexpression import ParameterValueType
@@ -81,13 +81,13 @@ class RGate(Gate):
         return RGate(-self.params[0], self.params[1])
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the R gate."""
+        """Return a np.array for the R gate."""
         theta, phi = float(self.params[0]), float(self.params[1])
         cos = math.cos(theta / 2)
         sin = math.sin(theta / 2)
         exp_m = exp(-1j * phi)
         exp_p = exp(1j * phi)
-        return numpy.array([[cos, -1j * exp_m * sin], [-1j * exp_p * sin, cos]], dtype=dtype)
+        return np.array([[cos, -1j * exp_m * sin], [-1j * exp_p * sin, cos]], dtype=dtype)
 
     def power(self, exponent: float):
         """Raise gate to a power."""

--- a/qiskit/circuit/library/standard_gates/rx.py
+++ b/qiskit/circuit/library/standard_gates/rx.py
@@ -15,7 +15,7 @@
 import math
 from math import pi
 from typing import Optional, Union
-import numpy
+import numpy as np
 
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
@@ -101,10 +101,10 @@ class RXGate(Gate):
         return RXGate(-self.params[0])
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the RX gate."""
+        """Return a np.array for the RX gate."""
         cos = math.cos(self.params[0] / 2)
         sin = math.sin(self.params[0] / 2)
-        return numpy.array([[cos, -1j * sin], [-1j * sin, cos]], dtype=dtype)
+        return np.array([[cos, -1j * sin], [-1j * sin, cos]], dtype=dtype)
 
     def power(self, exponent: float):
         """Raise gate to a power."""
@@ -226,15 +226,15 @@ class CRXGate(ControlledGate):
         return CRXGate(-self.params[0], ctrl_state=self.ctrl_state)
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the CRX gate."""
+        """Return a np.array for the CRX gate."""
         half_theta = float(self.params[0]) / 2
         cos = math.cos(half_theta)
         isin = 1j * math.sin(half_theta)
         if self.ctrl_state:
-            return numpy.array(
+            return np.array(
                 [[1, 0, 0, 0], [0, cos, 0, -isin], [0, 0, 1, 0], [0, -isin, 0, cos]], dtype=dtype
             )
         else:
-            return numpy.array(
+            return np.array(
                 [[cos, 0, -isin, 0], [0, 1, 0, 0], [-isin, 0, cos, 0], [0, 0, 0, 1]], dtype=dtype
             )

--- a/qiskit/circuit/library/standard_gates/rxx.py
+++ b/qiskit/circuit/library/standard_gates/rxx.py
@@ -13,7 +13,7 @@
 """Two-qubit XX-rotation gate."""
 import math
 from typing import Optional
-import numpy
+import numpy as np
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.parameterexpression import ParameterValueType
@@ -111,11 +111,11 @@ class RXXGate(Gate):
         return RXXGate(-self.params[0])
 
     def __array__(self, dtype=None):
-        """Return a Numpy.array for the RXX gate."""
+        """Return a np.array for the RXX gate."""
         theta2 = float(self.params[0]) / 2
         cos = math.cos(theta2)
         isin = 1j * math.sin(theta2)
-        return numpy.array(
+        return np.array(
             [[cos, 0, 0, -isin], [0, cos, -isin, 0], [0, -isin, cos, 0], [-isin, 0, 0, cos]],
             dtype=dtype,
         )

--- a/qiskit/circuit/library/standard_gates/ry.py
+++ b/qiskit/circuit/library/standard_gates/ry.py
@@ -15,7 +15,7 @@
 import math
 from math import pi
 from typing import Optional, Union
-import numpy
+import numpy as np
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
@@ -100,10 +100,10 @@ class RYGate(Gate):
         return RYGate(-self.params[0])
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the RY gate."""
+        """Return a np.array for the RY gate."""
         cos = math.cos(self.params[0] / 2)
         sin = math.sin(self.params[0] / 2)
-        return numpy.array([[cos, -sin], [sin, cos]], dtype=dtype)
+        return np.array([[cos, -sin], [sin, cos]], dtype=dtype)
 
     def power(self, exponent: float):
         """Raise gate to a power."""
@@ -219,15 +219,15 @@ class CRYGate(ControlledGate):
         return CRYGate(-self.params[0], ctrl_state=self.ctrl_state)
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the CRY gate."""
+        """Return a np.array for the CRY gate."""
         half_theta = float(self.params[0]) / 2
         cos = math.cos(half_theta)
         sin = math.sin(half_theta)
         if self.ctrl_state:
-            return numpy.array(
+            return np.array(
                 [[1, 0, 0, 0], [0, cos, 0, -sin], [0, 0, 1, 0], [0, sin, 0, cos]], dtype=dtype
             )
         else:
-            return numpy.array(
+            return np.array(
                 [[cos, 0, -sin, 0], [0, 1, 0, 0], [sin, 0, cos, 0], [0, 0, 0, 1]], dtype=dtype
             )

--- a/qiskit/circuit/library/standard_gates/rz.py
+++ b/qiskit/circuit/library/standard_gates/rz.py
@@ -111,7 +111,7 @@ class RZGate(Gate):
         return RZGate(-self.params[0])
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the RZ gate."""
+        """Return a np.array for the RZ gate."""
         import numpy as np
 
         ilam2 = 0.5j * float(self.params[0])
@@ -237,17 +237,17 @@ class CRZGate(ControlledGate):
         return CRZGate(-self.params[0], ctrl_state=self.ctrl_state)
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the CRZ gate."""
-        import numpy
+        """Return a np.array for the CRZ gate."""
+        import numpy as np
 
         arg = 1j * float(self.params[0]) / 2
         if self.ctrl_state:
-            return numpy.array(
+            return np.array(
                 [[1, 0, 0, 0], [0, exp(-arg), 0, 0], [0, 0, 1, 0], [0, 0, 0, exp(arg)]],
                 dtype=dtype,
             )
         else:
-            return numpy.array(
+            return np.array(
                 [[exp(-arg), 0, 0, 0], [0, 1, 0, 0], [0, 0, exp(arg), 0], [0, 0, 0, 1]],
                 dtype=dtype,
             )

--- a/qiskit/circuit/library/standard_gates/rzx.py
+++ b/qiskit/circuit/library/standard_gates/rzx.py
@@ -155,13 +155,13 @@ class RZXGate(Gate):
         return RZXGate(-self.params[0])
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the RZX gate."""
-        import numpy
+        """Return a np.array for the RZX gate."""
+        import numpy as np
 
         half_theta = float(self.params[0]) / 2
         cos = math.cos(half_theta)
         isin = 1j * math.sin(half_theta)
-        return numpy.array(
+        return np.array(
             [[cos, 0, -isin, 0], [0, cos, 0, isin], [-isin, 0, cos, 0], [0, isin, 0, cos]],
             dtype=dtype,
         )

--- a/qiskit/circuit/library/standard_gates/rzz.py
+++ b/qiskit/circuit/library/standard_gates/rzz.py
@@ -119,11 +119,11 @@ class RZZGate(Gate):
         return RZZGate(-self.params[0])
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the RZZ gate."""
-        import numpy
+        """Return a np.array for the RZZ gate."""
+        import numpy as np
 
         itheta2 = 1j * float(self.params[0]) / 2
-        return numpy.array(
+        return np.array(
             [
                 [exp(-itheta2), 0, 0, 0],
                 [0, exp(itheta2), 0, 0],

--- a/qiskit/circuit/library/standard_gates/s.py
+++ b/qiskit/circuit/library/standard_gates/s.py
@@ -15,7 +15,7 @@
 from math import pi
 from typing import Optional, Union
 
-import numpy
+import numpy as np
 
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
@@ -79,12 +79,12 @@ class SGate(Gate):
         return SdgGate()
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the S gate."""
-        return numpy.array([[1, 0], [0, 1j]], dtype=dtype)
+        """Return a np.array for the S gate."""
+        return np.array([[1, 0], [0, 1j]], dtype=dtype)
 
     def power(self, exponent: float):
         """Raise gate to a power."""
-        return PhaseGate(0.5 * numpy.pi * exponent)
+        return PhaseGate(0.5 * np.pi * exponent)
 
 
 class SdgGate(Gate):
@@ -143,12 +143,12 @@ class SdgGate(Gate):
         return SGate()
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the Sdg gate."""
-        return numpy.array([[1, 0], [0, -1j]], dtype=dtype)
+        """Return a np.array for the Sdg gate."""
+        return np.array([[1, 0], [0, -1j]], dtype=dtype)
 
     def power(self, exponent: float):
         """Raise gate to a power."""
-        return PhaseGate(-0.5 * numpy.pi * exponent)
+        return PhaseGate(-0.5 * np.pi * exponent)
 
 
 class CSGate(ControlledGate):
@@ -180,7 +180,7 @@ class CSGate(ControlledGate):
             \end{pmatrix}
     """
     # Define class constants. This saves future allocation time.
-    _matrix1 = numpy.array(
+    _matrix1 = np.array(
         [
             [1, 0, 0, 0],
             [0, 1, 0, 0],
@@ -188,7 +188,7 @@ class CSGate(ControlledGate):
             [0, 0, 0, 1j],
         ]
     )
-    _matrix0 = numpy.array(
+    _matrix0 = np.array(
         [
             [1, 0, 0, 0],
             [0, 1, 0, 0],
@@ -214,15 +214,15 @@ class CSGate(ControlledGate):
         return CSdgGate(ctrl_state=self.ctrl_state)
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the CS gate."""
+        """Return a np.array for the CS gate."""
         mat = self._matrix1 if self.ctrl_state == 1 else self._matrix0
         if dtype is not None:
-            return numpy.asarray(mat, dtype=dtype)
+            return np.asarray(mat, dtype=dtype)
         return mat
 
     def power(self, exponent: float):
         """Raise gate to a power."""
-        return CPhaseGate(0.5 * numpy.pi * exponent)
+        return CPhaseGate(0.5 * np.pi * exponent)
 
 
 class CSdgGate(ControlledGate):
@@ -254,7 +254,7 @@ class CSdgGate(ControlledGate):
             \end{pmatrix}
     """
     # Define class constants. This saves future allocation time.
-    _matrix1 = numpy.array(
+    _matrix1 = np.array(
         [
             [1, 0, 0, 0],
             [0, 1, 0, 0],
@@ -262,7 +262,7 @@ class CSdgGate(ControlledGate):
             [0, 0, 0, -1j],
         ]
     )
-    _matrix0 = numpy.array(
+    _matrix0 = np.array(
         [
             [1, 0, 0, 0],
             [0, 1, 0, 0],
@@ -294,12 +294,12 @@ class CSdgGate(ControlledGate):
         return CSGate(ctrl_state=self.ctrl_state)
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the CSdg gate."""
+        """Return a np.array for the CSdg gate."""
         mat = self._matrix1 if self.ctrl_state == 1 else self._matrix0
         if dtype is not None:
-            return numpy.asarray(mat, dtype=dtype)
+            return np.asarray(mat, dtype=dtype)
         return mat
 
     def power(self, exponent: float):
         """Raise gate to a power."""
-        return CPhaseGate(-0.5 * numpy.pi * exponent)
+        return CPhaseGate(-0.5 * np.pi * exponent)

--- a/qiskit/circuit/library/standard_gates/swap.py
+++ b/qiskit/circuit/library/standard_gates/swap.py
@@ -13,7 +13,7 @@
 """Swap gate."""
 
 from typing import Optional, Union
-import numpy
+import numpy as np
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
@@ -108,8 +108,8 @@ class SwapGate(Gate):
         return SwapGate()  # self-inverse
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the SWAP gate."""
-        return numpy.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]], dtype=dtype)
+        """Return a np.array for the SWAP gate."""
+        return np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]], dtype=dtype)
 
 
 class CSwapGate(ControlledGate):
@@ -189,7 +189,7 @@ class CSwapGate(ControlledGate):
         |1, b, c\rangle \rightarrow |1, c, b\rangle
     """
     # Define class constants. This saves future allocation time.
-    _matrix1 = numpy.array(
+    _matrix1 = np.array(
         [
             [1, 0, 0, 0, 0, 0, 0, 0],
             [0, 1, 0, 0, 0, 0, 0, 0],
@@ -201,7 +201,7 @@ class CSwapGate(ControlledGate):
             [0, 0, 0, 0, 0, 0, 0, 1],
         ]
     )
-    _matrix0 = numpy.array(
+    _matrix0 = np.array(
         [
             [1, 0, 0, 0, 0, 0, 0, 0],
             [0, 1, 0, 0, 0, 0, 0, 0],
@@ -255,8 +255,8 @@ class CSwapGate(ControlledGate):
         return CSwapGate(ctrl_state=self.ctrl_state)  # self-inverse
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the Fredkin (CSWAP) gate."""
+        """Return a np.array for the Fredkin (CSWAP) gate."""
         mat = self._matrix1 if self.ctrl_state else self._matrix0
         if dtype:
-            return numpy.asarray(mat, dtype=dtype)
+            return np.asarray(mat, dtype=dtype)
         return mat

--- a/qiskit/circuit/library/standard_gates/sx.py
+++ b/qiskit/circuit/library/standard_gates/sx.py
@@ -14,7 +14,7 @@
 
 from math import pi
 from typing import Optional, Union
-import numpy
+import numpy as np
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
@@ -108,8 +108,8 @@ class SXGate(Gate):
         return super().control(num_ctrl_qubits=num_ctrl_qubits, label=label, ctrl_state=ctrl_state)
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the SX gate."""
-        return numpy.array([[1 + 1j, 1 - 1j], [1 - 1j, 1 + 1j]], dtype=dtype) / 2
+        """Return a np.array for the SX gate."""
+        return np.array([[1 + 1j, 1 - 1j], [1 - 1j, 1 + 1j]], dtype=dtype) / 2
 
 
 class SXdgGate(Gate):
@@ -166,8 +166,8 @@ class SXdgGate(Gate):
         return SXGate()
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the SXdg gate."""
-        return numpy.array([[1 - 1j, 1 + 1j], [1 + 1j, 1 - 1j]], dtype=dtype) / 2
+        """Return a np.array for the SXdg gate."""
+        return np.array([[1 - 1j, 1 + 1j], [1 + 1j, 1 - 1j]], dtype=dtype) / 2
 
 
 class CSXGate(ControlledGate):
@@ -226,7 +226,7 @@ class CSXGate(ControlledGate):
 
     """
     # Define class constants. This saves future allocation time.
-    _matrix1 = numpy.array(
+    _matrix1 = np.array(
         [
             [1, 0, 0, 0],
             [0, (1 + 1j) / 2, 0, (1 - 1j) / 2],
@@ -234,7 +234,7 @@ class CSXGate(ControlledGate):
             [0, (1 - 1j) / 2, 0, (1 + 1j) / 2],
         ]
     )
-    _matrix0 = numpy.array(
+    _matrix0 = np.array(
         [
             [(1 + 1j) / 2, 0, (1 - 1j) / 2, 0],
             [0, 1, 0, 0],
@@ -266,8 +266,8 @@ class CSXGate(ControlledGate):
         self.definition = qc
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the CSX gate."""
+        """Return a np.array for the CSX gate."""
         mat = self._matrix1 if self.ctrl_state else self._matrix0
         if dtype:
-            return numpy.asarray(mat, dtype=dtype)
+            return np.asarray(mat, dtype=dtype)
         return mat

--- a/qiskit/circuit/library/standard_gates/t.py
+++ b/qiskit/circuit/library/standard_gates/t.py
@@ -15,7 +15,7 @@ import math
 from math import pi
 from typing import Optional
 
-import numpy
+import numpy as np
 
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.library.standard_gates.p import PhaseGate
@@ -79,12 +79,12 @@ class TGate(Gate):
         return TdgGate()
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the T gate."""
-        return numpy.array([[1, 0], [0, (1 + 1j) / numpy.sqrt(2)]], dtype=dtype)
+        """Return a np.array for the T gate."""
+        return np.array([[1, 0], [0, (1 + 1j) / np.sqrt(2)]], dtype=dtype)
 
     def power(self, exponent: float):
         """Raise gate to a power."""
-        return PhaseGate(0.25 * numpy.pi * exponent)
+        return PhaseGate(0.25 * np.pi * exponent)
 
 
 class TdgGate(Gate):
@@ -143,9 +143,9 @@ class TdgGate(Gate):
         return TGate()
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the inverse T gate."""
-        return numpy.array([[1, 0], [0, (1 - 1j) / math.sqrt(2)]], dtype=dtype)
+        """Return a np.array for the inverse T gate."""
+        return np.array([[1, 0], [0, (1 - 1j) / math.sqrt(2)]], dtype=dtype)
 
     def power(self, exponent: float):
         """Raise gate to a power."""
-        return PhaseGate(-0.25 * numpy.pi * exponent)
+        return PhaseGate(-0.25 * np.pi * exponent)

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -14,7 +14,7 @@
 import math
 from cmath import exp
 from typing import Optional, Union
-import numpy
+import numpy as np
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.parameterexpression import ParameterValueType
@@ -115,11 +115,11 @@ class UGate(Gate):
         return super().control(num_ctrl_qubits=num_ctrl_qubits, label=label, ctrl_state=ctrl_state)
 
     def __array__(self, dtype=complex):
-        """Return a numpy.array for the U gate."""
+        """Return a np.array for the U gate."""
         theta, phi, lam = (float(param) for param in self.params)
         cos = math.cos(theta / 2)
         sin = math.sin(theta / 2)
-        return numpy.array(
+        return np.array(
             [
                 [cos, -exp(1j * lam) * sin],
                 [exp(1j * phi) * sin, exp(1j * (phi + lam)) * cos],
@@ -254,22 +254,18 @@ class CUGate(ControlledGate):
         )
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the CU gate."""
+        """Return a np.array for the CU gate."""
         theta, phi, lam, gamma = (float(param) for param in self.params)
-        cos = numpy.cos(theta / 2)
-        sin = numpy.sin(theta / 2)
-        a = numpy.exp(1j * gamma) * cos
-        b = -numpy.exp(1j * (gamma + lam)) * sin
-        c = numpy.exp(1j * (gamma + phi)) * sin
-        d = numpy.exp(1j * (gamma + phi + lam)) * cos
+        cos = np.cos(theta / 2)
+        sin = np.sin(theta / 2)
+        a = np.exp(1j * gamma) * cos
+        b = -np.exp(1j * (gamma + lam)) * sin
+        c = np.exp(1j * (gamma + phi)) * sin
+        d = np.exp(1j * (gamma + phi + lam)) * cos
         if self.ctrl_state:
-            return numpy.array(
-                [[1, 0, 0, 0], [0, a, 0, b], [0, 0, 1, 0], [0, c, 0, d]], dtype=dtype
-            )
+            return np.array([[1, 0, 0, 0], [0, a, 0, b], [0, 0, 1, 0], [0, c, 0, d]], dtype=dtype)
         else:
-            return numpy.array(
-                [[a, 0, b, 0], [0, 1, 0, 0], [c, 0, d, 0], [0, 0, 0, 1]], dtype=dtype
-            )
+            return np.array([[a, 0, b, 0], [0, 1, 0, 0], [c, 0, d, 0], [0, 0, 0, 1]], dtype=dtype)
 
     @property
     def params(self):

--- a/qiskit/circuit/library/standard_gates/u1.py
+++ b/qiskit/circuit/library/standard_gates/u1.py
@@ -13,7 +13,7 @@
 """U1 Gate."""
 from __future__ import annotations
 from cmath import exp
-import numpy
+import numpy as np
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.parameterexpression import ParameterValueType
@@ -142,9 +142,9 @@ class U1Gate(Gate):
         return U1Gate(-self.params[0])
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the U1 gate."""
+        """Return a np.array for the U1 gate."""
         lam = float(self.params[0])
-        return numpy.array([[1, 0], [0, numpy.exp(1j * lam)]], dtype=dtype)
+        return np.array([[1, 0], [0, np.exp(1j * lam)]], dtype=dtype)
 
 
 class CU1Gate(ControlledGate):
@@ -260,14 +260,14 @@ class CU1Gate(ControlledGate):
         return CU1Gate(-self.params[0], ctrl_state=self.ctrl_state)
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the CU1 gate."""
+        """Return a np.array for the CU1 gate."""
         eith = exp(1j * float(self.params[0]))
         if self.ctrl_state:
-            return numpy.array(
+            return np.array(
                 [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, eith]], dtype=dtype
             )
         else:
-            return numpy.array(
+            return np.array(
                 [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, eith, 0], [0, 0, 0, 1]], dtype=dtype
             )
 

--- a/qiskit/circuit/library/standard_gates/u2.py
+++ b/qiskit/circuit/library/standard_gates/u2.py
@@ -14,7 +14,7 @@
 from math import sqrt, pi
 from cmath import exp
 from typing import Optional
-import numpy
+import numpy as np
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit.circuit.quantumregister import QuantumRegister
@@ -113,11 +113,11 @@ class U2Gate(Gate):
         return U2Gate(-self.params[1] - pi, -self.params[0] + pi)
 
     def __array__(self, dtype=complex):
-        """Return a Numpy.array for the U2 gate."""
+        """Return a np.array for the U2 gate."""
         isqrt2 = 1 / sqrt(2)
         phi, lam = self.params
         phi, lam = float(phi), float(lam)
-        return numpy.array(
+        return np.array(
             [
                 [isqrt2, -exp(1j * lam) * isqrt2],
                 [exp(1j * phi) * isqrt2, exp(1j * (phi + lam)) * isqrt2],

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -14,7 +14,7 @@
 import math
 from cmath import exp
 from typing import Optional, Union
-import numpy
+import numpy as np
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.parameterexpression import ParameterValueType
@@ -128,12 +128,12 @@ class U3Gate(Gate):
         self.definition = qc
 
     def __array__(self, dtype=complex):
-        """Return a Numpy.array for the U3 gate."""
+        """Return a np.array for the U3 gate."""
         theta, phi, lam = self.params
         theta, phi, lam = float(theta), float(phi), float(lam)
         cos = math.cos(theta / 2)
         sin = math.sin(theta / 2)
-        return numpy.array(
+        return np.array(
             [
                 [cos, -exp(1j * lam) * sin],
                 [exp(1j * phi) * sin, exp(1j * (phi + lam)) * cos],
@@ -266,13 +266,13 @@ class CU3Gate(ControlledGate):
         )
 
     def __array__(self, dtype=complex):
-        """Return a numpy.array for the CU3 gate."""
+        """Return a np.array for the CU3 gate."""
         theta, phi, lam = self.params
         theta, phi, lam = float(theta), float(phi), float(lam)
         cos = math.cos(theta / 2)
         sin = math.sin(theta / 2)
         if self.ctrl_state:
-            return numpy.array(
+            return np.array(
                 [
                     [1, 0, 0, 0],
                     [0, cos, 0, -exp(1j * lam) * sin],
@@ -282,7 +282,7 @@ class CU3Gate(ControlledGate):
                 dtype=dtype,
             )
         else:
-            return numpy.array(
+            return np.array(
                 [
                     [cos, 0, -exp(1j * lam) * sin, 0],
                     [0, 1, 0, 0],

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 from typing import Optional, Union, Type
 from math import ceil, pi
-import numpy
+import numpy as np
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
@@ -120,8 +120,8 @@ class XGate(Gate):
         return XGate()  # self-inverse
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the X gate."""
-        return numpy.array([[0, 1], [1, 0]], dtype=dtype)
+        """Return a np.array for the X gate."""
+        return np.array([[0, 1], [1, 0]], dtype=dtype)
 
 
 class CXGate(ControlledGate):
@@ -246,15 +246,11 @@ class CXGate(ControlledGate):
         return CXGate(ctrl_state=self.ctrl_state)  # self-inverse
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the CX gate."""
+        """Return a np.array for the CX gate."""
         if self.ctrl_state:
-            return numpy.array(
-                [[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0]], dtype=dtype
-            )
+            return np.array([[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0]], dtype=dtype)
         else:
-            return numpy.array(
-                [[0, 0, 1, 0], [0, 1, 0, 0], [1, 0, 0, 0], [0, 0, 0, 1]], dtype=dtype
-            )
+            return np.array([[0, 0, 1, 0], [0, 1, 0, 0], [1, 0, 0, 0], [0, 0, 0, 1]], dtype=dtype)
 
 
 class CCXGate(ControlledGate):
@@ -402,12 +398,12 @@ class CCXGate(ControlledGate):
         return CCXGate(ctrl_state=self.ctrl_state)  # self-inverse
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the CCX gate."""
+        """Return a np.array for the CCX gate."""
         mat = _compute_control_matrix(
             self.base_gate.to_matrix(), self.num_ctrl_qubits, ctrl_state=self.ctrl_state
         )
         if dtype:
-            return numpy.asarray(mat, dtype=dtype)
+            return np.asarray(mat, dtype=dtype)
         return mat
 
 
@@ -467,8 +463,8 @@ class RCCXGate(Gate):
         self.definition = qc
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the simplified CCX gate."""
-        return numpy.array(
+        """Return a np.array for the simplified CCX gate."""
+        return np.array(
             [
                 [1, 0, 0, 0, 0, 0, 0, 0],
                 [0, 1, 0, 0, 0, 0, 0, 0],
@@ -531,7 +527,7 @@ class C3SXGate(ControlledGate):
         from qiskit.circuit.quantumcircuit import QuantumCircuit
         from .u1 import CU1Gate
 
-        angle = numpy.pi / 8
+        angle = np.pi / 8
         q = QuantumRegister(4, name="q")
         rules = [
             (HGate(), [q[3]], []),
@@ -700,12 +696,12 @@ class C3XGate(ControlledGate):
         return C3XGate(ctrl_state=self.ctrl_state)
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the C4X gate."""
+        """Return a np.array for the C4X gate."""
         mat = _compute_control_matrix(
             self.base_gate.to_matrix(), self.num_ctrl_qubits, ctrl_state=self.ctrl_state
         )
         if dtype:
-            return numpy.asarray(mat, dtype=dtype)
+            return np.asarray(mat, dtype=dtype)
         return mat
 
 
@@ -781,8 +777,8 @@ class RC3XGate(Gate):
         self.definition = qc
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the RC3X gate."""
-        return numpy.array(
+        """Return a np.array for the RC3X gate."""
+        return np.array(
             [
                 [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                 [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -858,11 +854,11 @@ class C4XGate(ControlledGate):
         qc = QuantumCircuit(q, name=self.name)
         rules = [
             (HGate(), [q[4]], []),
-            (CU1Gate(numpy.pi / 2), [q[3], q[4]], []),
+            (CU1Gate(np.pi / 2), [q[3], q[4]], []),
             (HGate(), [q[4]], []),
             (RC3XGate(), [q[0], q[1], q[2], q[3]], []),
             (HGate(), [q[4]], []),
-            (CU1Gate(-numpy.pi / 2), [q[3], q[4]], []),
+            (CU1Gate(-np.pi / 2), [q[3], q[4]], []),
             (HGate(), [q[4]], []),
             (RC3XGate().inverse(), [q[0], q[1], q[2], q[3]], []),
             (C3SXGate(), [q[0], q[1], q[2], q[4]], []),
@@ -900,12 +896,12 @@ class C4XGate(ControlledGate):
         return C4XGate(ctrl_state=self.ctrl_state)
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the C4X gate."""
+        """Return a np.array for the C4X gate."""
         mat = _compute_control_matrix(
             self.base_gate.to_matrix(), self.num_ctrl_qubits, ctrl_state=self.ctrl_state
         )
         if dtype:
-            return numpy.asarray(mat, dtype=dtype)
+            return np.asarray(mat, dtype=dtype)
         return mat
 
 
@@ -1062,7 +1058,7 @@ class MCXGrayCode(MCXGate):
         q = QuantumRegister(self.num_qubits, name="q")
         qc = QuantumCircuit(q, name=self.name)
         qc._append(HGate(), [q[-1]], [])
-        qc._append(MCU1Gate(numpy.pi, num_ctrl_qubits=self.num_ctrl_qubits), q[:], [])
+        qc._append(MCU1Gate(np.pi, num_ctrl_qubits=self.num_ctrl_qubits), q[:], [])
         qc._append(HGate(), [q[-1]], [])
         self.definition = qc
 
@@ -1189,15 +1185,15 @@ class MCXVChain(MCXGate):
         if self._dirty_ancillas:
             i = self.num_ctrl_qubits - 3
             ancilla_pre_rule = [
-                (U2Gate(0, numpy.pi), [q_target], []),
+                (U2Gate(0, np.pi), [q_target], []),
                 (CXGate(), [q_target, q_ancillas[i]], []),
-                (U1Gate(-numpy.pi / 4), [q_ancillas[i]], []),
+                (U1Gate(-np.pi / 4), [q_ancillas[i]], []),
                 (CXGate(), [q_controls[-1], q_ancillas[i]], []),
-                (U1Gate(numpy.pi / 4), [q_ancillas[i]], []),
+                (U1Gate(np.pi / 4), [q_ancillas[i]], []),
                 (CXGate(), [q_target, q_ancillas[i]], []),
-                (U1Gate(-numpy.pi / 4), [q_ancillas[i]], []),
+                (U1Gate(-np.pi / 4), [q_ancillas[i]], []),
                 (CXGate(), [q_controls[-1], q_ancillas[i]], []),
-                (U1Gate(numpy.pi / 4), [q_ancillas[i]], []),
+                (U1Gate(np.pi / 4), [q_ancillas[i]], []),
             ]
             for inst in ancilla_pre_rule:
                 definition.append(inst)
@@ -1216,15 +1212,15 @@ class MCXVChain(MCXGate):
 
         if self._dirty_ancillas:
             ancilla_post_rule = [
-                (U1Gate(-numpy.pi / 4), [q_ancillas[i]], []),
+                (U1Gate(-np.pi / 4), [q_ancillas[i]], []),
                 (CXGate(), [q_controls[-1], q_ancillas[i]], []),
-                (U1Gate(numpy.pi / 4), [q_ancillas[i]], []),
+                (U1Gate(np.pi / 4), [q_ancillas[i]], []),
                 (CXGate(), [q_target, q_ancillas[i]], []),
-                (U1Gate(-numpy.pi / 4), [q_ancillas[i]], []),
+                (U1Gate(-np.pi / 4), [q_ancillas[i]], []),
                 (CXGate(), [q_controls[-1], q_ancillas[i]], []),
-                (U1Gate(numpy.pi / 4), [q_ancillas[i]], []),
+                (U1Gate(np.pi / 4), [q_ancillas[i]], []),
                 (CXGate(), [q_target, q_ancillas[i]], []),
-                (U2Gate(0, numpy.pi), [q_target], []),
+                (U2Gate(0, np.pi), [q_target], []),
             ]
             for inst in ancilla_post_rule:
                 definition.append(inst)

--- a/qiskit/circuit/library/standard_gates/xx_plus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_plus_yy.py
@@ -154,14 +154,14 @@ class XXPlusYYGate(Gate):
         return XXPlusYYGate(-self.params[0], self.params[1])
 
     def __array__(self, dtype=complex):
-        """Return a numpy.array for the XX+YY gate."""
-        import numpy
+        """Return a np.array for the XX+YY gate."""
+        import numpy as np
 
         half_theta = float(self.params[0]) / 2
         beta = float(self.params[1])
         cos = math.cos(half_theta)
         sin = math.sin(half_theta)
-        return numpy.array(
+        return np.array(
             [
                 [1, 0, 0, 0],
                 [0, cos, -1j * sin * exp(-1j * beta), 0],

--- a/qiskit/circuit/library/standard_gates/y.py
+++ b/qiskit/circuit/library/standard_gates/y.py
@@ -14,7 +14,7 @@
 
 from math import pi
 from typing import Optional, Union
-import numpy
+import numpy as np
 
 # pylint: disable=cyclic-import
 from qiskit.circuit.controlledgate import ControlledGate
@@ -115,8 +115,8 @@ class YGate(Gate):
         return YGate()  # self-inverse
 
     def __array__(self, dtype=complex):
-        """Return a numpy.array for the Y gate."""
-        return numpy.array([[0, -1j], [1j, 0]], dtype=dtype)
+        """Return a np.array for the Y gate."""
+        return np.array([[0, -1j], [1j, 0]], dtype=dtype)
 
 
 class CYGate(ControlledGate):
@@ -175,8 +175,8 @@ class CYGate(ControlledGate):
 
     """
     # Define class constants. This saves future allocation time.
-    _matrix1 = numpy.array([[1, 0, 0, 0], [0, 0, 0, -1j], [0, 0, 1, 0], [0, 1j, 0, 0]])
-    _matrix0 = numpy.array([[0, 0, -1j, 0], [0, 1, 0, 0], [1j, 0, 0, 0], [0, 0, 0, 1]])
+    _matrix1 = np.array([[1, 0, 0, 0], [0, 0, 0, -1j], [0, 0, 1, 0], [0, 1j, 0, 0]])
+    _matrix0 = np.array([[0, 0, -1j, 0], [0, 1, 0, 0], [1j, 0, 0, 0], [0, 0, 0, 1]])
 
     def __init__(self, label: Optional[str] = None, ctrl_state: Optional[Union[str, int]] = None):
         """Create new CY gate."""
@@ -206,8 +206,8 @@ class CYGate(ControlledGate):
         return CYGate(ctrl_state=self.ctrl_state)  # self-inverse
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the CY gate."""
+        """Return a np.array for the CY gate."""
         mat = self._matrix1 if self.ctrl_state else self._matrix0
         if dtype:
-            return numpy.asarray(mat, dtype=dtype)
+            return np.asarray(mat, dtype=dtype)
         return mat

--- a/qiskit/circuit/library/standard_gates/z.py
+++ b/qiskit/circuit/library/standard_gates/z.py
@@ -15,7 +15,7 @@
 from math import pi
 from typing import Optional, Union
 
-import numpy
+import numpy as np
 
 from qiskit.circuit._utils import _compute_control_matrix
 from qiskit.circuit.controlledgate import ControlledGate
@@ -119,12 +119,12 @@ class ZGate(Gate):
         return ZGate()  # self-inverse
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the Z gate."""
-        return numpy.array([[1, 0], [0, -1]], dtype=dtype)
+        """Return a np.array for the Z gate."""
+        return np.array([[1, 0], [0, -1]], dtype=dtype)
 
     def power(self, exponent: float):
         """Raise gate to a power."""
-        return PhaseGate(numpy.pi * exponent)
+        return PhaseGate(np.pi * exponent)
 
 
 class CZGate(ControlledGate):
@@ -189,15 +189,11 @@ class CZGate(ControlledGate):
         return CZGate(ctrl_state=self.ctrl_state)  # self-inverse
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the CZ gate."""
+        """Return a np.array for the CZ gate."""
         if self.ctrl_state:
-            return numpy.array(
-                [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, -1]], dtype=dtype
-            )
+            return np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, -1]], dtype=dtype)
         else:
-            return numpy.array(
-                [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]], dtype=dtype
-            )
+            return np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]], dtype=dtype)
 
 
 class CCZGate(ControlledGate):
@@ -268,10 +264,10 @@ class CCZGate(ControlledGate):
         return CCZGate(ctrl_state=self.ctrl_state)  # self-inverse
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the CCZ gate."""
+        """Return a np.array for the CCZ gate."""
         mat = _compute_control_matrix(
             self.base_gate.to_matrix(), self.num_ctrl_qubits, ctrl_state=self.ctrl_state
         )
         if dtype is not None:
-            return numpy.asarray(mat, dtype=dtype)
+            return np.asarray(mat, dtype=dtype)
         return mat

--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -19,7 +19,7 @@ from typing import Callable, Union
 import numbers
 import operator
 
-import numpy
+import numpy as np
 
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.utils import optionals as _optionals
@@ -269,7 +269,7 @@ class ParameterExpression:
             self._raise_if_parameter_names_conflict(other._names)
             parameter_symbols = {**self._parameter_symbols, **other._parameter_symbols}
             other_expr = other._symbol_expr
-        elif isinstance(other, numbers.Number) and numpy.isfinite(other):
+        elif isinstance(other, numbers.Number) and np.isfinite(other):
             parameter_symbols = self._parameter_symbols.copy()
             other_expr = other
         else:

--- a/qiskit/extensions/hamiltonian_gate.py
+++ b/qiskit/extensions/hamiltonian_gate.py
@@ -15,7 +15,7 @@ Gate described by the time evolution of a Hermitian Hamiltonian operator.
 """
 
 from numbers import Number
-import numpy
+import numpy as np
 
 from qiskit.circuit import Gate, QuantumCircuit, QuantumRegister, ParameterExpression
 from qiskit.quantum_info.operators.predicates import matrix_equal
@@ -56,15 +56,15 @@ class HamiltonianGate(Gate):
             # numpy matrix from `Operator.data`.
             data = data.to_operator().data
         # Convert to numpy array in case not already an array
-        data = numpy.array(data, dtype=complex)
+        data = np.array(data, dtype=complex)
         # Check input is unitary
         if not is_hermitian_matrix(data):
             raise ExtensionError("Input matrix is not Hermitian.")
-        if isinstance(time, Number) and time != numpy.real(time):
+        if isinstance(time, Number) and time != np.real(time):
             raise ExtensionError("Evolution time is not real.")
         # Check input is N-qubit matrix
         input_dim, output_dim = data.shape
-        num_qubits = int(numpy.log2(input_dim))
+        num_qubits = int(np.log2(input_dim))
         if input_dim != output_dim or 2**num_qubits != input_dim:
             raise ExtensionError("Input matrix is not an N-qubit operator.")
 
@@ -99,7 +99,7 @@ class HamiltonianGate(Gate):
 
     def conjugate(self):
         """Return the conjugate of the Hamiltonian."""
-        return HamiltonianGate(numpy.conj(self.params[0]), -self.params[1])
+        return HamiltonianGate(np.conj(self.params[0]), -self.params[1])
 
     def adjoint(self):
         """Return the adjoint of the unitary."""
@@ -107,7 +107,7 @@ class HamiltonianGate(Gate):
 
     def transpose(self):
         """Return the transpose of the Hamiltonian."""
-        return HamiltonianGate(numpy.transpose(self.params[0]), self.params[1])
+        return HamiltonianGate(np.transpose(self.params[0]), self.params[1])
 
     def _define(self):
         """Calculate a subcircuit that implements this unitary."""
@@ -122,7 +122,7 @@ class HamiltonianGate(Gate):
 
     def validate_parameter(self, parameter):
         """Hamiltonian parameter has to be an ndarray, operator or float."""
-        if isinstance(parameter, (float, int, numpy.ndarray)):
+        if isinstance(parameter, (float, int, np.ndarray)):
             return parameter
         elif isinstance(parameter, ParameterExpression) and len(parameter.parameters) == 0:
             return float(parameter)

--- a/qiskit/extensions/unitary.py
+++ b/qiskit/extensions/unitary.py
@@ -14,7 +14,7 @@
 Arbitrary unitary circuit instruction.
 """
 
-import numpy
+import numpy as np
 
 from qiskit.circuit import Gate, ControlledGate
 from qiskit.circuit import QuantumCircuit
@@ -76,13 +76,13 @@ class UnitaryGate(Gate):
             # numpy matrix from `Operator.data`.
             data = data.to_operator().data
         # Convert to numpy array in case not already an array
-        data = numpy.array(data, dtype=complex)
+        data = np.array(data, dtype=complex)
         # Check input is unitary
         if not is_unitary_matrix(data):
             raise ExtensionError("Input matrix is not unitary.")
         # Check input is N-qubit matrix
         input_dim, output_dim = data.shape
-        num_qubits = int(numpy.log2(input_dim))
+        num_qubits = int(np.log2(input_dim))
         if input_dim != output_dim or 2**num_qubits != input_dim:
             raise ExtensionError("Input matrix is not an N-qubit operator.")
 
@@ -109,7 +109,7 @@ class UnitaryGate(Gate):
 
     def conjugate(self):
         """Return the conjugate of the unitary."""
-        return UnitaryGate(numpy.conj(self.to_matrix()))
+        return UnitaryGate(np.conj(self.to_matrix()))
 
     def adjoint(self):
         """Return the adjoint of the unitary."""
@@ -117,7 +117,7 @@ class UnitaryGate(Gate):
 
     def transpose(self):
         """Return the transpose of the unitary."""
-        return UnitaryGate(numpy.transpose(self.to_matrix()))
+        return UnitaryGate(np.transpose(self.to_matrix()))
 
     def _define(self):
         """Calculate a subcircuit that implements this unitary."""
@@ -176,7 +176,7 @@ class UnitaryGate(Gate):
 
     def validate_parameter(self, parameter):
         """Unitary gate parameter has to be an ndarray."""
-        if isinstance(parameter, numpy.ndarray):
+        if isinstance(parameter, np.ndarray):
             return parameter
         else:
             raise CircuitError(f"invalid param type {type(parameter)} in gate {self.name}")

--- a/qiskit/qobj/pulse_qobj.py
+++ b/qiskit/qobj/pulse_qobj.py
@@ -19,7 +19,7 @@ import copy
 import pprint
 from typing import Union, List
 
-import numpy
+import numpy as np
 from qiskit.qobj.common import QobjDictField
 from qiskit.qobj.common import QobjHeader
 from qiskit.qobj.common import QobjExperimentHeader
@@ -502,7 +502,7 @@ class PulseLibraryItem:
         """
         self.name = name
         if isinstance(samples[0], list):
-            self.samples = numpy.array([complex(sample[0], sample[1]) for sample in samples])
+            self.samples = np.array([complex(sample[0], sample[1]) for sample in samples])
         else:
             self.samples = samples
 
@@ -598,11 +598,11 @@ class PulseQobj:
         .. code-block::
 
             import json
-            import numpy
+            import numpy as np
 
             class QobjEncoder(json.JSONEncoder):
                 def default(self, obj):
-                    if isinstance(obj, numpy.ndarray):
+                    if isinstance(obj, np.ndarray):
                         return obj.tolist()
                     if isinstance(obj, complex):
                         return (obj.real, obj.imag)

--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -20,7 +20,7 @@ from functools import singledispatchmethod
 from itertools import zip_longest
 from collections import defaultdict
 
-import rustworkx
+import rustworkx as rx
 
 from qiskit.circuit import Gate, ParameterVector, QuantumRegister, ControlFlowOp, QuantumCircuit
 from qiskit.dagcircuit import DAGCircuit
@@ -385,11 +385,11 @@ class BasisTranslator(TransformationPass):
 
 
 class StopIfBasisRewritable(Exception):
-    """Custom exception that signals `rustworkx.dijkstra_search` to stop."""
+    """Custom exception that signals `rx.dijkstra_search` to stop."""
 
 
-class BasisSearchVisitor(rustworkx.visit.DijkstraVisitor):
-    """Handles events emitted during `rustworkx.dijkstra_search`."""
+class BasisSearchVisitor(rx.visit.DijkstraVisitor):
+    """Handles events emitted during `rx.dijkstra_search`."""
 
     def __init__(self, graph, source_basis, target_basis):
         self.graph = graph
@@ -440,7 +440,7 @@ class BasisSearchVisitor(rustworkx.visit.DijkstraVisitor):
         # if there are gates in this `rule` that we have not yet generated, we can't apply
         # this `rule`. if `target` is already in basis, it's not beneficial to use this rule.
         if self._num_gates_remain_for_rule[edata.index] > 0 or target in self.target_basis:
-            raise rustworkx.visit.PruneSearch
+            raise rx.visit.PruneSearch
 
     def edge_relaxed(self, edge):
         _, target, edata = edge
@@ -519,7 +519,7 @@ def _basis_search(equiv_lib, source_basis, target_basis):
         )
         rtn = None
         try:
-            rustworkx.digraph_dijkstra_search(graph, [dummy], vis.edge_cost, vis)
+            rx.digraph_dijkstra_search(graph, [dummy], vis.edge_cost, vis)
         except StopIfBasisRewritable:
             rtn = vis.basis_transforms
 
@@ -586,7 +586,6 @@ def _compose_transforms(basis_transforms, source_basis, source_dag):
             ]
 
             if doomed_nodes and logger.isEnabledFor(logging.DEBUG):
-
                 logger.debug(
                     "Updating transform for mapped instr %s %s from \n%s",
                     mapped_instr_name,
@@ -595,7 +594,6 @@ def _compose_transforms(basis_transforms, source_basis, source_dag):
                 )
 
             for node in doomed_nodes:
-
                 replacement = equiv.assign_parameters(
                     dict(zip_longest(equiv_params, node.op.params))
                 )
@@ -605,7 +603,6 @@ def _compose_transforms(basis_transforms, source_basis, source_dag):
                 dag.substitute_node_with_dag(node, replacement_dag)
 
             if doomed_nodes and logger.isEnabledFor(logging.DEBUG):
-
                 logger.debug(
                     "Updated transform for mapped instr %s %s to\n%s",
                     mapped_instr_name,

--- a/qiskit/transpiler/passes/layout/dense_layout.py
+++ b/qiskit/transpiler/passes/layout/dense_layout.py
@@ -14,7 +14,7 @@
 
 
 import numpy as np
-import rustworkx
+import rustworkx as rx
 
 from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.basepasses import AnalysisPass
@@ -121,7 +121,7 @@ class DenseLayout(AnalysisPass):
         if num_qubits == 0:
             return []
 
-        adjacency_matrix = rustworkx.adjacency_matrix(coupling_map.graph)
+        adjacency_matrix = rx.adjacency_matrix(coupling_map.graph)
         reverse_index_map = {v: k for k, v in enumerate(coupling_map.graph.nodes())}
 
         error_mat, use_error = _build_error_matrix(

--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -15,7 +15,7 @@
 import logging
 from copy import copy, deepcopy
 
-import rustworkx
+import rustworkx as rx
 
 from qiskit.circuit.library.standard_gates import SwapGate
 from qiskit.transpiler.basepasses import TransformationPass
@@ -157,9 +157,7 @@ class SabreSwap(TransformationPass):
             self.coupling_map.make_symmetric()
         self._neighbor_table = None
         if self.coupling_map is not None:
-            self._neighbor_table = NeighborTable(
-                rustworkx.adjacency_matrix(self.coupling_map.graph)
-            )
+            self._neighbor_table = NeighborTable(rx.adjacency_matrix(self.coupling_map.graph))
 
         self.heuristic = heuristic
         self.seed = seed

--- a/qiskit/visualization/bloch.py
+++ b/qiskit/visualization/bloch.py
@@ -50,7 +50,7 @@ __all__ = ["Bloch"]
 
 import os
 import numpy as np
-import matplotlib
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib.patches import FancyArrowPatch
 from mpl_toolkits.mplot3d import Axes3D, proj3d
@@ -86,7 +86,7 @@ class Arrow3D(Patch3D, FancyArrowPatch):
     def draw(self, renderer):
         xs3d, ys3d, zs3d = zip(*self._segment3d)
         x_s, y_s, _ = proj3d.proj_transform(xs3d, ys3d, zs3d, self.axes.M)
-        self._path2d = matplotlib.path.Path(np.column_stack([x_s, y_s]))
+        self._path2d = mpl.path.Path(np.column_stack([x_s, y_s]))
         self.set_positions((x_s[0], y_s[0]), (x_s[1], y_s[1]))
         FancyArrowPatch.draw(self, renderer)
 
@@ -152,7 +152,6 @@ class Bloch:
     def __init__(
         self, fig=None, axes=None, view=None, figsize=None, background=False, font_size=20
     ):
-
         # Figure and axes
         self._ext_fig = False
         if fig is not None:
@@ -416,7 +415,7 @@ class Bloch:
             self.fig = plt.figure(figsize=self.figsize)
 
         if not self._ext_axes:
-            if tuple(int(x) for x in matplotlib.__version__.split(".")) >= (3, 4, 0):
+            if tuple(int(x) for x in mpl.__version__.split(".")) >= (3, 4, 0):
                 self.axes = Axes3D(
                     self.fig, azim=self.view[0], elev=self.view[1], auto_add_to_figure=False
                 )
@@ -585,7 +584,6 @@ class Bloch:
         """Plot vector"""
         # -X and Y data are switched for plotting purposes
         for k in range(len(self.vectors)):
-
             xs3d = self.vectors[k][1] * np.array([0, 1])
             ys3d = -self.vectors[k][0] * np.array([0, 1])
             zs3d = self.vectors[k][2] * np.array([0, 1])

--- a/qiskit/visualization/gate_map.py
+++ b/qiskit/visualization/gate_map.py
@@ -1314,7 +1314,7 @@ def plot_error_map(backend, figsize=(12, 9), show_title=True, qubit_coordinates=
             plot_error_map(backend)
     """
     import seaborn as sns
-    import matplotlib
+    import matplotlib as mpl
     import matplotlib.pyplot as plt
     from matplotlib import gridspec, ticker
 
@@ -1403,20 +1403,17 @@ def plot_error_map(backend, figsize=(12, 9), show_title=True, qubit_coordinates=
     single_gate_errors = 100 * np.asarray(single_gate_errors)
     avg_1q_err = np.mean(single_gate_errors)
 
-    single_norm = matplotlib.colors.Normalize(
-        vmin=min(single_gate_errors), vmax=max(single_gate_errors)
-    )
+    single_norm = mpl.colors.Normalize(vmin=min(single_gate_errors), vmax=max(single_gate_errors))
     q_colors = [color_map(single_norm(err)) for err in single_gate_errors]
 
     directed = False
     line_colors = []
     if cmap:
-
         # Convert to percent
         cx_errors = 100 * np.asarray(cx_errors)
         avg_cx_err = np.mean(cx_errors)
 
-        cx_norm = matplotlib.colors.Normalize(vmin=min(cx_errors), vmax=max(cx_errors))
+        cx_norm = mpl.colors.Normalize(vmin=min(cx_errors), vmax=max(cx_errors))
         line_colors = [color_map(cx_norm(err)) for err in cx_errors]
 
     read_err = 100 * np.asarray(read_err)
@@ -1453,7 +1450,7 @@ def plot_error_map(backend, figsize=(12, 9), show_title=True, qubit_coordinates=
     main_ax.axis("off")
     main_ax.set_aspect(1)
     if cmap:
-        single_cb = matplotlib.colorbar.ColorbarBase(
+        single_cb = mpl.colorbar.ColorbarBase(
             bleft_ax, cmap=color_map, norm=single_norm, orientation="horizontal"
         )
         tick_locator = ticker.MaxNLocator(nbins=5)
@@ -1467,7 +1464,7 @@ def plot_error_map(backend, figsize=(12, 9), show_title=True, qubit_coordinates=
         bleft_ax.set_title(f"H error rate (%) = {round(avg_1q_err, 3)}")
 
     if cmap:
-        cx_cb = matplotlib.colorbar.ColorbarBase(
+        cx_cb = mpl.colorbar.ColorbarBase(
             bright_ax, cmap=color_map, norm=cx_norm, orientation="horizontal"
         )
         tick_locator = ticker.MaxNLocator(nbins=5)

--- a/qiskit/visualization/pulse_v2/plotters/matplotlib.py
+++ b/qiskit/visualization/pulse_v2/plotters/matplotlib.py
@@ -14,7 +14,7 @@
 
 from typing import Optional
 
-import matplotlib
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.patches import Rectangle
@@ -184,7 +184,7 @@ class Mpl2DPlotter(BasePlotter):
                 size=self.canvas.formatter["text_size.fig_title"],
             )
 
-    def get_image(self, interactive: bool = False) -> matplotlib.pyplot.Figure:
+    def get_image(self, interactive: bool = False) -> mpl.pyplot.Figure:
         """Get image data to return.
 
         Args:

--- a/qiskit/visualization/timeline/plotters/matplotlib.py
+++ b/qiskit/visualization/timeline/plotters/matplotlib.py
@@ -16,7 +16,7 @@
 
 from typing import Optional, Tuple
 
-import matplotlib
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.collections import PatchCollection
@@ -177,7 +177,7 @@ class MplPlotter(BasePlotter):
         """
         plt.savefig(filename, bbox_inches="tight", dpi=self.canvas.formatter["general.dpi"])
 
-    def get_image(self, interactive: bool = False) -> matplotlib.pyplot.Figure:
+    def get_image(self, interactive: bool = False) -> mpl.pyplot.Figure:
         """Get image data to return.
         Args:
             interactive: When set `True` show the circuit in a new window.

--- a/qiskit/visualization/transition_visualization.py
+++ b/qiskit/visualization/transition_visualization.py
@@ -158,7 +158,7 @@ def visualize_transition(circuit, trace=False, saveas=None, fpg=100, spg=2):
         has_ipython = False
 
     try:
-        import matplotlib
+        import matplotlib as mpl
         from matplotlib import pyplot as plt
         from matplotlib import animation
         from mpl_toolkits.mplot3d import Axes3D
@@ -266,7 +266,7 @@ def visualize_transition(circuit, trace=False, saveas=None, fpg=100, spg=2):
     starting_pos = _normalize(np.array([0, 0, 1]))
 
     fig = plt.figure(figsize=(5, 5))
-    if tuple(int(x) for x in matplotlib.__version__.split(".")) >= (3, 4, 0):
+    if tuple(int(x) for x in mpl.__version__.split(".")) >= (3, 4, 0):
         _ax = Axes3D(fig, auto_add_to_figure=False)
         fig.add_axes(_ax)
     else:
@@ -356,7 +356,7 @@ def visualize_transition(circuit, trace=False, saveas=None, fpg=100, spg=2):
         ani.save(saveas, fps=30)
     if jupyter:
         # This is necessary to overcome matplotlib memory limit
-        matplotlib.rcParams["animation.embed_limit"] = 50
+        mpl.rcParams["animation.embed_limit"] = 50
         plt.close(fig)
         return HTML(ani.to_jshtml())
     plt.show()

--- a/qiskit/visualization/utils.py
+++ b/qiskit/visualization/utils.py
@@ -43,7 +43,8 @@ def matplotlib_close_if_inline(figure):
     duplicate images appearing; the inline backends will capture the figure in preparation and
     display it as well, whereas the drawers want to return the figure to be displayed."""
     # This can only called if figure has already been created, so matplotlib must exist.
-    import matplotlib.pyplot
+    import matplotlib as mpl
+    import matplotlib.pyplot as plt
 
-    if matplotlib.get_backend() in MATPLOTLIB_INLINE_BACKENDS:
-        matplotlib.pyplot.close(figure)
+    if mpl.get_backend() in MATPLOTLIB_INLINE_BACKENDS:
+        plt.close(figure)

--- a/test/python/algorithms/optimizers/test_optimizers_scikitquant.py
+++ b/test/python/algorithms/optimizers/test_optimizers_scikitquant.py
@@ -17,7 +17,7 @@ from test.python.algorithms import QiskitAlgorithmsTestCase
 
 from ddt import ddt, data, unpack
 
-import numpy
+import numpy as np
 from qiskit import BasicAer
 from qiskit.circuit.library import RealAmplitudes
 from qiskit.utils import QuantumInstance, algorithm_globals
@@ -69,7 +69,7 @@ class TestOptimizers(QiskitAlgorithmsTestCase):
             self.skipTest(str(ex))
 
     @unittest.skipIf(
-        tuple(map(int, numpy.__version__.split("."))) >= (1, 24, 0),
+        tuple(map(int, np.__version__.split("."))) >= (1, 24, 0),
         "scikit's SnobFit currently incompatible with NumPy 1.24.0.",
     )
     def test_snobfit(self):
@@ -81,7 +81,7 @@ class TestOptimizers(QiskitAlgorithmsTestCase):
             self.skipTest(str(ex))
 
     @unittest.skipIf(
-        tuple(map(int, numpy.__version__.split("."))) >= (1, 24, 0),
+        tuple(map(int, np.__version__.split("."))) >= (1, 24, 0),
         "scikit's SnobFit currently incompatible with NumPy 1.24.0.",
     )
     @data((None,), ([(-1, 1), (None, None)],))

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -20,7 +20,7 @@ from operator import add, mul, sub, truediv
 
 from test import combine
 
-import numpy
+import numpy as np
 from ddt import data, ddt, named_data
 
 import qiskit
@@ -200,10 +200,10 @@ class TestParameters(QiskitTestCase):
         y = Parameter("y")
         z = Parameter("z")
         v = ParameterVector("v", 3)
-        for i in (numpy.float16, numpy.float32):
+        for i in (np.float16, np.float32):
             with self.subTest(float_type=i):
                 expr = (v[0] * (x + y + z) + phase) - (v[2] * v[1])
-                params = numpy.array([0.1 * j for j in range(8)], dtype=i)
+                params = np.array([0.1 * j for j in range(8)], dtype=i)
                 order = [phase] + v[:] + [x, y, z]
                 param_dict = dict(zip(order, params))
                 bound_value = expr.bind(param_dict)
@@ -349,9 +349,9 @@ class TestParameters(QiskitTestCase):
     @named_data(
         ["int", 2, int],
         ["float", 2.5, float],
-        ["float16", numpy.float16(2.5), float],
-        ["float32", numpy.float32(2.5), float],
-        ["float64", numpy.float64(2.5), float],
+        ["float16", np.float16(2.5), float],
+        ["float32", np.float32(2.5), float],
+        ["float64", np.float64(2.5), float],
     )
     def test_circuit_assignment_to_numeric(self, value, type_):
         """Test binding a numeric value to a circuit instruction"""
@@ -653,7 +653,7 @@ class TestParameters(QiskitTestCase):
         for assign_fun in ["bind_parameters", "assign_parameters"]:
             with self.subTest(assign_fun=assign_fun):
                 circs = []
-                theta_list = numpy.linspace(0, numpy.pi, 20)
+                theta_list = np.linspace(0, np.pi, 20)
                 for theta_i in theta_list:
                     circs.append(getattr(qc_aer, assign_fun)({theta: theta_i}))
                 qobj = assemble(circs)
@@ -684,7 +684,7 @@ class TestParameters(QiskitTestCase):
         qr1 = QuantumRegister(1, name="qr1")
         qc1 = QuantumCircuit(qr1)
         qc1.rx(theta, qr1)
-        qc1.rz(numpy.pi / 2, qr1)
+        qc1.rz(np.pi / 2, qr1)
         qc1.ry(theta, qr1)
         gate = qc1.to_instruction()
         self.assertEqual(gate.params, [theta])
@@ -722,7 +722,7 @@ class TestParameters(QiskitTestCase):
             for i, q in enumerate(qc.qubits[:-1]):
                 qc.cx(qc.qubits[i], qc.qubits[i + 1])
             qc.barrier()
-        theta_vals = numpy.linspace(0, 1, len(theta)) * numpy.pi
+        theta_vals = np.linspace(0, 1, len(theta)) * np.pi
         self.assertEqual(set(qc.parameters), set(theta.params))
         for assign_fun in ["bind_parameters", "assign_parameters"]:
             with self.subTest(assign_fun=assign_fun):
@@ -1043,7 +1043,7 @@ class TestParameters(QiskitTestCase):
 
         for assign_fun in ["bind_parameters", "assign_parameters"]:
             with self.subTest(assign_fun=assign_fun):
-                bound_qc = getattr(unbound_qc, assign_fun)({theta: numpy.pi / 2})
+                bound_qc = getattr(unbound_qc, assign_fun)({theta: np.pi / 2})
 
                 shots = 1024
                 job = execute(bound_qc, backend=BasicAer.get_backend("qasm_simulator"), shots=shots)
@@ -1144,13 +1144,13 @@ class TestParameters(QiskitTestCase):
         theta = Parameter(name="theta")
 
         qc = QuantumCircuit(2)
-        qc.p(numpy.abs(-phi), 0)
-        qc.p(numpy.cos(phi), 0)
-        qc.p(numpy.sin(phi), 0)
-        qc.p(numpy.tan(phi), 0)
-        qc.rz(numpy.arccos(theta), 1)
-        qc.rz(numpy.arctan(theta), 1)
-        qc.rz(numpy.arcsin(theta), 1)
+        qc.p(np.abs(-phi), 0)
+        qc.p(np.cos(phi), 0)
+        qc.p(np.sin(phi), 0)
+        qc.p(np.tan(phi), 0)
+        qc.rz(np.arccos(theta), 1)
+        qc.rz(np.arctan(theta), 1)
+        qc.rz(np.arcsin(theta), 1)
 
         qc.assign_parameters({phi: pi, theta: 1}, inplace=True)
 
@@ -1173,13 +1173,13 @@ class TestParameters(QiskitTestCase):
         theta = ParameterVector("theta", length=7)
 
         qc = QuantumCircuit(7)
-        qc.rx(numpy.abs(theta[0]), 0)
-        qc.rx(numpy.cos(theta[1]), 1)
-        qc.rx(numpy.sin(theta[2]), 2)
-        qc.rx(numpy.tan(theta[3]), 3)
-        qc.rx(numpy.arccos(theta[4]), 4)
-        qc.rx(numpy.arctan(theta[5]), 5)
-        qc.rx(numpy.arcsin(theta[6]), 6)
+        qc.rx(np.abs(theta[0]), 0)
+        qc.rx(np.cos(theta[1]), 1)
+        qc.rx(np.sin(theta[2]), 2)
+        qc.rx(np.tan(theta[3]), 3)
+        qc.rx(np.arccos(theta[4]), 4)
+        qc.rx(np.arctan(theta[5]), 5)
+        qc.rx(np.arcsin(theta[6]), 6)
 
         # transpile to different basis
         transpiled = transpile(qc, basis_gates=["rz", "sx", "x", "cx"], optimization_level=0)
@@ -1416,7 +1416,7 @@ class TestParameterExpressions(QiskitTestCase):
     def test_expressions_of_parameter_with_constant(self):
         """Verify operating on a Parameter with a constant."""
 
-        good_constants = [2, 1.3, 0, -1, -1.0, numpy.pi, 1j]
+        good_constants = [2, 1.3, 0, -1, -1.0, np.pi, 1j]
 
         x = Parameter("x")
 
@@ -1480,7 +1480,7 @@ class TestParameterExpressions(QiskitTestCase):
     def test_operating_on_a_parameter_with_a_non_float_will_raise(self):
         """Verify operations between a Parameter and a non-float will raise."""
 
-        bad_constants = ["1", numpy.Inf, numpy.NaN, None, {}, []]
+        bad_constants = ["1", np.Inf, np.NaN, None, {}, []]
 
         x = Parameter("x")
 
@@ -1525,15 +1525,15 @@ class TestParameterExpressions(QiskitTestCase):
 
             self.assertEqual(partially_bound_expr.parameters, {y})
 
-            fully_bound_expr = partially_bound_expr.bind({y: -numpy.pi})
+            fully_bound_expr = partially_bound_expr.bind({y: -np.pi})
 
             self.assertEqual(fully_bound_expr.parameters, set())
-            self.assertEqual(float(fully_bound_expr), op(2.3, -numpy.pi))
+            self.assertEqual(float(fully_bound_expr), op(2.3, -np.pi))
 
-            bound_expr = expr.bind({x: 2.3, y: -numpy.pi})
+            bound_expr = expr.bind({x: 2.3, y: -np.pi})
 
             self.assertEqual(bound_expr.parameters, set())
-            self.assertEqual(float(bound_expr), op(2.3, -numpy.pi))
+            self.assertEqual(float(bound_expr), op(2.3, -np.pi))
 
     def test_expressions_operation_order(self):
         """Verify ParameterExpressions respect order of operations."""
@@ -1647,7 +1647,7 @@ class TestParameterExpressions(QiskitTestCase):
         qc1 = QuantumCircuit(qr1)
 
         qc1.rx(theta, qr1)
-        qc1.rz(numpy.pi / 2, qr1)
+        qc1.rz(np.pi / 2, qr1)
         qc1.ry(theta * phi, qr1)
 
         if target_type == "gate":
@@ -1668,9 +1668,9 @@ class TestParameterExpressions(QiskitTestCase):
         binds = {delta: 1, theta: 2, phi: 3}
         expected_qc = QuantumCircuit(qr2)
         expected_qc.rx(2, 1)
-        expected_qc.rz(numpy.pi / 2, 1)
+        expected_qc.rz(np.pi / 2, 1)
         expected_qc.ry(3 * 2, 1)
-        expected_qc.r(1, numpy.pi / 2, 0)
+        expected_qc.r(1, np.pi / 2, 0)
 
         if order == "bind-decompose":
             decomp_bound_qc = qc2.assign_parameters(binds).decompose()
@@ -1690,7 +1690,7 @@ class TestParameterExpressions(QiskitTestCase):
         qc1 = QuantumCircuit(qr1)
 
         qc1.rx(theta, qr1)
-        qc1.rz(numpy.pi / 2, qr1)
+        qc1.rz(np.pi / 2, qr1)
         qc1.ry(theta * phi, qr1)
 
         theta_p = Parameter("theta")
@@ -1714,9 +1714,9 @@ class TestParameterExpressions(QiskitTestCase):
         binds = {delta: 1, theta_p: 2, phi_p: 3}
         expected_qc = QuantumCircuit(qr2)
         expected_qc.rx(2, 1)
-        expected_qc.rz(numpy.pi / 2, 1)
+        expected_qc.rz(np.pi / 2, 1)
         expected_qc.ry(3 * 2, 1)
-        expected_qc.r(1, numpy.pi / 2, 0)
+        expected_qc.r(1, np.pi / 2, 0)
 
         if order == "bind-decompose":
             decomp_bound_qc = qc2.assign_parameters(binds).decompose()
@@ -1748,7 +1748,7 @@ class TestParameterExpressions(QiskitTestCase):
         qc.h(0)
         qc.measure(0, 0)
 
-        theta_range = numpy.linspace(0, 2 * numpy.pi, 128)
+        theta_range = np.linspace(0, 2 * np.pi, 128)
         circuits = [qc.assign_parameters({theta: theta_val}) for theta_val in theta_range]
 
         self.assertEqual(len(circuits), len(theta_range))
@@ -1851,7 +1851,7 @@ class TestParameterExpressions(QiskitTestCase):
         circuit.append(gate_class(*free_params), list(range(num_qubits)))
         bound_circuit = circuit.assign_parameters({free_params: params})
 
-        numpy.testing.assert_array_almost_equal(Operator(bound_circuit).data, gate.to_matrix())
+        np.testing.assert_array_almost_equal(Operator(bound_circuit).data, gate.to_matrix())
 
     def test_parameter_expression_grad(self):
         """Verify correctness of ParameterExpression gradients."""
@@ -1953,7 +1953,7 @@ class TestParameterEquality(QiskitTestCase):
         """Verfiy ParameterExpression phi
         and ParameterExpression cos(phi) have the same symbol map"""
         phi = Parameter("phi")
-        cos_phi = numpy.cos(phi)
+        cos_phi = np.cos(phi)
         self.assertEqual(phi._parameter_symbols, cos_phi._parameter_symbols)
 
 

--- a/test/python/circuit/test_registerless_circuit.py
+++ b/test/python/circuit/test_registerless_circuit.py
@@ -12,7 +12,7 @@
 
 """Test registerless QuantumCircuit and Gates on wires"""
 
-import numpy
+import numpy as np
 
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.circuit import Qubit, Clbit, AncillaQubit
@@ -232,7 +232,7 @@ class TestGatesOnWires(QiskitTestCase):
 
     def test_circuit_initialize_single_qubit(self):
         """Test initialize on single qubit."""
-        init_vector = [numpy.sqrt(0.5), numpy.sqrt(0.5)]
+        init_vector = [np.sqrt(0.5), np.sqrt(0.5)]
         qreg = QuantumRegister(2)
         circuit = QuantumCircuit(qreg)
         circuit.initialize(init_vector, qreg[0])
@@ -383,10 +383,10 @@ class TestGatesOnWireSlice(QiskitTestCase):
 
     def test_wire_np_int(self):
         """Test gate wire with numpy int"""
-        numpy_int = numpy.dtype("int").type(2)
+        np_int = np.dtype("int").type(2)
         qreg = QuantumRegister(4)
         circuit = QuantumCircuit(qreg)
-        circuit.h(numpy_int)
+        circuit.h(np_int)
 
         expected = QuantumCircuit(qreg)
         expected.h(qreg[2])
@@ -395,7 +395,7 @@ class TestGatesOnWireSlice(QiskitTestCase):
 
     def test_wire_np_1d_array(self):
         """Test gate wire with numpy array (one-dimensional)"""
-        numpy_arr = numpy.array([0, 1])
+        numpy_arr = np.array([0, 1])
         qreg = QuantumRegister(4)
         circuit = QuantumCircuit(qreg)
         circuit.h(numpy_arr)
@@ -490,7 +490,7 @@ class TestGatesOnWireSlice(QiskitTestCase):
 
     def test_wire_np_2d_array(self):
         """Test gate wire with numpy array (two-dimensional). Raises."""
-        numpy_arr = numpy.array([[0, 1], [2, 3]])
+        numpy_arr = np.array([[0, 1], [2, 3]])
         qreg = QuantumRegister(4)
         circuit = QuantumCircuit(qreg)
         self.assertRaises(CircuitError, circuit.h, numpy_arr)  # circuit.h(numpy_arr)

--- a/test/python/circuit/test_unitary.py
+++ b/test/python/circuit/test_unitary.py
@@ -13,7 +13,7 @@
 """UnitaryGate tests"""
 
 import json
-import numpy
+import numpy as np
 from numpy.testing import assert_allclose
 
 import qiskit
@@ -57,14 +57,14 @@ class TestUnitaryGate(QiskitTestCase):
 
     def test_conjugate(self):
         """test conjugate"""
-        ymat = numpy.array([[0, -1j], [1j, 0]])
+        ymat = np.array([[0, -1j], [1j, 0]])
         uni = UnitaryGate([[0, 1j], [-1j, 0]])
-        self.assertTrue(numpy.array_equal(uni.conjugate().to_matrix(), ymat))
+        self.assertTrue(np.array_equal(uni.conjugate().to_matrix(), ymat))
 
     def test_adjoint(self):
         """test adjoint operation"""
         uni = UnitaryGate([[0, 1j], [-1j, 0]])
-        self.assertTrue(numpy.array_equal(uni.adjoint().to_matrix(), uni.to_matrix()))
+        self.assertTrue(np.array_equal(uni.adjoint().to_matrix(), uni.to_matrix()))
 
 
 class TestUnitaryCircuit(QiskitTestCase):
@@ -75,7 +75,7 @@ class TestUnitaryCircuit(QiskitTestCase):
         qr = QuantumRegister(1)
         cr = ClassicalRegister(1)
         qc = QuantumCircuit(qr, cr)
-        matrix = numpy.array([[1, 0], [0, 1]])
+        matrix = np.array([[1, 0], [0, 1]])
         qc.x(qr[0])
         qc.append(UnitaryGate(matrix), [qr[0]])
         # test of qasm output
@@ -95,9 +95,9 @@ class TestUnitaryCircuit(QiskitTestCase):
         qr = QuantumRegister(2)
         cr = ClassicalRegister(2)
         qc = QuantumCircuit(qr, cr)
-        sigmax = numpy.array([[0, 1], [1, 0]])
-        sigmay = numpy.array([[0, -1j], [1j, 0]])
-        matrix = numpy.kron(sigmax, sigmay)
+        sigmax = np.array([[0, 1], [1, 0]])
+        sigmay = np.array([[0, -1j], [1j, 0]])
+        matrix = np.kron(sigmax, sigmay)
         qc.x(qr[0])
         uni2q = UnitaryGate(matrix)
         qc.append(uni2q, [qr[0], qr[1]])
@@ -122,9 +122,9 @@ class TestUnitaryCircuit(QiskitTestCase):
         """test 3 qubit unitary matrix on non-consecutive bits"""
         qr = QuantumRegister(4)
         qc = QuantumCircuit(qr)
-        sigmax = numpy.array([[0, 1], [1, 0]])
-        sigmay = numpy.array([[0, -1j], [1j, 0]])
-        matrix = numpy.kron(sigmay, numpy.kron(sigmax, sigmay))
+        sigmax = np.array([[0, 1], [1, 0]])
+        sigmay = np.array([[0, -1j], [1j, 0]])
+        matrix = np.kron(sigmay, np.kron(sigmax, sigmay))
         qc.x(qr[0])
         uni3q = UnitaryGate(matrix)
         qc.append(uni3q, [qr[0], qr[1], qr[3]])
@@ -141,8 +141,8 @@ class TestUnitaryCircuit(QiskitTestCase):
 
     def test_1q_unitary_int_qargs(self):
         """test single qubit unitary matrix with 'int' and 'list of ints' qubits argument"""
-        sigmax = numpy.array([[0, 1], [1, 0]])
-        sigmaz = numpy.array([[1, 0], [0, -1]])
+        sigmax = np.array([[0, 1], [1, 0]])
+        sigmaz = np.array([[1, 0], [0, -1]])
         # new syntax
         qr = QuantumRegister(2)
         qc = QuantumCircuit(qr)
@@ -160,17 +160,17 @@ class TestUnitaryCircuit(QiskitTestCase):
         """test qobj output with unitary matrix"""
         qr = QuantumRegister(4)
         qc = QuantumCircuit(qr)
-        sigmax = numpy.array([[0, 1], [1, 0]])
-        sigmay = numpy.array([[0, -1j], [1j, 0]])
-        matrix = numpy.kron(sigmay, numpy.kron(sigmax, sigmay))
-        qc.rx(numpy.pi / 4, qr[0])
+        sigmax = np.array([[0, 1], [1, 0]])
+        sigmay = np.array([[0, -1j], [1j, 0]])
+        matrix = np.kron(sigmay, np.kron(sigmax, sigmay))
+        qc.rx(np.pi / 4, qr[0])
         uni = UnitaryGate(matrix)
         qc.append(uni, [qr[0], qr[1], qr[3]])
         qc.cx(qr[3], qr[2])
         qobj = qiskit.compiler.assemble(qc)
         instr = qobj.experiments[0].instructions[1]
         self.assertEqual(instr.name, "unitary")
-        assert_allclose(numpy.array(instr.params[0]).astype(numpy.complex64), matrix)
+        assert_allclose(np.array(instr.params[0]).astype(np.complex64), matrix)
         # check conversion to dict
         qobj_dict = qobj.to_dict()
 
@@ -178,7 +178,7 @@ class TestUnitaryCircuit(QiskitTestCase):
             """Class for encoding json str with complex and numpy arrays."""
 
             def default(self, obj):
-                if isinstance(obj, numpy.ndarray):
+                if isinstance(obj, np.ndarray):
                     return obj.tolist()
                 if isinstance(obj, complex):
                     return (obj.real, obj.imag)
@@ -191,9 +191,9 @@ class TestUnitaryCircuit(QiskitTestCase):
         """test qobj output with unitary matrix"""
         qr = QuantumRegister(4)
         qc = QuantumCircuit(qr)
-        sigmax = numpy.array([[0, 1], [1, 0]])
-        sigmay = numpy.array([[0, -1j], [1j, 0]])
-        matrix = numpy.kron(sigmax, sigmay)
+        sigmax = np.array([[0, 1], [1, 0]])
+        sigmay = np.array([[0, -1j], [1j, 0]])
+        matrix = np.kron(sigmax, sigmay)
         uni = UnitaryGate(matrix, label="xy")
         qc.append(uni, [qr[0], qr[1]])
         qobj = qiskit.compiler.assemble(qc)
@@ -207,7 +207,7 @@ class TestUnitaryCircuit(QiskitTestCase):
         qr = QuantumRegister(2, "q0")
         cr = ClassicalRegister(1, "c0")
         qc = QuantumCircuit(qr, cr)
-        matrix = numpy.array([[1, 0], [0, 1]])
+        matrix = np.array([[1, 0], [0, 1]])
         unitary_gate = UnitaryGate(matrix)
 
         qc.x(qr[0])
@@ -231,7 +231,7 @@ class TestUnitaryCircuit(QiskitTestCase):
         qr = QuantumRegister(2, "q0")
         cr = ClassicalRegister(1, "c0")
         qc = QuantumCircuit(qr, cr)
-        matrix = numpy.array([[1, 0], [0, 1]])
+        matrix = np.array([[1, 0], [0, 1]])
         unitary_gate = UnitaryGate(matrix)
 
         qc.x(qr[0])
@@ -255,7 +255,7 @@ class TestUnitaryCircuit(QiskitTestCase):
         qr = QuantumRegister(2, "q0")
         cr = ClassicalRegister(1, "c0")
         qc = QuantumCircuit(qr, cr)
-        matrix = numpy.asarray([[0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0], [1, 0, 0, 0]])
+        matrix = np.asarray([[0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0], [1, 0, 0, 0]])
         unitary_gate = UnitaryGate(matrix)
 
         qc.x(qr[0])
@@ -277,7 +277,7 @@ class TestUnitaryCircuit(QiskitTestCase):
     def test_qasm_unitary_noop(self):
         """Test that an identity unitary can be converted to OpenQASM 2"""
         qc = QuantumCircuit(QuantumRegister(3, "q0"))
-        qc.unitary(numpy.eye(8), qc.qubits)
+        qc.unitary(np.eye(8), qc.qubits)
         expected_qasm = (
             "OPENQASM 2.0;\n"
             'include "qelib1.inc";\n'
@@ -295,17 +295,17 @@ class TestUnitaryCircuit(QiskitTestCase):
 
     def test_unitary_decomposition_via_definition(self):
         """Test decomposition for 1Q unitary via definition."""
-        mat = numpy.array([[0, 1], [1, 0]])
-        self.assertTrue(numpy.allclose(Operator(UnitaryGate(mat).definition).data, mat))
+        mat = np.array([[0, 1], [1, 0]])
+        self.assertTrue(np.allclose(Operator(UnitaryGate(mat).definition).data, mat))
 
     def test_unitary_decomposition_via_definition_2q(self):
         """Test decomposition for 2Q unitary via definition."""
-        mat = numpy.array([[0, 0, 1, 0], [0, 0, 0, -1], [1, 0, 0, 0], [0, -1, 0, 0]])
-        self.assertTrue(numpy.allclose(Operator(UnitaryGate(mat).definition).data, mat))
+        mat = np.array([[0, 0, 1, 0], [0, 0, 0, -1], [1, 0, 0, 0], [0, -1, 0, 0]])
+        self.assertTrue(np.allclose(Operator(UnitaryGate(mat).definition).data, mat))
 
     def test_unitary_control(self):
         """Test parameters of controlled - unitary."""
-        mat = numpy.array([[0, 1], [1, 0]])
+        mat = np.array([[0, 1], [1, 0]])
         gate = UnitaryGate(mat).control()
-        self.assertTrue(numpy.allclose(gate.params, mat))
-        self.assertTrue(numpy.allclose(gate.base_gate.params, mat))
+        self.assertTrue(np.allclose(gate.params, mat))
+        self.assertTrue(np.allclose(gate.base_gate.params, mat))

--- a/test/python/opflow/test_state_op_meas_evals.py
+++ b/test/python/opflow/test_state_op_meas_evals.py
@@ -18,7 +18,7 @@
 import unittest
 from test.python.opflow import QiskitOpflowTestCase
 from ddt import ddt, data
-import numpy
+import numpy as np
 
 from qiskit.circuit import QuantumCircuit, Parameter
 from qiskit.utils import QuantumInstance
@@ -88,7 +88,7 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
 
         with self.subTest("coeff gets squared in CircuitSampler shot-based readout"):
             with self.assertWarns(DeprecationWarning):
-                state = (Plus + Minus) / numpy.sqrt(2)
+                state = (Plus + Minus) / np.sqrt(2)
                 sampler = CircuitSampler(q_instance).convert(~StateFn(op) @ state)
                 self.assertAlmostEqual(sampler.eval(), 1 + 0j)
 
@@ -135,10 +135,10 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
         """Test evaluating a ListOp with non-linear combo function works with coefficients."""
 
         state = One
-        op = ListOp(5 * [I], coeff=2, combo_fn=numpy.prod)
+        op = ListOp(5 * [I], coeff=2, combo_fn=np.prod)
         expr1 = ~StateFn(op) @ state
 
-        expr2 = ListOp(5 * [~state @ I @ state], coeff=2, combo_fn=numpy.prod)
+        expr2 = ListOp(5 * [~state @ I @ state], coeff=2, combo_fn=np.prod)
 
         self.assertEqual(expr1.eval(), 2)  # if the coeff is propagated too far the result is 4
         self.assertEqual(expr2.eval(), 2)
@@ -176,7 +176,6 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
         circuit.ry(x, 0)
 
         with self.assertWarns(DeprecationWarning):
-
             expr1 = ~StateFn(H) @ StateFn(circuit)
             expr2 = ~StateFn(X) @ StateFn(circuit)
             sampler = CircuitSampler(Aer.get_backend("aer_simulator_statevector"), caching=caching)

--- a/test/python/transpiler/test_layout.py
+++ b/test/python/transpiler/test_layout.py
@@ -14,7 +14,7 @@
 
 import copy
 import unittest
-import numpy
+import numpy as np
 
 from qiskit.circuit import QuantumRegister, Qubit
 from qiskit.transpiler.layout import Layout
@@ -338,7 +338,7 @@ class LayoutTest(QiskitTestCase):
         qr1 = QuantumRegister(1, "qr1")
         qr2 = QuantumRegister(2, "qr2")
         qr3 = QuantumRegister(3, "qr3")
-        intlist_layout = numpy.array([0, 1, 2, 3, 4, 5])
+        intlist_layout = np.array([0, 1, 2, 3, 4, 5])
         layout = Layout.from_intlist(intlist_layout, qr1, qr2, qr3)
 
         expected = Layout.generate_trivial_layout(qr1, qr2, qr3)

--- a/test/python/transpiler/test_vf2_layout.py
+++ b/test/python/transpiler/test_vf2_layout.py
@@ -18,8 +18,8 @@ import unittest
 from math import pi
 
 import ddt
-import numpy
-import rustworkx
+import numpy as np
+import rustworkx as rx
 
 from qiskit import QuantumRegister, QuantumCircuit, ClassicalRegister
 from qiskit.circuit import ControlFlowOp
@@ -298,12 +298,12 @@ class TestVF2LayoutLattice(LayoutTestCase):
 
     def graph_state_from_pygraph(self, graph):
         """Creates a GraphState circuit from a PyGraph"""
-        adjacency_matrix = rustworkx.adjacency_matrix(graph)
+        adjacency_matrix = rx.adjacency_matrix(graph)
         return GraphState(adjacency_matrix).decompose()
 
     def test_hexagonal_lattice_graph_20_in_25(self):
         """A 20x20 interaction map in 25x25 coupling map"""
-        graph_20_20 = rustworkx.generators.hexagonal_lattice_graph(20, 20)
+        graph_20_20 = rx.generators.hexagonal_lattice_graph(20, 20)
         circuit = self.graph_state_from_pygraph(graph_20_20)
 
         dag = circuit_to_dag(circuit)
@@ -313,7 +313,7 @@ class TestVF2LayoutLattice(LayoutTestCase):
 
     def test_hexagonal_lattice_graph_9_in_25(self):
         """A 9x9 interaction map in 25x25 coupling map"""
-        graph_9_9 = rustworkx.generators.hexagonal_lattice_graph(9, 9)
+        graph_9_9 = rx.generators.hexagonal_lattice_graph(9, 9)
         circuit = self.graph_state_from_pygraph(graph_9_9)
 
         dag = circuit_to_dag(circuit)
@@ -514,7 +514,7 @@ class TestVF2LayoutBackend(LayoutTestCase):
         rows = [x[0] for x in manhattan_cm]
         cols = [x[1] for x in manhattan_cm]
 
-        adj_matrix = numpy.zeros((65, 65))
+        adj_matrix = np.zeros((65, 65))
         adj_matrix[rows, cols] = 1
 
         circuit = GraphState(adj_matrix).decompose()

--- a/test/python/transpiler/test_vf2_post_layout.py
+++ b/test/python/transpiler/test_vf2_post_layout.py
@@ -12,7 +12,7 @@
 
 """Test the VF2Layout pass"""
 
-import rustworkx
+import rustworkx as rx
 
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.circuit import ControlFlowOp
@@ -397,7 +397,7 @@ class TestVF2PostLayoutScoring(QiskitTestCase):
         """Test error rate is 0 for empty circuit."""
         bit_map = {}
         reverse_bit_map = {}
-        im_graph = rustworkx.PyDiGraph()
+        im_graph = rx.PyDiGraph()
         backend = FakeYorktownV2()
         vf2_pass = VF2PostLayout(target=backend.target)
         layout = Layout()
@@ -408,7 +408,7 @@ class TestVF2PostLayoutScoring(QiskitTestCase):
         """Test error rate for all 1q input."""
         bit_map = {Qubit(): 0, Qubit(): 1}
         reverse_bit_map = {v: k for k, v in bit_map.items()}
-        im_graph = rustworkx.PyDiGraph()
+        im_graph = rx.PyDiGraph()
         im_graph.add_node({"sx": 1})
         im_graph.add_node({"sx": 1})
         backend = FakeYorktownV2()

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -19,7 +19,7 @@ import unittest.mock
 from codecs import encode
 from math import pi
 
-import numpy
+import numpy as np
 
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister, transpile
 from qiskit.circuit import Gate, Parameter, Qubit, Clbit, Instruction
@@ -1447,7 +1447,7 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
                               "q: |0>┤ kraus ├",
                               "      └───────┘"])
         # fmt: on
-        error = SuperOp(0.75 * numpy.eye(4) + 0.25 * numpy.diag([1, -1, -1, 1]))
+        error = SuperOp(0.75 * np.eye(4) + 0.25 * np.diag([1, -1, -1, 1]))
         qr = QuantumRegister(1, name="q")
         qc = QuantumCircuit(qr)
         qc.append(error, [qr[0]])
@@ -1467,7 +1467,7 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
             ]
         )
 
-        cx_multiplexer = UCGate([numpy.eye(2), numpy.array([[0, 1], [1, 0]])])
+        cx_multiplexer = UCGate([np.eye(2), np.array([[0, 1], [1, 0]])])
 
         qr = QuantumRegister(2, name="q")
         qc = QuantumCircuit(qr)
@@ -1491,7 +1491,7 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
         circ = QuantumCircuit(qr)
         circ.append(XGate(), [qr[0]])
         circ.append(XGate(label="alt-X"), [qr[0]])
-        circ.append(UnitaryGate(numpy.eye(4), label="iswap"), [qr[0], qr[1]])
+        circ.append(UnitaryGate(np.eye(4), label="iswap"), [qr[0], qr[1]])
 
         self.assertEqual(str(_text_circuit_drawer(circ)), expected)
 
@@ -1928,7 +1928,7 @@ class TestTextDrawerParams(QiskitTestCase):
         # fmt: on
         qr = QuantumRegister(1, "q")
         circuit = QuantumCircuit(qr)
-        circuit.unitary(numpy.array([[0, 1], [1, 0]]), 0)
+        circuit.unitary(np.array([[0, 1], [1, 0]]), 0)
         self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
 
     def test_text_qc_parameters(self):
@@ -3140,7 +3140,7 @@ class TestTextConditional(QiskitTestCase):
 
     def test_conditional_multiplexer_cregbundle(self):
         """Test Multiplexer with cregbundle."""
-        cx_multiplexer = UCGate([numpy.eye(2), numpy.array([[0, 1], [1, 0]])])
+        cx_multiplexer = UCGate([np.eye(2), np.array([[0, 1], [1, 0]])])
         qr = QuantumRegister(3, name="qr")
         cr = ClassicalRegister(1, "cr")
         qc = QuantumCircuit(qr, cr)
@@ -3164,7 +3164,7 @@ class TestTextConditional(QiskitTestCase):
 
     def test_conditional_multiplexer(self):
         """Test Multiplexer."""
-        cx_multiplexer = UCGate([numpy.eye(2), numpy.array([[0, 1], [1, 0]])])
+        cx_multiplexer = UCGate([np.eye(2), np.array([[0, 1], [1, 0]])])
         qr = QuantumRegister(3, name="qr")
         cr = ClassicalRegister(1, "cr")
         qc = QuantumCircuit(qr, cr)
@@ -3561,7 +3561,7 @@ class TestTextNonRational(QiskitTestCase):
                 "     └────────────────────────────────────┘",
             ]
         )
-        ket = numpy.array([0.5 + 0.1 * 1j, 0, 0, 0.8602325267042626 * 1j])
+        ket = np.array([0.5 + 0.1 * 1j, 0, 0, 0.8602325267042626 * 1j])
         circuit = QuantumCircuit(2)
         circuit.initialize(ket, [0, 1])
         self.assertEqual(circuit.draw(output="text").single_string(), expected)
@@ -3578,7 +3578,7 @@ class TestTextNonRational(QiskitTestCase):
                 "        └────────────────────────────────┘",
             ]
         )
-        ket = numpy.array([0.1 * numpy.pi, 0, 0, 0.9493702944526474 * 1j])
+        ket = np.array([0.1 * np.pi, 0, 0, 0.9493702944526474 * 1j])
         circuit = QuantumCircuit(2)
         circuit.initialize(ket, [0, 1])
         self.assertEqual(circuit.draw(output="text", initial_state=True).single_string(), expected)
@@ -3596,7 +3596,7 @@ class TestTextNonRational(QiskitTestCase):
                 "        └────────────────────────────────┘",
             ]
         )
-        ket = numpy.array([0.9493702944526474, 0, 0, 0.1 * numpy.pi * 1j])
+        ket = np.array([0.9493702944526474, 0, 0, 0.1 * np.pi * 1j])
         circuit = QuantumCircuit(2)
         circuit.initialize(ket, [0, 1])
         self.assertEqual(circuit.draw(output="text", initial_state=True).single_string(), expected)
@@ -5047,7 +5047,7 @@ class TestTextHamiltonianGate(QiskitTestCase):
         # fmt: on
         qr = QuantumRegister(1, "q0")
         circuit = QuantumCircuit(qr)
-        matrix = numpy.zeros((2, 2))
+        matrix = np.zeros((2, 2))
         theta = Parameter("theta")
         circuit.append(HamiltonianGate(matrix, theta), [qr[0]])
         circuit = circuit.bind_parameters({theta: 1})
@@ -5067,7 +5067,7 @@ class TestTextHamiltonianGate(QiskitTestCase):
 
         qr = QuantumRegister(2, "q0")
         circuit = QuantumCircuit(qr)
-        matrix = numpy.zeros((4, 4))
+        matrix = np.zeros((4, 4))
         theta = Parameter("theta")
         circuit.append(HamiltonianGate(matrix, theta), [qr[0], qr[1]])
         circuit = circuit.bind_parameters({theta: 1})

--- a/test/python/visualization/visualization.py
+++ b/test/python/visualization/visualization.py
@@ -19,11 +19,11 @@ import os
 import unittest
 from filecmp import cmp as cmpfile
 from shutil import copyfile
-import matplotlib
+import matplotlib as mpl
 
 from qiskit.test import QiskitTestCase
 
-matplotlib.use("ps")
+mpl.use("ps")
 
 
 def path_to_diagram_reference(filename):


### PR DESCRIPTION
Enable `flake8-import-conventions` (ICN) and fix a bunch of places that  were not compliant.
This enforces a few canonical import names:

- numpy as np
- matplotlib as mpl
- matplotlib.pyplot as plt
- rustworkx as rx

The latter is non-default but very standard within qiskit.
Enforcing common naming improves readability and copy-paste movability of code.
