### PR TITLE
Add support for semantic equality checking of `Expr`s in `DAGCircuit`

### DIFF
--- a/qiskit/circuit/classical/expr/__init__.py
+++ b/qiskit/circuit/classical/expr/__init__.py
@@ -142,6 +142,14 @@ For the convenience of simple visitors that only need to inspect the variables i
 not the general structure, the iterator method :func:`iter_vars` is provided.
 
 .. autofunction:: iter_vars
+
+Two expressions can be compared for direct structural equality by using the built-in Python ``==``
+operator.  In general, though, one might want to compare two expressions slightly more semantically,
+allowing that the :class:`Var` nodes inside them are bound to different memory-location descriptions
+between two different circuits.  In this case, one can use :func:`structurally_equivalent` with two
+suitable "key" functions to do the comparison.
+
+.. autofunction:: structurally_equivalent
 """
 
 __all__ = [
@@ -153,6 +161,7 @@ __all__ = [
     "Binary",
     "ExprVisitor",
     "iter_vars",
+    "structurally_equivalent",
     "lift",
     "cast",
     "bit_not",
@@ -172,7 +181,7 @@ __all__ = [
 ]
 
 from .expr import Expr, Var, Value, Cast, Unary, Binary
-from .visitors import ExprVisitor, iter_vars
+from .visitors import ExprVisitor, iter_vars, structurally_equivalent
 from .constructors import (
     lift,
     cast,

--- a/qiskit/circuit/classical/expr/visitors.py
+++ b/qiskit/circuit/classical/expr/visitors.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 __all__ = [
     "ExprVisitor",
     "iter_vars",
+    "structurally_equivalent",
 ]
 
 import typing
@@ -96,3 +97,121 @@ def iter_vars(node: expr.Expr) -> typing.Iterator[expr.Var]:
                     print(node.var.name)
     """
     yield from node.accept(_VAR_WALKER)
