### PR TITLE
Add `Expr` support to `DAGCircuit.compose`

### DIFF
--- a/qiskit/circuit/_classical_resource_map.py
+++ b/qiskit/circuit/_classical_resource_map.py
@@ -33,24 +33,22 @@ class VariableMapper(expr.ExprVisitor[expr.Expr]):
 
     If an ``add_register`` callable is given to the initialiser, the mapper will use it to attempt
     to add new aliasing registers to the outer circuit object, if there is not already a suitable
-    register for the mapping available in the circuit.  If this parameter is not given, the mapping
-    function will raise an exception of type ``exc_type`` instead.
-    """
+    register for the mapping available in the circuit.  If this parameter is not given, a
+    ``ValueError`` will be raised instead.  The given ``add_register`` callable may choose to raise
+    its own exception."""
 
-    __slots__ = ("target_cregs", "register_map", "bit_map", "add_register", "exc_type")
+    __slots__ = ("target_cregs", "register_map", "bit_map", "add_register")
 
     def __init__(
         self,
         target_cregs: typing.Iterable[ClassicalRegister],
         bit_map: typing.Mapping[Bit, Bit],
         add_register: typing.Callable[[ClassicalRegister], None] | None = None,
-        exc_type: typing.Type[Exception] = ValueError,
     ):
         self.target_cregs = tuple(target_cregs)
         self.register_map = {}
         self.bit_map = bit_map
         self.add_register = add_register
