### PR TITLE
Add `Expr` supprt to `DAGCircuit` simple constructors

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -30,7 +30,7 @@ import numpy as np
 import rustworkx as rx
 
 from qiskit.circuit import ControlFlowOp, ForLoopOp, IfElseOp, WhileLoopOp, SwitchCaseOp
-from qiskit.circuit.controlflow import condition_resources
+from qiskit.circuit.controlflow import condition_resources, node_resources
 from qiskit.circuit.quantumregister import QuantumRegister, Qubit
 from qiskit.circuit.classicalregister import ClassicalRegister, Clbit
 from qiskit.circuit.gate import Gate
@@ -476,17 +476,26 @@ class DAGCircuit:
                 raise DAGCircuitError(f"(qu)bit {wire} not found in {amap}")
 
     @staticmethod
-    def _bits_in_condition(cond):
-        """Return a list of bits in the given condition.
+    def _bits_in_operation(operation):
+        """Return an iterable over the classical bits that are inherent to an instruction.  This
+        includes a `condition`, or the `target` of a :class:`.ControlFlowOp`.
 
         Args:
-            cond (tuple or expr.Expr or None): optional condition in any form that the control-flow
-                operations accept.
+            instruction: the :class:`~.circuit.Instruction` instance for a node.
 
         Returns:
-            list[Clbit]: list of classical bits
+            Iterable[Clbit]: the :class:`.Clbit`\\ s involved.
         """
-        return [] if cond is None else list(condition_resources(cond).clbits)
+        if (condition := getattr(operation, "condition", None)) is not None:
+            yield from condition_resources(condition).clbits
+        if isinstance(operation, SwitchCaseOp):
+            target = operation.target
+            if isinstance(target, Clbit):
+                yield target
+            elif isinstance(target, ClassicalRegister):
+                yield from target
+            else:
+                yield from node_resources(target).clbits
 
     def _increment_op(self, op):
         if op.name in self._op_names:
@@ -571,8 +580,7 @@ class DAGCircuit:
         qargs = tuple(qargs) if qargs is not None else ()
         cargs = tuple(cargs) if cargs is not None else ()
 
-        all_cbits = self._bits_in_condition(getattr(op, "condition", None))
-        all_cbits = set(all_cbits).union(cargs)
+        all_cbits = set(self._bits_in_operation(op)).union(cargs)
 
         self._check_condition(op.name, getattr(op, "condition", None))
         self._check_bits(qargs, self.output_map)
@@ -603,8 +611,7 @@ class DAGCircuit:
         Raises:
             DAGCircuitError: if initial nodes connected to multiple out edges
         """
-        all_cbits = self._bits_in_condition(getattr(op, "condition", None))
-        all_cbits.extend(cargs)
+        all_cbits = set(self._bits_in_operation(op)).union(cargs)
 
         self._check_condition(op.name, getattr(op, "condition", None))
         self._check_bits(qargs, self.input_map)
@@ -1183,9 +1190,7 @@ class DAGCircuit:
             # condition as well.
             if not propagate_condition:
                 node_wire_order += [
-                    bit
-                    for bit in self._bits_in_condition(getattr(node.op, "condition", None))
-                    if bit not in node_cargs
+                    bit for bit in self._bits_in_operation(node.op) if bit not in node_cargs
                 ]
             if len(wires) != len(node_wire_order):
                 raise DAGCircuitError(
@@ -1729,8 +1734,6 @@ class DAGCircuit:
             op = copy.copy(next_node.op)
             qargs = copy.copy(next_node.qargs)
             cargs = copy.copy(next_node.cargs)
-            condition = copy.copy(getattr(next_node.op, "condition", None))
-            _ = self._bits_in_condition(condition)
 
             # Add node to new_layer
             new_layer.apply_operation_back(op, qargs, cargs)

--- a/qiskit/transpiler/passes/layout/sabre_layout.py
+++ b/qiskit/transpiler/passes/layout/sabre_layout.py
@@ -311,7 +311,7 @@ class SabreLayout(TransformationPass):
         for node in dag.topological_op_nodes():
             cargs = {original_clbit_indices[x] for x in node.cargs}
             if node.op.condition is not None:
-                for clbit in dag._bits_in_condition(node.op.condition):
+                for clbit in dag._bits_in_operation(node.op):
                     cargs.add(original_clbit_indices[clbit])
 
             dag_list.append(

--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -240,7 +240,7 @@ class SabreSwap(TransformationPass):
         for node in dag.topological_op_nodes():
             cargs = {self._clbit_indices[x] for x in node.cargs}
             if node.op.condition is not None:
-                for clbit in dag._bits_in_condition(node.op.condition):
+                for clbit in dag._bits_in_operation(node.op):
                     cargs.add(self._clbit_indices[clbit])
 
             dag_list.append(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This adds support to the `DAGCircuit` builder methods `apply_operation_front` and `apply_operation_back`, and consequently to the converter `circuit_to_dag`.  This commit does not directly enhance `DAGCircuit.compose`, which will come later.

The principal change is that `_bits_in_condition` is modified to the more general `_bits_in_operation`, which now accounts for both a `condition` (if set) and any additional fields from a `target` if the operation is a suitable `ControlFlowOp`.  This has the effect of upgrading the converters into the `SabreDAG` format as well, but nothing is done to change the Sabre algorithms themselves.


### Details and comments

Close #10226.  Depends on #10358.  Changelog to follow as part of #10331.

The change of `_bits_in_condition` to `_bits_in_operation` likely does most of the remaining work for #10232 on top of its prerequisites #9419 and #9421 (although a PR for #10232 will still need to add tests).