### PR TITLE
Unpin macOS CI from Python 3.7.16

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -177,8 +177,7 @@ stages:
 
         - template: ".azure/test-macos.yml"
           parameters:
-            # Overridden to specific version to account for _bz2 missing on Azure images.
-            pythonVersion: "3.7.16"
+            pythonVersion: ${{ parameters.minimumPythonVersion }}
 
         - template: ".azure/test-macos.yml"
           parameters:


### PR DESCRIPTION
### Summary

GitHub Actions have uploaded a fixed version of Python 3.7.17 on macOS, so we should be able to release this pin now.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments


See #10307.