### PR TITLE
small fixes in docs: bullet lists in transpiler levels

### DIFF
--- a/qiskit/algorithms/minimum_eigensolvers/qaoa.py
+++ b/qiskit/algorithms/minimum_eigensolvers/qaoa.py
@@ -116,7 +116,7 @@ class QAOA(SamplingVQE):
                 [0,1]` parameter for a CVaR expectation value.
             callback: A callback that can access the intermediate data at each optimization step.
                 These data are: the evaluation count, the optimizer parameters for the ansatz, the
-                evaluated value, the the metadata dictionary.
+                evaluated value, the metadata dictionary.
         """
         validate_min("reps", reps, 1)
 

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -304,7 +304,7 @@ def _generate_gray_code(num_bits):
 
 
 def _gray_code_chain(q, num_ctrl_qubits, gate):
-    """Apply the gate to the the last qubit in the register ``q``, controlled on all
+    """Apply the gate to the last qubit in the register ``q``, controlled on all
     preceding qubits. This function uses the gray code to propagate down to the last qubit.
 
     Ported and adapted from Aqua (github.com/Qiskit/qiskit-aqua),

--- a/qiskit/circuit/register.py
+++ b/qiskit/circuit/register.py
@@ -143,8 +143,8 @@ class Register:
             self._bits = [self.bit_type(self, idx) for idx in range(size)]
 
             # Since the hash of Bits created by the line above will depend upon
-            # the the hash of self, which is not guaranteed to have been initialized
-            # first on deepcopying or on pickling, so defer populating _bit_indices
+            # the hash of self, which is not guaranteed to have been initialized
+            # first on deep-copying or on pickling, so defer populating _bit_indices
             # until first access.
             self._bit_indices = None
 

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -210,10 +210,12 @@ def transpile(
         optimization_level: How much optimization to perform on the circuits.
             Higher levels generate more optimized circuits,
             at the expense of longer transpilation time.
-            * 0: no optimization
-            * 1: light optimization
-            * 2: heavy optimization
-            * 3: even heavier optimization
+
+                * 0: no optimization
+                * 1: light optimization
+                * 2: heavy optimization
+                * 3: even heavier optimization
+
             If ``None``, level 1 will be chosen as default.
         callback: A callback function that will be called after each
             pass execution. The function will be called with 5 keyword

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -211,10 +211,10 @@ def transpile(
             Higher levels generate more optimized circuits,
             at the expense of longer transpilation time.
 
-                * 0: no optimization
-                * 1: light optimization
-                * 2: heavy optimization
-                * 3: even heavier optimization
+            * 0: no optimization
+            * 1: light optimization
+            * 2: heavy optimization
+            * 3: even heavier optimization
 
             If ``None``, level 1 will be chosen as default.
         callback: A callback function that will be called after each

--- a/qiskit/execute_function.py
+++ b/qiskit/execute_function.py
@@ -148,10 +148,12 @@ def execute(
         optimization_level (int): How much optimization to perform on the circuits.
             Higher levels generate more optimized circuits,
             at the expense of longer transpilation time.
-            #. No optimization
-            #. Light optimization
-            #. Heavy optimization
-            #. Highest optimization
+
+                * No optimization
+                * Light optimization
+                * Heavy optimization
+                * Highest optimization
+
             If None, level 1 will be chosen as default.
 
         pass_manager (PassManager): The pass manager to use during transpilation. If this

--- a/qiskit/execute_function.py
+++ b/qiskit/execute_function.py
@@ -149,10 +149,10 @@ def execute(
             Higher levels generate more optimized circuits,
             at the expense of longer transpilation time.
 
-                * No optimization
-                * Light optimization
-                * Heavy optimization
-                * Highest optimization
+            * 0: no optimization
+            * 1: light optimization
+            * 2: heavy optimization
+            * 3: even heavier optimization
 
             If None, level 1 will be chosen as default.
 

--- a/qiskit/pulse/library/parametric_pulses.py
+++ b/qiskit/pulse/library/parametric_pulses.py
@@ -80,7 +80,7 @@ class ParametricPulse(Pulse):
         """Create a parametric pulse and validate the input parameters.
 
         Args:
-            duration: Pulse length in terms of the the sampling period `dt`.
+            duration: Pulse length in terms of the sampling period `dt`.
             name: Display name for this pulse envelope.
             limit_amplitude: If ``True``, then limit the amplitude of the
                              waveform to 1. The default is ``True`` and the
@@ -151,7 +151,7 @@ class Gaussian(ParametricPulse):
         """Initialize the gaussian pulse.
 
         Args:
-            duration: Pulse length in terms of the the sampling period `dt`.
+            duration: Pulse length in terms of the sampling period `dt`.
             amp: The amplitude of the Gaussian envelope.
             sigma: A measure of how wide or narrow the Gaussian peak is; described mathematically
                    in the class docstring.
@@ -265,7 +265,7 @@ class GaussianSquare(ParametricPulse):
         """Initialize the gaussian square pulse.
 
         Args:
-            duration: Pulse length in terms of the the sampling period `dt`.
+            duration: Pulse length in terms of the sampling period `dt`.
             amp: The amplitude of the Gaussian and of the square pulse.
             sigma: A measure of how wide or narrow the Gaussian risefall is; see the class
                    docstring for more details.
@@ -434,7 +434,7 @@ class Drag(ParametricPulse):
         """Initialize the drag pulse.
 
         Args:
-            duration: Pulse length in terms of the the sampling period `dt`.
+            duration: Pulse length in terms of the sampling period `dt`.
             amp: The amplitude of the Drag envelope.
             sigma: A measure of how wide or narrow the Gaussian peak is; described mathematically
                    in the class docstring.
@@ -556,7 +556,7 @@ class Constant(ParametricPulse):
         Initialize the constant-valued pulse.
 
         Args:
-            duration: Pulse length in terms of the the sampling period `dt`.
+            duration: Pulse length in terms of the sampling period `dt`.
             amp: The amplitude of the constant square pulse.
             name: Display name for this pulse envelope.
             limit_amplitude: If ``True``, then limit the amplitude of the

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -221,7 +221,7 @@ class SparsePauliOp(LinearOp):
 
     @property
     def paulis(self):
-        """Return the the PauliList."""
+        """Return the PauliList."""
         return self._pauli_list
 
     @paulis.setter

--- a/qiskit/result/mitigation/correlated_readout_mitigator.py
+++ b/qiskit/result/mitigation/correlated_readout_mitigator.py
@@ -84,7 +84,7 @@ class CorrelatedReadoutMitigator(BaseReadoutMitigator):
         Args:
             data: Counts object
             diagonal: Optional, the vector of diagonal values for summing the
-                      expectation value. If ``None`` the the default value is
+                      expectation value. If ``None`` the default value is
                       :math:`[1, -1]^\otimes n`.
             qubits: Optional, the measured physical qubits the count
                     bitstrings correspond to. If None qubits are assumed to be

--- a/qiskit/result/mitigation/local_readout_mitigator.py
+++ b/qiskit/result/mitigation/local_readout_mitigator.py
@@ -113,7 +113,7 @@ class LocalReadoutMitigator(BaseReadoutMitigator):
         Args:
             data: Counts object
             diagonal: Optional, the vector of diagonal values for summing the
-                      expectation value. If ``None`` the the default value is
+                      expectation value. If ``None`` the default value is
                       :math:`[1, -1]^\otimes n`.
             qubits: Optional, the measured physical qubits the count
                     bitstrings correspond to. If None qubits are assumed to be

--- a/qiskit/transpiler/passes/optimization/template_matching/template_matching.py
+++ b/qiskit/transpiler/passes/optimization/template_matching/template_matching.py
@@ -235,11 +235,11 @@ class TemplateMatching:
     def run_template_matching(self):
         """
         Run the complete algorithm for finding all maximal matches for the given template and
-        circuit. First it fixes the configuration of the the circuit due to the first match.
+        circuit. First it fixes the configuration of the circuit due to the first match.
         Then it explores all compatible qubit configurations of the circuit. For each
         qubit configurations, we apply first the Forward part of the algorithm  and then
         the Backward part of the algorithm. The longest matches for the given configuration
-        are stored. Finally the list of stored matches is sorted.
+        are stored. Finally, the list of stored matches is sorted.
         """
 
         # Get the number of qubits/clbits for both circuit and template.

--- a/qiskit/transpiler/passes/synthesis/solovay_kitaev_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/solovay_kitaev_synthesis.py
@@ -204,7 +204,7 @@ class SolovayKitaevSynthesis(UnitarySynthesisPlugin):
         defaults to ``["h", "t", "tdg"]``.
 
     depth (int):
-        The gate-depth of the the basic approximations. All possible, unique combinations of the
+        The gate-depth of the basic approximations. All possible, unique combinations of the
         basis gates up to length ``depth`` are considered. If None, defaults to 10.
 
     recursion_degree (int):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes the bullet list for the transpilation level in the documentation, besides some other small issues (like double "the"s)

Before 
<img width="757" alt="Screenshot 2023-07-06 at 11 24 45" src="https://github.com/Qiskit/qiskit-terra/assets/766693/89ba6eed-16f3-4b9b-84dc-dfc551031191">

After
<img width="787" alt="Screenshot 2023-07-06 at 11 24 21" src="https://github.com/Qiskit/qiskit-terra/assets/766693/e8b2ed82-bbfd-43a6-afd1-c12c6db47753">


