### PR TITLE
Temporarily pin `scipy<1.11` in CI

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -10,3 +10,8 @@ qiskit-aer==0.12.0
 # tests to flake. See https://github.com/Qiskit/qiskit-terra/issues/10305,
 # remove pin when resolving that.
 numpy<1.25
+
+# Scipy 1.11 seems to have caused an instability in the Weyl coordinates
+# eigensystem code for one of the test cases.  See
+# https://github.com/Qiskit/qiskit-terra/issues/10345 for current details.
+scipy<1.11


### PR DESCRIPTION
### Summary

The newest Scipy on Windows seems to have caused a convergence error in some of the Weyl-chamber code.  This pins Scipy temporarily while we resolve that issue.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

See #10345 for more detail.
