### PR TITLE
fix typo in real_amplitude.py

### DIFF
--- a/qiskit/circuit/library/n_local/real_amplitudes.py
+++ b/qiskit/circuit/library/n_local/real_amplitudes.py
@@ -24,7 +24,7 @@ class RealAmplitudes(TwoLocal):
 
     The ``RealAmplitudes`` circuit is a heuristic trial wave function used as Ansatz in chemistry
     applications or classification circuits in machine learning. The circuit consists of
-    of alternating layers of :math:`Y` rotations and :math:`CX` entanglements. The entanglement
+    alternating layers of :math:`Y` rotations and :math:`CX` entanglements. The entanglement
     pattern can be user-defined or selected from a predefined set.
     It is called ``RealAmplitudes`` since the prepared quantum states will only have
     real amplitudes, the complex part is always 0.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Correct small typo in real_amplitude.py file.

Fixes #10340

### Details and comments

Erased repeated "of"