-        self.exc_type = exc_type
 
     def _map_register(self, theirs: ClassicalRegister) -> ClassicalRegister:
         """Map the target's registers to suitable equivalents in the destination, adding an
@@ -64,9 +62,7 @@ class VariableMapper(expr.ExprVisitor[expr.Expr]):
                 break
         else:
             if self.add_register is None:
-                raise self.exc_type(
-                    f"Register '{theirs.name}' has no counterpart in the destination."
-                )
+                raise ValueError(f"Register '{theirs.name}' has no counterpart in the destination.")
             mapped_theirs = ClassicalRegister(bits=mapped_bits)
             self.add_register(mapped_theirs)
         self.register_map[theirs.name] = mapped_theirs

--- a/qiskit/circuit/_classical_resource_map.py
+++ b/qiskit/circuit/_classical_resource_map.py
@@ -1,0 +1,148 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Shared helper utility for mapping classical resources from one circuit or DAG to another."""
+
+from __future__ import annotations
+
+import typing
+
+from .bit import Bit
+from .classical import expr
+from .classicalregister import ClassicalRegister, Clbit
+
+
+class VariableMapper(expr.ExprVisitor[expr.Expr]):
+    """Stateful helper class that manages the mapping of variables in conditions and expressions.
+
+    This is designed to be used by both :class:`.QuantumCircuit` and :class:`.DAGCircuit` when
+    managing operations that need to map classical resources from one circuit to another.
+
+    The general usage is to initialise this at the start of a many-block mapping operation, then
+    call its :meth:`map_condition`, :meth:`map_target` or :meth:`map_expr` methods as appropriate,
+    which will return the new object that should be used.
+
+    If an ``add_register`` callable is given to the initialiser, the mapper will use it to attempt
+    to add new aliasing registers to the outer circuit object, if there is not already a suitable
+    register for the mapping available in the circuit.  If this parameter is not given, the mapping
+    function will raise an exception of type ``exc_type`` instead.
+    """
+
+    __slots__ = ("target_cregs", "register_map", "bit_map", "add_register", "exc_type")
+
+    def __init__(
+        self,
+        target_cregs: typing.Iterable[ClassicalRegister],
+        bit_map: typing.Mapping[Bit, Bit],
+        add_register: typing.Callable[[ClassicalRegister], None] | None = None,
+        exc_type: typing.Type[Exception] = ValueError,
+    ):
+        self.target_cregs = tuple(target_cregs)
+        self.register_map = {}
+        self.bit_map = bit_map
+        self.add_register = add_register
+        self.exc_type = exc_type
+
+    def _map_register(self, theirs: ClassicalRegister) -> ClassicalRegister:
+        """Map the target's registers to suitable equivalents in the destination, adding an
+        extra one if there's no exact match."""
+        if (mapped_theirs := self.register_map.get(theirs.name)) is not None:
+            return mapped_theirs
+        mapped_bits = [self.bit_map[bit] for bit in theirs]
+        for ours in self.target_cregs:
+            if mapped_bits == list(ours):
+                mapped_theirs = ours
+                break
+        else:
+            if self.add_register is None:
+                raise self.exc_type(
+                    f"Register '{theirs.name}' has no counterpart in the destination."
+                )
+            mapped_theirs = ClassicalRegister(bits=mapped_bits)
+            self.add_register(mapped_theirs)
+        self.register_map[theirs.name] = mapped_theirs
+        return mapped_theirs
+
+    def map_condition(self, condition, /, *, allow_reorder=False):
+        """Map the given ``condition`` so that it only references variables in the destination
+        circuit (as given to this class on initialisation).
+
+        If ``allow_reorder`` is ``True``, then when a legacy condition (the two-tuple form) is made
+        on a register that has a counterpart in the destination with all the same (mapped) bits but
+        in a different order, then that register will be used and the value suitably modified to
+        make the equality condition work.  This is maintaining legacy (tested) behaviour of
+        :meth:`.DAGCircuit.compose`; nowhere else does this, and in general this would require *far*
+        more complex classical rewriting than Terra needs to worry about in the full expression era.
+        """
+        if condition is None:
+            return None
+        if isinstance(condition, expr.Expr):
+            return self.map_expr(condition)
+        target, value = condition
+        if isinstance(target, Clbit):
+            return (self.bit_map[target], value)
+        if not allow_reorder:
+            return (self._map_register(target), value)
+        # This is maintaining the legacy behaviour of `DAGCircuit.compose`.  We don't attempt to
+        # speed-up this lookup with a cache, since that would just make the more standard cases more
+        # annoying to deal with.
+        mapped_bits_order = [self.bit_map[bit] for bit in target]
+        mapped_bits_set = set(mapped_bits_order)
+        for register in self.target_cregs:
+            if mapped_bits_set == set(register):
+                mapped_theirs = register
+                break
+        else:
+            if self.add_register is None:
+                raise self.exc_type(
+                    f"Register '{target.name}' has no counterpart in the destination."
+                )
+            mapped_theirs = ClassicalRegister(bits=mapped_bits_order)
+            self.add_register(mapped_theirs)
+        new_order = {bit: i for i, bit in enumerate(mapped_bits_order)}
+        value_bits = f"{value:0{len(target)}b}"[::-1]  # Little-index-indexed binary bitstring.
+        mapped_value = int("".join(value_bits[new_order[bit]] for bit in mapped_theirs)[::-1], 2)
+        return (mapped_theirs, mapped_value)
+
+    def map_target(self, target, /):
+        """Map the runtime variables in a ``target`` of a :class:`.SwitchCaseOp` to the new circuit,
+        as defined in the ``circuit`` argument of the initialiser of this class."""
+        if isinstance(target, Clbit):
+            return self.bit_map[target]
+        if isinstance(target, ClassicalRegister):
+            return self._map_register(target)
+        return self.map_expr(target)
+
+    def map_expr(self, node: expr.Expr, /) -> expr.Expr:
+        """Map the variables in an :class:`~.expr.Expr` node to the new circuit."""
+        return node.accept(self)
+
+    def visit_var(self, node, /):
+        if isinstance(node.var, Clbit):
+            return expr.Var(self.bit_map[node.var], node.type)
+        if isinstance(node.var, ClassicalRegister):
+            return expr.Var(self._map_register(node.var), node.type)
+        # Defensive against the expansion of the variable system; we don't want to silently do the
+        # wrong thing (which would be `return node` without mapping, right now).
+        raise RuntimeError(f"unhandled variable in 'compose': {node}")  # pragma: no cover
+
+    def visit_value(self, node, /):
+        return expr.Value(node.value, node.type)
+
+    def visit_unary(self, node, /):
+        return expr.Unary(node.op, node.operand.accept(self), node.type)
+
+    def visit_binary(self, node, /):
+        return expr.Binary(node.op, node.left.accept(self), node.right.accept(self), node.type)
+
+    def visit_cast(self, node, /):
+        return expr.Cast(node.operand.accept(self), node.type, implicit=node.implicit)

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -48,6 +48,7 @@ from qiskit.circuit.gate import Gate
 from qiskit.circuit.parameter import Parameter
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.utils import optionals as _optionals
+from . import _classical_resource_map
 from .classical import expr
 from .parameterexpression import ParameterExpression, ParameterValueType
 from .quantumregister import QuantumRegister, Qubit, AncillaRegister, AncillaQubit