+
+
+class _StructuralEquivalenceImpl(ExprVisitor[bool]):
+    # The strategy here is to continue to do regular double dispatch through the visitor format,
+    # since we simply exit out with a ``False`` as soon as the structure of the two trees isn't the
+    # same; we never need to do any sort of "triple" dispatch.  To recurse through both trees
+    # simultaneously, we hold a pointer to the "full" expression of the other (at the given depth)
+    # in the stack variables of each visit function, and pass the next "deeper" pointer via the
+    # `other` state in the class instance.
+
+    __slots__ = (
+        "self_key",
+        "other_key",
+        "other",
+    )
+
+    def __init__(self, other: expr.Expr, self_key, other_key):
+        self.self_key = self_key
+        self.other_key = other_key
+        self.other = other
+
+    def visit_var(self, node, /):
+        if self.other.__class__ is not node.__class__ or self.other.type != node.type:
+            return False
+        if self.self_key is None or (self_var := self.self_key(node.var)) is None:
+            self_var = node.var
+        if self.other_key is None or (other_var := self.other_key(self.other.var)) is None:
+            other_var = self.other.var
+        return self_var == other_var
+
+    def visit_value(self, node, /):
+        return (
+            node.__class__ is self.other.__class__
+            and node.type == self.other.type
+            and node.value == self.other.value
+        )
+
+    def visit_unary(self, node, /):
+        if (
+            self.other.__class__ is not node.__class__
+            or self.other.op is not node.op
+            or self.other.type != node.type
+        ):
+            return False
+        self.other = self.other.operand
+        return node.operand.accept(self)
+
+    def visit_binary(self, node, /):
+        if (
+            self.other.__class__ is not node.__class__
+            or self.other.op is not node.op
+            or self.other.type != node.type
+        ):
+            return False
+        other = self.other
+        self.other = other.left
+        if not node.left.accept(self):
+            return False
+        self.other = other.right
+        return node.right.accept(self)
+
+    def visit_cast(self, node, /):
+        if self.other.__class__ is not node.__class__ or self.other.type != node.type:
+            return False
+        self.other = self.other.operand
+        return node.operand.accept(self)
+
+
+def structurally_equivalent(
+    left: expr.Expr,
+    right: expr.Expr,
+    left_var_key: typing.Callable[[typing.Any], typing.Any] | None = None,
+    right_var_key: typing.Callable[[typing.Any], typing.Any] | None = None,
+) -> bool:
+    """Do these two expressions have exactly the same tree structure, up to some key function for
+    the :class:`~.expr.Var` objects?
+
+    In other words, are these two expressions the exact same trees, except we compare the
+    :attr:`.Var.var` fields by calling the appropriate ``*_var_key`` function on them, and comparing
+    that output for equality.  This function does not allow any semantic "equivalences" such as
+    asserting that ``a == b`` is equivalent to ``b == a``; the evaluation order of the operands
+    could, in general, cause such a statement to be false (consider hypothetical ``extern``
+    functions that access global state).
+
+    There's no requirements on the key functions, except that their outputs should have general
+    ``__eq__`` methods.  If a key function returns ``None``, the variable will be used verbatim
+    instead.
+
+    Args:
+        left: one of the :class:`~.expr.Expr` nodes.
+        right: the other :class:`~.expr.Expr` node.
+        left_var_key: a callable whose output should be used when comparing :attr:`.Var.var`
+            attributes.  If this argument is ``None`` or its output is ``None`` for a given
+            variable in ``left``, the variable will be used verbatim.
+        right_var_key: same as ``left_var_key``, but used on the variables in ``right`` instead.
+
+    Examples:
+        Comparing two expressions for structural equivalence, with no remapping of the variables.
+        These are different because the different :class:`.Clbit` instances compare differently::
+
+            >>> from qiskit.circuit import Clbit
+            >>> from qiskit.circuit.classical import expr
+            >>> left_bits = [Clbit(), Clbit()]
+            >>> right_bits = [Clbit(), Clbit()]
+            >>> left = expr.logic_and(expr.logic_not(left_bits[0]), left_bits[1])
+            >>> right = expr.logic_and(expr.logic_not(right_bits[0]), right_bits[1])
+            >>> expr.structurally_equivalent(left, right)
+            False
+
+        Comparing the same two expressions, but this time using mapping functions that associate
+        the bits with simple indices::
+
+            >>> left_key = {var: i for i, var in enumerate(left_bits)}.get
+            >>> right_key = {var: i for i, var in enumerate(right_bits)}.get
+            >>> expr.structurally_equivalent(left, right, left_key, right_key)
+            True
+    """
+    return left.accept(_StructuralEquivalenceImpl(right, left_var_key, right_var_key))

--- a/qiskit/circuit/controlflow/switch_case.py
+++ b/qiskit/circuit/controlflow/switch_case.py
@@ -139,9 +139,13 @@ class SwitchCaseOp(ControlFlowOp):
     def __eq__(self, other):
         # The general __eq__ will compare the blocks in the right order, so we just need to ensure
         # that all the labels point the right way as well.
