### PR TITLE
Honour CI constraints in Neko tests

### DIFF
--- a/.github/workflows/neko.yml
+++ b/.github/workflows/neko.yml
@@ -16,3 +16,4 @@ jobs:
       - uses: Qiskit/qiskit-neko@main
         with:
           test_selection: terra
+          repo_install_command: "pip install -c constraints.txt ."


### PR DESCRIPTION
### Summary

Ideally we'd be running the Neko tests against the requirements that will actually form the complete package.  In practice, however, there are persistent failures from Neko stemming from PySCF's use of SciPy, which we get via Nature, which is no longer under Qiskit control.

While we work out what the future of the Neko test suite is, with the application modules now no longer being IBM-managed Qiskit packages, we can apply the CI constraints so we can return to getting reports from the parts of the integration tests that are actually within our control.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

We might choose to revert this in the future, when we've got a different view on what the Neko tests will look like in the future.  We can also revert it more eagerly, if PySCF makes a new release that includes pyscf/pyscf#1771, since the part that's failing for us is just their incompatibility with SciPy 1.11.