@@ -949,7 +950,9 @@ class QuantumCircuit:
                 )
             edge_map.update(zip(other.clbits, dest.cbit_argument_conversion(clbits)))
 
-        variable_mapper = _ComposeVariableMapper(dest, edge_map)
+        variable_mapper = _classical_resource_map.VariableMapper(
+            dest.cregs, edge_map, dest.add_register
+        )
         mapped_instrs: list[CircuitInstruction] = []
         for instr in other.data:
             n_qargs: list[Qubit] = [edge_map[qarg] for qarg in instr.qubits]
@@ -5225,79 +5228,3 @@ def _bit_argument_conversion_scalar(specifier, bit_sequence, bit_set, type_):
         else f"Invalid bit index: '{specifier}' of type '{type(specifier)}'"
     )
     raise CircuitError(message)
-
-
-class _ComposeVariableMapper(expr.ExprVisitor[expr.Expr]):
-    """Stateful helper class that manages the mapping of variables in conditions and expressions to
-    items in the destination ``circuit``.
-
-    This mutates ``circuit`` by adding registers as required."""
-
-    __slots__ = ("circuit", "register_map", "bit_map")
-
-    def __init__(self, circuit, bit_map):
-        self.circuit = circuit
-        self.register_map = {}
-        self.bit_map = bit_map
-
-    def _map_register(self, theirs):
-        """Map the target's registers to suitable equivalents in the destination, adding an
-        extra one if there's no exact match."""
-        if (mapped_theirs := self.register_map.get(theirs.name)) is not None:
-            return mapped_theirs
-        mapped_bits = [self.bit_map[bit] for bit in theirs]
-        for ours in self.circuit.cregs:
-            if mapped_bits == list(ours):
-                mapped_theirs = ours
-                break
-        else:
-            mapped_theirs = ClassicalRegister(bits=mapped_bits)
-            self.circuit.add_register(mapped_theirs)
-        self.register_map[theirs.name] = mapped_theirs
-        return mapped_theirs
-
-    def map_condition(self, condition, /):
-        """Map the given ``condition`` so that it only references variables in the destination
-        circuit (as given to this class on initialisation)."""
-        if condition is None:
-            return None
-        if isinstance(condition, expr.Expr):
-            return self.map_expr(condition)
-        target, value = condition
-        if isinstance(target, Clbit):
-            return (self.bit_map[target], value)
-        return (self._map_register(target), value)
-
-    def map_target(self, target, /):
-        """Map the runtime variables in a ``target`` of a :class:`.SwitchCaseOp` to the new circuit,
-        as defined in the ``circuit`` argument of the initialiser of this class."""
-        if isinstance(target, Clbit):
-            return self.bit_map[target]
-        if isinstance(target, ClassicalRegister):
-            return self._map_register(target)
-        return self.map_expr(target)
-
-    def map_expr(self, node: expr.Expr, /) -> expr.Expr:
-        """Map the variables in an :class:`~.expr.Expr` node to the new circuit."""
-        return node.accept(self)
-
-    def visit_var(self, node, /):
-        if isinstance(node.var, Clbit):
-            return expr.Var(self.bit_map[node.var], node.type)
-        if isinstance(node.var, ClassicalRegister):
-            return expr.Var(self._map_register(node.var), node.type)
-        # Defensive against the expansion of the variable system; we don't want to silently do the
-        # wrong thing (which would be `return node` without mapping, right now).
-        raise CircuitError(f"unhandled variable in 'compose': {node}")  # pragma: no cover
-
-    def visit_value(self, node, /):
-        return expr.Value(node.value, node.type)
-
-    def visit_unary(self, node, /):
-        return expr.Unary(node.op, node.operand.accept(self), node.type)
-
-    def visit_binary(self, node, /):
-        return expr.Binary(node.op, node.left.accept(self), node.right.accept(self), node.type)
-
-    def visit_cast(self, node, /):
-        return expr.Cast(node.operand.accept(self), node.type, implicit=node.implicit)

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -710,8 +710,12 @@ class DAGCircuit:
         for gate, cals in other.calibrations.items():
             dag._calibrations[gate].update(cals)
 