-        return super().__eq__(other) and all(
-            set(labels_self) == set(labels_other)
-            for labels_self, labels_other in zip(self._label_spec, other._label_spec)
+        return (
+            super().__eq__(other)
+            and self.target == other.target
+            and all(
+                set(labels_self) == set(labels_other)
+                for labels_self, labels_other in zip(self._label_spec, other._label_spec)
+            )
         )
 
     def cases_specifier(self) -> Iterable[Tuple[Tuple, QuantumCircuit]]:

--- a/qiskit/converters/circuit_to_dag.py
+++ b/qiskit/converters/circuit_to_dag.py
@@ -16,7 +16,7 @@ import copy
 from qiskit.dagcircuit.dagcircuit import DAGCircuit
 
 
-def circuit_to_dag(circuit, copy_operations=True):
+def circuit_to_dag(circuit, copy_operations=True, *, qubit_order=None, clbit_order=None):
     """Build a ``DAGCircuit`` object from a ``QuantumCircuit``.
 
     Args:
@@ -28,6 +28,10 @@ def circuit_to_dag(circuit, copy_operations=True):
             :class:`~.DAGCircuit` will be shared instances and modifications to
             operations in the :class:`~.DAGCircuit` will be reflected in the
             :class:`~.QuantumCircuit` (and vice versa).
+        qubit_order (Iterable[Qubit] or None): the ordered that the qubits should be indexed in the
+            output DAG.  Defaults to the same order as in the circuit.
+        clbit_order (Iterable[Clbit] or None): the ordered that the clbits should be indexed in the
+            output DAG.  Defaults to the same order as in the circuit.
 
     Return:
         DAGCircuit: the DAG representing the input circuit.
@@ -54,8 +58,8 @@ def circuit_to_dag(circuit, copy_operations=True):
     dagcircuit.calibrations = circuit.calibrations
     dagcircuit.metadata = circuit.metadata
 
-    dagcircuit.add_qubits(circuit.qubits)
-    dagcircuit.add_clbits(circuit.clbits)
+    dagcircuit.add_qubits(circuit.qubits if qubit_order is None else qubit_order)
+    dagcircuit.add_clbits(circuit.clbits if clbit_order is None else clbit_order)
 
     for register in circuit.qregs:
         dagcircuit.add_qreg(register)

--- a/qiskit/converters/circuit_to_dag.py
+++ b/qiskit/converters/circuit_to_dag.py
@@ -28,13 +28,17 @@ def circuit_to_dag(circuit, copy_operations=True, *, qubit_order=None, clbit_ord
             :class:`~.DAGCircuit` will be shared instances and modifications to
             operations in the :class:`~.DAGCircuit` will be reflected in the
             :class:`~.QuantumCircuit` (and vice versa).
-        qubit_order (Iterable[Qubit] or None): the ordered that the qubits should be indexed in the
+        qubit_order (Iterable[Qubit] or None): the order that the qubits should be indexed in the
             output DAG.  Defaults to the same order as in the circuit.
-        clbit_order (Iterable[Clbit] or None): the ordered that the clbits should be indexed in the
+        clbit_order (Iterable[Clbit] or None): the order that the clbits should be indexed in the
             output DAG.  Defaults to the same order as in the circuit.
 
     Return:
         DAGCircuit: the DAG representing the input circuit.
+
+    Raises:
+        ValueError: if the ``qubit_order`` or ``clbit_order`` parameters do not match the bits in
+            the circuit.
 
     Example:
         .. code-block::
@@ -58,8 +62,22 @@ def circuit_to_dag(circuit, copy_operations=True, *, qubit_order=None, clbit_ord
     dagcircuit.calibrations = circuit.calibrations
     dagcircuit.metadata = circuit.metadata
 
-    dagcircuit.add_qubits(circuit.qubits if qubit_order is None else qubit_order)
-    dagcircuit.add_clbits(circuit.clbits if clbit_order is None else clbit_order)
+    if qubit_order is None:
+        qubits = circuit.qubits
+    elif len(qubit_order) != circuit.num_qubits or set(qubit_order) != set(circuit.qubits):
+        raise ValueError("'qubit_order' does not contain exactly the same qubits as the circuit")
+    else:
+        qubits = qubit_order
+
+    if clbit_order is None:
+        clbits = circuit.clbits
+    elif len(clbit_order) != circuit.num_clbits or set(clbit_order) != set(circuit.clbits):
+        raise ValueError("'clbit_order' does not contain exactly the same clbits as the circuit")
+    else:
+        clbits = clbit_order
+
+    dagcircuit.add_qubits(qubits)
+    dagcircuit.add_clbits(clbits)
 
     for register in circuit.qregs:
         dagcircuit.add_qreg(register)

--- a/qiskit/dagcircuit/dagnode.py
+++ b/qiskit/dagcircuit/dagnode.py
@@ -13,19 +13,157 @@
 
 """Objects to represent the information at a node in the DAGCircuit."""
 
-import warnings
+import uuid
 from typing import Iterable
 
-from qiskit.circuit import Qubit, Clbit
+from qiskit.circuit import (
+    Qubit,
+    Clbit,
+    ClassicalRegister,
+    ControlFlowOp,
+    IfElseOp,
+    WhileLoopOp,
+    SwitchCaseOp,
+    ForLoopOp,
+    Parameter,
+)
+from qiskit.circuit.classical import expr
 
 
-def _condition_as_indices(operation, bit_indices):
-    cond = getattr(operation, "condition", None)
-    if cond is None:
+def _legacy_condition_eq(cond1, cond2, bit_indices1, bit_indices2):
+    if cond1 is cond2 is None:
+        return True
+    elif None in (cond1, cond2):
+        return False
+    target1, val1 = cond1
+    target2, val2 = cond2
+    if val1 != val2:
+        return False
+    if isinstance(target1, Clbit) and isinstance(target2, Clbit):
+        return bit_indices1[target1] == bit_indices2[target2]
+    if isinstance(target1, ClassicalRegister) and isinstance(target2, ClassicalRegister):
+        return target1.size == target2.size and all(
+            bit_indices1[t1] == bit_indices2[t2] for t1, t2 in zip(target1, target2)
+        )
+    return False
+
+
+def _circuit_to_dag(circuit, node_qargs, node_cargs, bit_indices):
+    """Get a :class:`.DAGCircuit` of the given :class:`.QuantumCircuit`.  The bits in the output
+    will be ordered in a canonical order based on their indices in the outer DAG, as defined by the
+    ``bit_indices`` mapping and the ``node_{q,c}args`` arguments."""
+    from qiskit.converters import circuit_to_dag  # pylint: disable=cyclic-import
+
+    def sort_key(bits):
+        outer, _inner = bits
+        return bit_indices[outer]
+
+    return circuit_to_dag(
+        circuit,
+        copy_operations=False,
+        qubit_order=[
+            inner for _outer, inner in sorted(zip(node_qargs, circuit.qubits), key=sort_key)
+        ],
+        clbit_order=[
+            inner for _outer, inner in sorted(zip(node_cargs, circuit.clbits), key=sort_key)
+        ],
+    )
+
+
+def _make_expr_key(bit_indices):
+    def key(var):
+        if isinstance(var, Clbit):
+            return bit_indices.get(var)
+        if isinstance(var, ClassicalRegister):
+            return [bit_indices.get(bit) for bit in var]
         return None
-    bits, value = cond
-    indices = [bit_indices[bits]] if isinstance(bits, Clbit) else [bit_indices[x] for x in bits]
-    return indices, value
+
+    return key
+
+
+def _condition_op_eq(node1, node2, bit_indices1, bit_indices2):
+    cond1 = node1.op.condition
+    cond2 = node2.op.condition
+    if isinstance(cond1, expr.Expr) and isinstance(cond2, expr.Expr):
+        if not expr.structurally_equivalent(
+            cond1, cond2, _make_expr_key(bit_indices1), _make_expr_key(bit_indices2)
+        ):
+            return False
+    elif isinstance(cond1, expr.Expr) or isinstance(cond2, expr.Expr):
+        return False
+    elif not _legacy_condition_eq(cond1, cond2, bit_indices1, bit_indices2):
+        return False
+    return len(node1.op.blocks) == len(node2.op.blocks) and all(
+        _circuit_to_dag(block1, node1.qargs, node1.cargs, bit_indices1)
+        == _circuit_to_dag(block2, node2.qargs, node2.cargs, bit_indices2)
+        for block1, block2 in zip(node1.op.blocks, node2.op.blocks)
+    )
+
+
+def _switch_case_eq(node1, node2, bit_indices1, bit_indices2):
+    target1 = node1.op.target
+    target2 = node2.op.target
+    if isinstance(target1, expr.Expr) and isinstance(target2, expr.Expr):
+        if not expr.structurally_equivalent(
+            target1, target2, _make_expr_key(bit_indices1), _make_expr_key(bit_indices2)
+        ):
+            return False
+    elif isinstance(target1, Clbit) and isinstance(target2, Clbit):
+        if bit_indices1[target1] != bit_indices2[target2]:
+            return False
+    elif isinstance(target1, ClassicalRegister) and isinstance(target2, ClassicalRegister):
+        if target1.size != target2.size or any(
+            bit_indices1[b1] != bit_indices2[b2] for b1, b2 in zip(target1, target2)
+        ):
+            return False
+    else:
+        return False
+    cases1 = [case for case, _ in node1.op.cases_specifier()]
+    cases2 = [case for case, _ in node2.op.cases_specifier()]
+    return (
+        len(cases1) == len(cases2)
+        and all(set(labels1) == set(labels2) for labels1, labels2 in zip(cases1, cases2))
+        and len(node1.op.blocks) == len(node2.op.blocks)
+        and all(
+            _circuit_to_dag(block1, node1.qargs, node1.cargs, bit_indices1)
+            == _circuit_to_dag(block2, node2.qargs, node2.cargs, bit_indices2)
+            for block1, block2 in zip(node1.op.blocks, node2.op.blocks)
+        )
+    )
+
+
+def _for_loop_eq(node1, node2, bit_indices1, bit_indices2):
+    indexset1, param1, body1 = node1.op.params
+    indexset2, param2, body2 = node2.op.params
+    if indexset1 != indexset2:
+        return False
+    if (param1 is None and param2 is not None) or (param1 is not None and param2 is None):
+        return False
+    if param1 is not None and param2 is not None:
+        sentinel = Parameter(str(uuid.uuid4()))
+        body1 = (
+            body1.assign_parameters({param1: sentinel}, inplace=False)
+            if param1 in body1.parameters
+            else body1
+        )
+        body2 = (
+            body2.assign_parameters({param2: sentinel}, inplace=False)
+            if param2 in body2.parameters
+            else body2
+        )
+    return _circuit_to_dag(body1, node1.qargs, node1.cargs, bit_indices1) == _circuit_to_dag(
+        body2, node2.qargs, node2.cargs, bit_indices2
+    )
+
+
+_SEMANTIC_EQ_CONTROL_FLOW = {
+    IfElseOp: _condition_op_eq,
+    WhileLoopOp: _condition_op_eq,
+    SwitchCaseOp: _switch_case_eq,
+    ForLoopOp: _for_loop_eq,
+}
+
+_SEMANTIC_EQ_SYMMETRIC = frozenset({"barrier", "swap", "break_loop", "continue_loop"})
 
 
 class DAGNode:
@@ -49,9 +187,10 @@ class DAGNode:
         return str(id(self))
 
     @staticmethod
-    def semantic_eq(node1, node2, bit_indices1=None, bit_indices2=None):
+    def semantic_eq(node1, node2, bit_indices1, bit_indices2):
         """
-        Check if DAG nodes are considered equivalent, e.g., as a node_match for nx.is_isomorphic.
+        Check if DAG nodes are considered equivalent, e.g., as a node_match for
+        :func:`rustworkx.is_isomorphic_node_match`.
 
         Args:
             node1 (DAGOpNode, DAGInNode, DAGOutNode): A node to compare.
@@ -64,44 +203,47 @@ class DAGNode:
         Return:
             Bool: If node1 == node2
         """
-        if bit_indices1 is None or bit_indices2 is None:
-            warnings.warn(
-                "DAGNode.semantic_eq now expects two bit-to-circuit index "
-                "mappings as arguments. To ease the transition, these will be "
-                "pre-populated based on the values found in Bit.index and "
-                "Bit.register. However, this behavior is deprecated and a future "
-                "release will require the mappings to be provided as arguments.",
-                DeprecationWarning,
+        if not isinstance(node1, DAGOpNode) or not isinstance(node1, DAGOpNode):
+            return type(node1) is type(node2) and bit_indices1.get(node1.wire) == bit_indices2.get(
+                node2.wire
             )
-            bit_indices1 = {arg: arg for arg in node1.qargs + node1.cargs}
-            bit_indices2 = {arg: arg for arg in node2.qargs + node2.cargs}
+        if isinstance(node1.op, ControlFlowOp) and isinstance(node2.op, ControlFlowOp):
+            # While control-flow operations aren't represented natively in the DAG, we have to do
+            # some unpleasant dispatching and very manual handling.  Once they have more first-class
+            # support we'll still be dispatching, but it'll look more appropriate (like the dispatch
+            # based on `DAGOpNode`/`DAGInNode`/`DAGOutNode` that already exists) and less like we're
+            # duplicating code from the `ControlFlowOp` classes.
+            if type(node1.op) is not type(node2.op):
+                return False
+            comparer = _SEMANTIC_EQ_CONTROL_FLOW.get(type(node1.op))
+            if comparer is None:  # pragma: no cover
+                raise RuntimeError(f"unhandled control-flow operation: {type(node1.op)}")
+            return comparer(node1, node2, bit_indices1, bit_indices2)
 
-        if isinstance(node1, DAGOpNode) and isinstance(node2, DAGOpNode):
-            node1_qargs = [bit_indices1[qarg] for qarg in node1.qargs]
-            node1_cargs = [bit_indices1[carg] for carg in node1.cargs]
+        node1_qargs = [bit_indices1[qarg] for qarg in node1.qargs]
+        node1_cargs = [bit_indices1[carg] for carg in node1.cargs]
 
-            node2_qargs = [bit_indices2[qarg] for qarg in node2.qargs]
-            node2_cargs = [bit_indices2[carg] for carg in node2.cargs]
+        node2_qargs = [bit_indices2[qarg] for qarg in node2.qargs]
+        node2_cargs = [bit_indices2[carg] for carg in node2.cargs]
 
-            # For barriers, qarg order is not significant so compare as sets
-            if node1.op.name == node2.op.name and node1.name in {"barrier", "swap"}:
-                return set(node1_qargs) == set(node2_qargs)
+        # For barriers, qarg order is not significant so compare as sets
+        if node1.op.name == node2.op.name and node1.name in _SEMANTIC_EQ_SYMMETRIC:
+            node1_qargs = set(node1_qargs)
+            node1_cargs = set(node1_cargs)
+            node2_qargs = set(node2_qargs)
+            node2_cargs = set(node2_cargs)
 
-            return (
-                node1_qargs == node2_qargs
-                and node1_cargs == node2_cargs
-                and (
-                    _condition_as_indices(node1.op, bit_indices1)
-                    == _condition_as_indices(node2.op, bit_indices2)
-                )
-                and node1.op == node2.op
+        return (
+            node1_qargs == node2_qargs
+            and node1_cargs == node2_cargs
+            and _legacy_condition_eq(
+                getattr(node1.op, "condition", None),
+                getattr(node2.op, "condition", None),
+                bit_indices1,
+                bit_indices2,
             )
-        if (isinstance(node1, DAGInNode) and isinstance(node2, DAGInNode)) or (
-            isinstance(node1, DAGOutNode) and isinstance(node2, DAGOutNode)
-        ):
-            return bit_indices1.get(node1.wire, None) == bit_indices2.get(node2.wire, None)
-
-        return False
+            and node1.op == node2.op
+        )
 
 
 class DAGOpNode(DAGNode):

--- a/test/python/circuit/classical/test_expr_helpers.py
+++ b/test/python/circuit/classical/test_expr_helpers.py
@@ -1,0 +1,117 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
+
+import copy
+import ddt
+
+from qiskit.circuit import Clbit, ClassicalRegister
+from qiskit.circuit.classical import expr, types
+from qiskit.test import QiskitTestCase
+
+
+@ddt.ddt
+class TestStructurallyEquivalent(QiskitTestCase):
+    @ddt.data(
+        expr.lift(Clbit()),
+        expr.lift(ClassicalRegister(3, "a")),
+        expr.lift(3, types.Uint(2)),
+        expr.cast(ClassicalRegister(3, "a"), types.Bool()),
+        expr.logic_not(Clbit()),
+        expr.bit_and(5, ClassicalRegister(3, "a")),
+        expr.logic_and(expr.less(2, ClassicalRegister(3, "a")), expr.lift(Clbit())),
+    )
+    def test_equivalent_to_self(self, node):
+        self.assertTrue(expr.structurally_equivalent(node, node))
+        self.assertTrue(expr.structurally_equivalent(node, copy.copy(node)))
+
+    # Not all of the `Binary.Op` opcodes are actually symmetric operations, but the asymmetric ones
+    # _definitely_ shouldn't compare equal when flipped!
+    @ddt.idata(expr.Binary.Op)
+    def test_does_not_compare_symmetrically(self, opcode):
+        """The function is specifically not meant to attempt things like flipping the symmetry of
+        equality.  We want the function to be simple and predictable to reason about, and allowing
+        flipping of even the mathematically symmetric binary operations are not necessarily
+        symmetric programmatically; the changed order of operations can have an effect in (say)
+        short-circuiting operations, or in external functional calls that modify global state."""
+        if opcode in (expr.Binary.Op.LOGIC_AND, expr.Binary.Op.LOGIC_OR):
+            left = expr.Value(True, types.Bool())
+            right = expr.Var(Clbit(), types.Bool())
+        else:
+            left = expr.Value(5, types.Uint(3))
+            right = expr.Var(ClassicalRegister(3, "a"), types.Uint(3))
+        if opcode in (expr.Binary.Op.BIT_AND, expr.Binary.Op.BIT_OR, expr.Binary.Op.BIT_XOR):
+            out_type = types.Uint(3)
+        else:
+            out_type = types.Bool()
+        cis = expr.Binary(opcode, left, right, out_type)
+        trans = expr.Binary(opcode, right, left, out_type)
+        self.assertFalse(expr.structurally_equivalent(cis, trans))
+        self.assertFalse(expr.structurally_equivalent(trans, cis))
+
+    def test_key_function_both(self):
+        left_clbit = Clbit()
+        left_cr = ClassicalRegister(3, "a")
+        right_clbit = Clbit()
+        right_cr = ClassicalRegister(3, "b")
+        self.assertNotEqual(left_clbit, right_clbit)
+        self.assertNotEqual(left_cr, right_cr)
+
+        left = expr.logic_not(expr.logic_and(expr.less(5, left_cr), left_clbit))
+        right = expr.logic_not(expr.logic_and(expr.less(5, right_cr), right_clbit))
+
+        self.assertFalse(expr.structurally_equivalent(left, right))
+        # The only two variables are a `Clbit` and a `ClassicalRegister`, so keying them on their
+        # types should give us a suitable comparison.
+        self.assertTrue(expr.structurally_equivalent(left, right, type, type))
+
+    def test_key_function_only_one(self):
+        left_clbit = Clbit()
+        left_cr = ClassicalRegister(3, "a")
+        right_clbit = Clbit()
+        right_cr = ClassicalRegister(3, "b")
+        self.assertNotEqual(left_clbit, right_clbit)
+        self.assertNotEqual(left_cr, right_cr)
+
+        left = expr.logic_not(expr.logic_and(expr.less(5, left_cr), left_clbit))
+        right = expr.logic_not(expr.logic_and(expr.less(5, right_cr), right_clbit))
+
+        left_to_right = {left_clbit: right_clbit, left_cr: right_cr}.get
+
+        self.assertFalse(expr.structurally_equivalent(left, right))
+        self.assertTrue(expr.structurally_equivalent(left, right, left_to_right, None))
+        self.assertTrue(expr.structurally_equivalent(right, left, None, left_to_right))
+
+    def test_key_function_can_return_none(self):
+        """If the key function returns ``None``, the variable should be used raw as the comparison
+        base, _not_ the ``None`` return value."""
+        left_bit = Clbit()
+        right_bit = Clbit()
+
+        class EqualsEverything:
+            def __eq__(self, _other):
+                return True
+
+        def not_handled(_):
+            return None
+
+        def always_equal(_):
+            return EqualsEverything()
+
+        left = expr.logic_and(left_bit, True)
+        right = expr.logic_and(right_bit, True)
+        self.assertFalse(expr.structurally_equivalent(left, right))
+        # If the function erroneously compares the ``None`` outputs, the following call would return
+        # ``True`` instead.
+        self.assertFalse(expr.structurally_equivalent(left, right, not_handled, not_handled))
+        self.assertTrue(expr.structurally_equivalent(left, right, always_equal, always_equal))

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -1611,6 +1611,39 @@ class TestDagEquivalence(QiskitTestCase):
         qc2.x(0).c_if(qc2.clbits[-1], False)
         self.assertNotEqual(circuit_to_dag(qc1), circuit_to_dag(qc2))
 
+    def test_semantic_expr(self):
+        """Test that the semantic equality is applied to the bits in `Expr` components as well."""
+        cr = ClassicalRegister(3, "c1")
+        clbit1 = Clbit()
+        clbit2 = Clbit()
+
+        body = QuantumCircuit(1)
+        body.x(0)
+
+        qc1 = QuantumCircuit(cr, [Qubit(), clbit1])
+        qc1.if_test(expr.logic_not(clbit1), body, [0], [])
+        qc2 = QuantumCircuit(cr, [Qubit(), clbit2])
+        qc2.if_test(expr.logic_not(clbit2), body, [0], [])
+        self.assertEqual(circuit_to_dag(qc1), circuit_to_dag(qc2))
+
+        qc1 = QuantumCircuit(cr, [Qubit(), clbit1])
+        qc2 = QuantumCircuit(cr, [Qubit(), clbit2])
+        qc1.switch(expr.bit_and(cr, 5), [(1, body)], [0], [])
+        qc2.switch(expr.bit_and(cr, 5), [(1, body)], [0], [])
+        self.assertEqual(circuit_to_dag(qc1), circuit_to_dag(qc2))
+
+        # Order of bits not the same.
+        qc1 = QuantumCircuit(cr, [Qubit(), clbit1])
+        qc1.if_test(expr.logic_not(clbit1), body, [0], [])
+        qc2 = QuantumCircuit([Qubit(), clbit2], cr)
+        qc2.if_test(expr.logic_not(clbit2), body, [0], [])
+
+        qc1 = QuantumCircuit(cr, [Qubit(), clbit1])
+        qc1.switch(expr.bit_and(cr, 5), [(1, body)], [0], [])
+        qc2 = QuantumCircuit([Qubit(), clbit2], cr)
+        qc2.switch(expr.bit_and(cr, 5), [(1, body)], [0], [])
+        self.assertNotEqual(circuit_to_dag(qc1), circuit_to_dag(qc2))
+
 
 class TestDagSubstitute(QiskitTestCase):
     """Test substituting a dag node with a sub-dag"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This adds support to semantically check the variables of `Expr` nodes that occur within `DAGCircuit` constructs, using similar logic to the remapping done by the existing condition checks.  As a knock-on effect of how the control-flow introspection was added to allow these checks, the canonicalisation performed by `qiskit.test._canonical.canonicalize_control_flow` is now inherent to the `DAGCircuit` equality methods, largely removing the need for that explicit canonical form in tests.

The dispatch of `QuantumCircuit.__eq__` to `DAGCircuit.__eq__` means that direct comparisons of `QuantumCircuit`s will also benefit from this change.

As a partial implementation detail, the semantic checking is achieved and defined by the function `expr.structurally_equivalent`, with key functions for mapping the variables.  The naming discrepancy (semantic versus structural) is deliberate. Classical expressions are considered "equal" if and only if their tree structures match exactly; there is no attempt to move the classical expressions into some canonical form, as this is not typically simple; even mathematically symmetric operations typically impact the order of sub-expression evaluation, and we don't want to get into the weeds of that.  Better to just define equality as "structurally exactly equal", and have the key function just so alpha-renaming-compatible variables can still be canonicalised into something that can be compared between expressions.


### Details and comments

Close #10359.  Depends on #10362 (and the rest of its chain).  Changelog to come as part of #10331.