### PR TITLE
Fix `CheckMap` with control-flow builder nested conditionals

### DIFF
--- a/releasenotes/notes/fix-checkmap-nested-condition-1776f952f6c6722a.yaml
+++ b/releasenotes/notes/fix-checkmap-nested-condition-1776f952f6c6722a.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The :class:`.CheckMap` transpiler pass will no longer spuriously error when dealing with nested
+    conditional structures created by the control-flow builder interface.  See `#10394
+    <https://github.com/Qiskit/qiskit-terra/issues/10394>`__.


### PR DESCRIPTION
### Summary

The recursion inside the `CheckMap` pass was based on a custom `DAGCircuit.compose` solution, rather than the more standard qubit-argument-binding setup we normally use.  This did not pass in the clbit ordering to the composition, which could cause it to fail to map nested conditional statements.

Instead, we can just enter each DAG naturally, and use the regular wire map to access the physical indices being referred to.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #10394.