+        # Ensure that the error raised here is a `DAGCircuitError` for backwards compatiblity.
+        def _reject_new_register(reg):
+            raise DAGCircuitError(f"No register with '{reg.bits}' to map this expression onto.")
+
         variable_mapper = _classical_resource_map.VariableMapper(
-            dag.cregs.values(), edge_map, exc_type=DAGCircuitError
+            dag.cregs.values(), edge_map, _reject_new_register
         )
         for nd in other.topological_nodes():
             if isinstance(nd, DAGInNode):

--- a/test/python/dagcircuit/test_compose.py
+++ b/test/python/dagcircuit/test_compose.py
@@ -14,7 +14,17 @@
 
 import unittest
 
-from qiskit.circuit import QuantumRegister, ClassicalRegister, QuantumCircuit
+from qiskit.circuit import (
+    QuantumRegister,
+    ClassicalRegister,
+    QuantumCircuit,
+    IfElseOp,
+    WhileLoopOp,
+    SwitchCaseOp,
+    CASE_DEFAULT,
+)
+from qiskit.circuit.classical import expr, types
+from qiskit.dagcircuit import DAGCircuit
 from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.test import QiskitTestCase
 from qiskit.pulse import Schedule
@@ -422,6 +432,113 @@ class TestDagCompose(QiskitTestCase):
         dag_expected = circuit_to_dag(circuit_right.copy())
 
         self.assertEqual(dag_composed, dag_expected)
+
+    def test_compose_expr_condition(self):
+        """Test that compose correctly maps clbits and registers in expression conditions."""
+        inner = QuantumCircuit(1)
+        inner.x(0)
+        qr_src = QuantumRegister(1)
+        a_src = ClassicalRegister(2, "a_src")
+        b_src = ClassicalRegister(2, "b_src")
+        source = DAGCircuit()
+        source.add_qreg(qr_src)
+        source.add_creg(a_src)
+        source.add_creg(b_src)
+
+        test_1 = lambda: expr.lift(a_src[0])
+        test_2 = lambda: expr.logic_not(b_src[1])
+        test_3 = lambda: expr.cast(expr.bit_and(b_src, 2), types.Bool())
+        node_1 = source.apply_operation_back(IfElseOp(test_1(), inner.copy(), None), qr_src, [])
+        node_2 = source.apply_operation_back(
+            IfElseOp(test_2(), inner.copy(), inner.copy()), qr_src, []
+        )
+        node_3 = source.apply_operation_back(WhileLoopOp(test_3(), inner.copy()), qr_src, [])
+
+        qr_dest = QuantumRegister(1)
+        a_dest = ClassicalRegister(2, "a_dest")
+        b_dest = ClassicalRegister(2, "b_dest")
+        dest = DAGCircuit()
+        dest.add_qreg(qr_dest)
+        dest.add_creg(a_dest)
+        dest.add_creg(b_dest)
+
+        dest.compose(source)
+
+        # Check that the input conditions weren't mutated.
+        for in_condition, node in zip((test_1, test_2, test_3), (node_1, node_2, node_3)):
+            self.assertEqual(in_condition(), node.op.condition)
+
+        expected = QuantumCircuit(qr_dest, a_dest, b_dest)
+        expected.if_test(expr.lift(a_dest[0]), inner.copy(), [0], [])
+        expected.if_else(expr.logic_not(b_dest[1]), inner.copy(), inner.copy(), [0], [])
+        expected.while_loop(expr.cast(expr.bit_and(b_dest, 2), types.Bool()), inner.copy(), [0], [])
+        self.assertEqual(dest, circuit_to_dag(expected))
+
+    def test_compose_expr_target(self):
+        """Test that compose correctly maps clbits and registers in expression targets."""
+        inner1 = QuantumCircuit(1)
+        inner1.x(0)
+        inner2 = QuantumCircuit(1)
+        inner2.z(0)
+
+        qr_src = QuantumRegister(1)
+        a_src = ClassicalRegister(2, "a_src")
+        b_src = ClassicalRegister(2, "b_src")
+        source = DAGCircuit()
+        source.add_qreg(qr_src)
+        source.add_creg(a_src)
+        source.add_creg(b_src)
+
+        test_1 = lambda: expr.lift(a_src[0])
+        test_2 = lambda: expr.logic_not(b_src[1])
+        test_3 = lambda: expr.lift(b_src)
+        test_4 = lambda: expr.bit_and(b_src, 2)
+        node_1 = source.apply_operation_back(
+            SwitchCaseOp(test_1(), [(False, inner1.copy()), (True, inner2.copy())]), qr_src, []
+        )
+        node_2 = source.apply_operation_back(
+            SwitchCaseOp(test_2(), [(False, inner1.copy()), (True, inner2.copy())]), qr_src, []
+        )
+        node_3 = source.apply_operation_back(
+            SwitchCaseOp(test_3(), [(0, inner1.copy()), (CASE_DEFAULT, inner2.copy())]), qr_src, []
+        )
+        node_4 = source.apply_operation_back(
+            SwitchCaseOp(test_4(), [(0, inner1.copy()), (CASE_DEFAULT, inner2.copy())]), qr_src, []
+        )
+
+        qr_dest = QuantumRegister(1)
+        a_dest = ClassicalRegister(2, "a_dest")
+        b_dest = ClassicalRegister(2, "b_dest")
+        dest = DAGCircuit()
+        dest.add_qreg(qr_dest)
+        dest.add_creg(a_dest)
+        dest.add_creg(b_dest)
+        dest.compose(source)
+
+        # Check that the input expressions weren't mutated.
+        for in_target, node in zip(
+            (test_1, test_2, test_3, test_4), (node_1, node_2, node_3, node_4)
+        ):
+            self.assertEqual(in_target(), node.op.target)
+
+        expected = QuantumCircuit(qr_dest, a_dest, b_dest)
+        expected.switch(
+            expr.lift(a_dest[0]), [(False, inner1.copy()), (True, inner2.copy())], [0], []
+        )
+        expected.switch(
+            expr.logic_not(b_dest[1]), [(False, inner1.copy()), (True, inner2.copy())], [0], []
+        )
+        expected.switch(
+            expr.lift(b_dest), [(0, inner1.copy()), (CASE_DEFAULT, inner2.copy())], [0], []
+        )
+        expected.switch(
+            expr.bit_and(b_dest, 2),
+            [(0, inner1.copy()), (CASE_DEFAULT, inner2.copy())],
+            [0],
+            [],
+        )
+
+        self.assertEqual(dest, circuit_to_dag(expected))
 
     def test_compose_calibrations(self):
         """Test that compose carries over the calibrations."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The remapping facilities are (except for some esoteric behaviour for mapping registers to others in a different order) the same as for `QuantumCircuit`, so it makes sense to unify the handling.  As part of switching the old `DAGCircuit` classical-resource-mapping methods over to the new general-purpose forms, this does most of the necessary work to upgrade `substitute_node_with_dag` as well.


### Details and comments

Resolve #10230.  Depends on #10375 (since I elected to generalise some of the new handling from that PR).  Changelog in #10331.
