### PR TITLE
Add `Expr` support to the control-flow builders

### DIFF
--- a/qiskit/circuit/controlflow/builder.py
+++ b/qiskit/circuit/controlflow/builder.py
@@ -153,7 +153,6 @@ class InstructionPlaceholder(Instruction, abc.ABC):
             The same instruction instance that was passed, but mutated to propagate the tracked
             changes to this class.
         """
-        # In general the tuple creation should be a no-op, because ``tuple(t) is t`` for tuples.
         instruction.condition = self.condition
         return instruction
 

--- a/qiskit/circuit/controlflow/builder.py
+++ b/qiskit/circuit/controlflow/builder.py
@@ -30,7 +30,7 @@ from qiskit.circuit.quantumcircuitdata import CircuitInstruction
 from qiskit.circuit.quantumregister import Qubit, QuantumRegister
 from qiskit.circuit.register import Register
 
-from ._builder_utils import condition_resources
+from ._builder_utils import condition_resources, node_resources
 
 if typing.TYPE_CHECKING:
     import qiskit  # pylint: disable=cyclic-import
@@ -154,7 +154,7 @@ class InstructionPlaceholder(Instruction, abc.ABC):
             changes to this class.
         """
         # In general the tuple creation should be a no-op, because ``tuple(t) is t`` for tuples.
-        instruction.condition = None if self.condition is None else tuple(self.condition)
+        instruction.condition = self.condition
         return instruction
 
     # Provide some better error messages, just in case something goes wrong during development and
@@ -402,7 +402,7 @@ class ControlFlowBuilderBlock:
             and using the minimal set of resources necessary to support them, within the enclosing
             scope.
         """
-        from qiskit.circuit import QuantumCircuit
+        from qiskit.circuit import QuantumCircuit, SwitchCaseOp
 
         # There's actually no real problem with building a scope more than once.  This flag is more
         # so _other_ operations, which aren't safe can be forbidden, such as mutating instructions
@@ -448,6 +448,18 @@ class ControlFlowBuilderBlock:
                         out.add_register(register)
             if getattr(instruction.operation, "condition", None) is not None:
                 for register in condition_resources(instruction.operation.condition).cregs:
+                    if register not in self.registers:
+                        self.add_register(register)
+                        out.add_register(register)
+            elif isinstance(instruction.operation, SwitchCaseOp):
+                target = instruction.operation.target
+                if isinstance(target, Clbit):
+                    target_registers = ()
+                elif isinstance(target, ClassicalRegister):
+                    target_registers = (target,)
+                else:
+                    target_registers = node_resources(target).cregs
+                for register in target_registers:
                     if register not in self.registers:
                         self.add_register(register)
                         out.add_register(register)

--- a/qiskit/circuit/controlflow/if_else.py
+++ b/qiskit/circuit/controlflow/if_else.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, Tuple, Union, Iterable
+from typing import Optional, Union, Iterable
 import itertools
 
 from qiskit.circuit import ClassicalRegister, Clbit, QuantumCircuit
@@ -182,9 +182,9 @@ class IfElsePlaceholder(InstructionPlaceholder):
 
     def __init__(
         self,
-        condition: Tuple[Union[ClassicalRegister, Clbit], int],
+        condition: tuple[ClassicalRegister, int] | tuple[Clbit, int] | expr.Expr,
         true_block: ControlFlowBuilderBlock,
-        false_block: Optional[ControlFlowBuilderBlock] = None,
+        false_block: ControlFlowBuilderBlock | None = None,
         *,
         label: Optional[str] = None,
     ):
@@ -333,10 +333,10 @@ class IfContext:
     def __init__(
         self,
         circuit: QuantumCircuit,
-        condition: Tuple[Union[ClassicalRegister, Clbit], int],
+        condition: tuple[ClassicalRegister, int] | tuple[Clbit, int] | expr.Expr,
         *,
         in_loop: bool,
-        label: Optional[str] = None,
+        label: str | None = None,
     ):
         self._circuit = circuit
         self._condition = validate_condition(condition)
@@ -354,7 +354,7 @@ class IfContext:
         return self._circuit
 
     @property
-    def condition(self) -> Tuple[Union[ClassicalRegister, Clbit], int]:
+    def condition(self) -> tuple[ClassicalRegister, int] | tuple[Clbit, int] | expr.Expr:
         """Get the expression that this statement is conditioned on."""
         return self._condition
 

--- a/qiskit/circuit/controlflow/switch_case.py
+++ b/qiskit/circuit/controlflow/switch_case.py
@@ -25,7 +25,7 @@ from qiskit.circuit.exceptions import CircuitError
 
 from .builder import InstructionPlaceholder, InstructionResources, ControlFlowBuilderBlock
 from .control_flow import ControlFlowOp
-from ._builder_utils import unify_circuit_resources, partition_registers
+from ._builder_utils import unify_circuit_resources, partition_registers, node_resources
 
 
 class _DefaultCaseType:
@@ -207,7 +207,7 @@ class SwitchCasePlaceholder(InstructionPlaceholder):
 
     def __init__(
         self,
-        target: Union[Clbit, ClassicalRegister],
+        target: Clbit | ClassicalRegister | expr.Expr,
         cases: List[Tuple[Any, ControlFlowBuilderBlock]],
         *,
         label: Optional[str] = None,
@@ -230,9 +230,13 @@ class SwitchCasePlaceholder(InstructionPlaceholder):
         cregs = set()
         if isinstance(self.__target, Clbit):
             clbits.add(self.__target)
-        else:
+        elif isinstance(self.__target, ClassicalRegister):
             clbits.update(self.__target)
             cregs.add(self.__target)
+        else:
+            resources = node_resources(self.__target)
+            clbits.update(resources.clbits)
+            cregs.update(resources.cregs)
         for _, body in self.__cases:
             qubits |= body.qubits
             clbits |= body.clbits
@@ -294,13 +298,23 @@ class SwitchContext:
     def __init__(
         self,
         circuit: QuantumCircuit,
-        target: Union[Clbit, ClassicalRegister],
+        target: Clbit | ClassicalRegister | expr.Expr,
         *,
         in_loop: bool,
         label: Optional[str] = None,
     ):
         self.circuit = circuit
-        self.target = target
+        self._target = target
+        if isinstance(target, Clbit):
+            self.target_clbits: tuple[Clbit, ...] = (target,)
+            self.target_cregs: tuple[ClassicalRegister, ...] = ()
+        elif isinstance(target, ClassicalRegister):
+            self.target_clbits = tuple(target)
+            self.target_cregs = (target,)
+        else:
+            resources = node_resources(target)
+            self.target_clbits = resources.clbits
+            self.target_cregs = resources.cregs
         self.in_loop = in_loop
         self.complete = False
         self._op_label = label
@@ -335,7 +349,7 @@ class SwitchContext:
         # If we're in a loop-builder context, we need to emit a placeholder so that any `break` or
         # `continue`s in any of our cases can be expanded when the loop-builder.  If we're not, we
         # need to emit a concrete instruction immediately.
-        placeholder = SwitchCasePlaceholder(self.target, self._cases, label=self._op_label)
+        placeholder = SwitchCasePlaceholder(self._target, self._cases, label=self._op_label)
         initial_resources = placeholder.placeholder_resources()
         if self.in_loop:
             self.circuit.append(placeholder, initial_resources.qubits, initial_resources.clbits)
@@ -386,14 +400,10 @@ class CaseBuilder:
             if self.switch.label_in_use(value) or value in seen:
                 raise CircuitError(f"duplicate case label: '{value}'")
             seen.add(value)
-        if isinstance(self.switch.target, Clbit):
-            target_clbits = [self.switch.target]
-            target_registers = []
-        else:
-            target_clbits = list(self.switch.target)
-            target_registers = [self.switch.target]
         self.switch.circuit._push_scope(
-            clbits=target_clbits, registers=target_registers, allow_jumps=self.switch.in_loop
+            clbits=self.switch.target_clbits,
+            registers=self.switch.target_cregs,
+            allow_jumps=self.switch.in_loop,
         )
 
         try:

--- a/qiskit/circuit/controlflow/while_loop.py
+++ b/qiskit/circuit/controlflow/while_loop.py
@@ -14,8 +14,6 @@
 
 from __future__ import annotations
 
-from typing import Union, Tuple, Optional
-
 from qiskit.circuit import Clbit, ClassicalRegister, QuantumCircuit
 from qiskit.circuit.classical import expr
 from qiskit.circuit.exceptions import CircuitError
@@ -140,13 +138,9 @@ class WhileLoopContext:
     def __init__(
         self,
         circuit: QuantumCircuit,
-        condition: Union[
-            Tuple[ClassicalRegister, int],
-            Tuple[Clbit, int],
-            Tuple[Clbit, bool],
-        ],
+        condition: tuple[ClassicalRegister, int] | tuple[Clbit, int] | expr.Expr,
         *,
-        label: Optional[str] = None,
+        label: str | None = None,
     ):
 
         self._circuit = circuit

--- a/releasenotes/notes/fix-controlflow-builder-nested-switch-008b8c43b2153a1f.yaml
+++ b/releasenotes/notes/fix-controlflow-builder-nested-switch-008b8c43b2153a1f.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The control-flow builder interface will now correctly include :class:`.ClassicalRegister`
+    resources from nested switch statements in their containing circuit scopes.  See `#10398
+    <https://github.com/Qiskit/qiskit-terra/issues/10398>`__.

--- a/test/python/circuit/test_control_flow_builders.py
+++ b/test/python/circuit/test_control_flow_builders.py
@@ -26,6 +26,7 @@ from qiskit.circuit import (
     QuantumRegister,
     Qubit,
 )
+from qiskit.circuit.classical import expr, types
 from qiskit.circuit.controlflow import ForLoopOp, IfElseOp, WhileLoopOp, SwitchCaseOp, CASE_DEFAULT
 from qiskit.circuit.controlflow.builder import ControlFlowBuilderBlock
 from qiskit.circuit.controlflow.if_else import IfElsePlaceholder
@@ -92,6 +93,32 @@ class TestControlFlowBuilders(QiskitTestCase):
         expected = QuantumCircuit(qr, cr)
         expected.measure(qr, cr)
         expected.if_test((cr, 0), if_true0, [qr[0]], cr)
+
+        self.assertEqual(canonicalize_control_flow(test), canonicalize_control_flow(expected))
+
+    def test_if_expr(self):
+        """Test a simple if statement builds correctly, when using an expression as the condition.
+        This requires the builder to unpack all the bits from contained registers to use as
+        resources."""
+        qr = QuantumRegister(2)
+        cr1 = ClassicalRegister(2)
+        cr2 = ClassicalRegister(2)
+
+        test = QuantumCircuit(qr, cr1, cr2)
+        test.measure(qr, cr1)
+        test.measure(qr, cr2)
+        with test.if_test(expr.less(cr1, expr.bit_not(cr2))):
+            test.x(0)
+
+        if_true0 = QuantumCircuit([qr[0]], cr1, cr2)
+        if_true0.x(qr[0])
+
+        expected = QuantumCircuit(qr, cr1, cr2)
+        expected.measure(qr, cr1)
+        expected.measure(qr, cr2)
+        expected.if_test(
+            expr.less(cr1, expr.bit_not(cr2)), if_true0, [qr[0]], list(cr1) + list(cr2)
+        )
 
         self.assertEqual(canonicalize_control_flow(test), canonicalize_control_flow(expected))
 
@@ -279,6 +306,116 @@ class TestControlFlowBuilders(QiskitTestCase):
                 clbits + list(cr1),
             )
 
+    def test_expr_condition_in_nested_block(self):
+        """Test that nested blocks can use expressions with registers of the outermost circuits as
+        conditions, and they get propagated through all the blocks."""
+
+        qr = QuantumRegister(2)
+        clbits = [Clbit(), Clbit(), Clbit()]
+        cr1 = ClassicalRegister(3)
+        # Try aliased classical registers as well, to catch potential overlap bugs.
+        cr2 = ClassicalRegister(bits=clbits[:2])
+        cr3 = ClassicalRegister(bits=clbits[1:])
+        cr4 = ClassicalRegister(bits=clbits)
+
+        with self.subTest("for/if"):
+            test = QuantumCircuit(qr, clbits, cr1, cr2, cr3, cr4)
+            with test.for_loop(range(3)):
+                with test.if_test(expr.equal(cr1, 0)):
+                    test.x(0)
+                with test.if_test(expr.less(expr.bit_or(cr2, 1), 2)):
+                    test.y(0)
+                with test.if_test(expr.cast(expr.bit_not(cr3), types.Bool())):
+                    test.z(0)
+
+            true_body1 = QuantumCircuit([qr[0]], cr1)
+            true_body1.x(0)
+            true_body2 = QuantumCircuit([qr[0]], cr2)
+            true_body2.y(0)
+            true_body3 = QuantumCircuit([qr[0]], cr3)
+            true_body3.z(0)
+
+            for_body = QuantumCircuit([qr[0]], clbits, cr1, cr2, cr3)  # but not cr4.
+            for_body.if_test(expr.equal(cr1, 0), true_body1, [qr[0]], cr1)
+            for_body.if_test(expr.less(expr.bit_or(cr2, 1), 2), true_body2, [qr[0]], cr2)
+            for_body.if_test(expr.cast(expr.bit_not(cr3), types.Bool()), true_body3, [qr[0]], cr3)
+
+            expected = QuantumCircuit(qr, clbits, cr1, cr2, cr3, cr4)
+            expected.for_loop(range(3), None, for_body, [qr[0]], clbits + list(cr1))
+
+            self.assertEqual(canonicalize_control_flow(test), canonicalize_control_flow(expected))
+
+        with self.subTest("for/while"):
+            test = QuantumCircuit(qr, clbits, cr1, cr2, cr3, cr4)
+            with test.for_loop(range(3)):
+                with test.while_loop(expr.equal(cr1, 0)):
+                    test.x(0)
+                with test.while_loop(expr.less(expr.bit_or(cr2, 1), 2)):
+                    test.y(0)
+                with test.while_loop(expr.cast(expr.bit_not(cr3), types.Bool())):
+                    test.z(0)
+
+            while_body1 = QuantumCircuit([qr[0]], cr1)
+            while_body1.x(0)
+            while_body2 = QuantumCircuit([qr[0]], cr2)
+            while_body2.y(0)
+            while_body3 = QuantumCircuit([qr[0]], cr3)
+            while_body3.z(0)
+
+            for_body = QuantumCircuit([qr[0]], clbits, cr1, cr2, cr3)
+            for_body.while_loop(expr.equal(cr1, 0), while_body1, [qr[0]], cr1)
+            for_body.while_loop(expr.less(expr.bit_or(cr2, 1), 2), while_body2, [qr[0]], cr2)
+            for_body.while_loop(
+                expr.cast(expr.bit_not(cr3), types.Bool()), while_body3, [qr[0]], cr3
+            )
+
+            expected = QuantumCircuit(qr, clbits, cr1, cr2, cr3, cr4)
+            expected.for_loop(range(3), None, for_body, [qr[0]], clbits + list(cr1))
+
+            self.assertEqual(canonicalize_control_flow(test), canonicalize_control_flow(expected))
+
+        with self.subTest("switch/if"):
+            test = QuantumCircuit(qr, clbits, cr1, cr2, cr3, cr4)
+            with test.switch(expr.lift(cr1)) as case_:
+                with case_(0):
+                    with test.if_test(expr.less(expr.bit_or(cr2, 1), 2)):
+                        test.x(0)
+                with case_(1, 2):
+                    with test.if_test(expr.cast(expr.bit_not(cr3), types.Bool())):
+                        test.y(0)
+                with case_(case_.DEFAULT):
+                    with test.if_test(expr.not_equal(cr4, 0)):
+                        test.z(0)
+
+            true_body1 = QuantumCircuit([qr[0]], cr2)
+            true_body1.x(0)
+            case_body1 = QuantumCircuit([qr[0]], clbits, cr1, cr2, cr3, cr4)
+            case_body1.if_test(expr.less(expr.bit_or(cr2, 1), 2), true_body1, [qr[0]], cr2)
+
+            true_body2 = QuantumCircuit([qr[0]], cr3)
+            true_body2.y(0)
+            case_body2 = QuantumCircuit([qr[0]], clbits, cr1, cr2, cr3, cr4)
+            case_body2.if_test(expr.cast(expr.bit_not(cr3), types.Bool()), true_body2, [qr[0]], cr3)
+
+            true_body3 = QuantumCircuit([qr[0]], cr4)
+            true_body3.z(0)
+            case_body3 = QuantumCircuit([qr[0]], clbits, cr1, cr2, cr3, cr4)
+            case_body3.if_test(expr.not_equal(cr4, 0), true_body3, [qr[0]], cr4)
+
+            expected = QuantumCircuit(qr, clbits, cr1, cr2, cr3, cr4)
+            expected.switch(
+                expr.lift(cr1),
+                [
+                    (0, case_body1),
+                    ((1, 2), case_body2),
+                    (CASE_DEFAULT, case_body3),
+                ],
+                [qr[0]],
+                clbits + list(cr1),
+            )
+
+            self.assertEqual(canonicalize_control_flow(test), canonicalize_control_flow(expected))
+
     def test_if_else_simple(self):
         """Test a simple if/else statement builds correctly, in the midst of other instructions.
         This test has paired if and else blocks the same natural width."""
@@ -321,6 +458,53 @@ class TestControlFlowBuilders(QiskitTestCase):
         expected.h(qubits[0])
         expected.measure(qubits[0], clbits[1])
         expected.if_else((clbits[1], 0), if_true1, if_false1, [qubits[0], qubits[1]], [clbits[1]])
+
+        self.assertEqual(canonicalize_control_flow(test), canonicalize_control_flow(expected))
+
+    def test_if_else_expr_simple(self):
+        """Test a simple if/else statement builds correctly, in the midst of other instructions.
+        This test has paired if and else blocks the same natural width."""
+        qubits = [Qubit(), Qubit()]
+        clbits = [Clbit(), Clbit()]
+
+        test = QuantumCircuit(qubits, clbits)
+        test.h(0)
+        test.measure(0, 0)
+        with test.if_test(expr.lift(clbits[0])) as else_:
+            test.x(0)
+        with else_:
+            test.z(0)
+        test.h(0)
+        test.measure(0, 1)
+        with test.if_test(expr.logic_not(clbits[1])) as else_:
+            test.h(1)
+            test.cx(1, 0)
+        with else_:
+            test.h(0)
+            test.h(1)
+
+        # Both the if and else blocks in this circuit are the same natural width to begin with.
+        if_true0 = QuantumCircuit([qubits[0], clbits[0]])
+        if_true0.x(qubits[0])
+        if_false0 = QuantumCircuit([qubits[0], clbits[0]])
+        if_false0.z(qubits[0])
+
+        if_true1 = QuantumCircuit([qubits[0], qubits[1], clbits[1]])
+        if_true1.h(qubits[1])
+        if_true1.cx(qubits[1], qubits[0])
+        if_false1 = QuantumCircuit([qubits[0], qubits[1], clbits[1]])
+        if_false1.h(qubits[0])
+        if_false1.h(qubits[1])
+
+        expected = QuantumCircuit(qubits, clbits)
+        expected.h(qubits[0])
+        expected.measure(qubits[0], clbits[0])
+        expected.if_else(expr.lift(clbits[0]), if_true0, if_false0, [qubits[0]], [clbits[0]])
+        expected.h(qubits[0])
+        expected.measure(qubits[0], clbits[1])
+        expected.if_else(
+            expr.logic_not(clbits[1]), if_true1, if_false1, [qubits[0], qubits[1]], [clbits[1]]
+        )
 
         self.assertEqual(canonicalize_control_flow(test), canonicalize_control_flow(expected))
 
@@ -537,6 +721,70 @@ class TestControlFlowBuilders(QiskitTestCase):
             expected.if_else(outer_cond, outer_true, outer_false, qubits, [clbits[0], clbits[2]])
             self.assertEqual(canonicalize_control_flow(test), canonicalize_control_flow(expected))
 
+    def test_if_else_expr_nested(self):
+        """Test that the if and else context managers can be nested, and don't interfere with each
+        other."""
+        qubits = [Qubit(), Qubit(), Qubit()]
+        clbits = [Clbit(), Clbit(), Clbit()]
+        cr = ClassicalRegister(2, "c")
+
+        outer_cond = expr.logic_not(clbits[0])
+        inner_cond = expr.logic_and(clbits[2], expr.greater(cr, 1))
+
+        with self.subTest("if (if) else"):
+            test = QuantumCircuit(qubits, clbits, cr)
+            with test.if_test(outer_cond) as else_:
+                with test.if_test(inner_cond):
+                    test.h(0)
+            with else_:
+                test.h(1)
+
+            inner_true = QuantumCircuit([qubits[0], clbits[2]], cr)
+            inner_true.h(qubits[0])
+
+            outer_true = QuantumCircuit([qubits[0], qubits[1], clbits[0], clbits[2]], cr)
+            outer_true.if_test(inner_cond, inner_true, [qubits[0]], [clbits[2]] + list(cr))
+            outer_false = QuantumCircuit([qubits[0], qubits[1], clbits[0], clbits[2]], cr)
+            outer_false.h(qubits[1])
+
+            expected = QuantumCircuit(qubits, clbits, cr)
+            expected.if_else(
+                outer_cond,
+                outer_true,
+                outer_false,
+                [qubits[0], qubits[1]],
+                [clbits[0], clbits[2]] + list(cr),
+            )
+            self.assertEqual(canonicalize_control_flow(test), canonicalize_control_flow(expected))
+
+        with self.subTest("if (if else) else"):
+            test = QuantumCircuit(qubits, clbits, cr)
+            with test.if_test(outer_cond) as outer_else:
+                with test.if_test(inner_cond) as inner_else:
+                    test.h(0)
+                with inner_else:
+                    test.h(2)
+            with outer_else:
+                test.h(1)
+
+            inner_true = QuantumCircuit([qubits[0], qubits[2], clbits[2]], cr)
+            inner_true.h(qubits[0])
+            inner_false = QuantumCircuit([qubits[0], qubits[2], clbits[2]], cr)
+            inner_false.h(qubits[2])
+
+            outer_true = QuantumCircuit(qubits, [clbits[0], clbits[2]], cr)
+            outer_true.if_else(
+                inner_cond, inner_true, inner_false, [qubits[0], qubits[2]], [clbits[2]] + list(cr)
+            )
+            outer_false = QuantumCircuit(qubits, [clbits[0], clbits[2]], cr)
+            outer_false.h(qubits[1])
+
+            expected = QuantumCircuit(qubits, clbits, cr)
+            expected.if_else(
+                outer_cond, outer_true, outer_false, qubits, [clbits[0], clbits[2]] + list(cr)
+            )
+            self.assertEqual(canonicalize_control_flow(test), canonicalize_control_flow(expected))
+
     def test_switch_simple(self):
         """Individual labels switch test."""
         qubits = [Qubit(), Qubit(), Qubit()]
@@ -566,6 +814,127 @@ class TestControlFlowBuilders(QiskitTestCase):
             [(0, body0), (1, body1), (2, body2), (3, body3)],
             [qubits[0], qubits[2]],
             list(creg),
+        )
+
+        self.assertEqual(canonicalize_control_flow(test), canonicalize_control_flow(expected))
+
+    def test_switch_expr_simple(self):
+        """Individual labels switch test."""
+        qubits = [Qubit(), Qubit(), Qubit()]
+        creg = ClassicalRegister(2)
+        test = QuantumCircuit(qubits, creg)
+        with test.switch(expr.bit_and(creg, 2)) as case:
+            with case(0):
+                test.x(0)
+            with case(1):
+                test.x(2)
+            with case(2):
+                test.h(0)
+            with case(3):
+                test.h(2)
+
+        body0 = QuantumCircuit([qubits[0], qubits[2]], creg)
+        body0.x(qubits[0])
+        body1 = QuantumCircuit([qubits[0], qubits[2]], creg)
+        body1.x(qubits[2])
+        body2 = QuantumCircuit([qubits[0], qubits[2]], creg)
+        body2.h(qubits[0])
+        body3 = QuantumCircuit([qubits[0], qubits[2]], creg)
+        body3.h(qubits[2])
+        expected = QuantumCircuit(qubits, creg)
+        expected.switch(
+            expr.bit_and(creg, 2),
+            [(0, body0), (1, body1), (2, body2), (3, body3)],
+            [qubits[0], qubits[2]],
+            list(creg),
+        )
+
+        self.assertEqual(canonicalize_control_flow(test), canonicalize_control_flow(expected))
+
+    def test_switch_nested(self):
+        """Individual labels switch test."""
+        qubits = [Qubit(), Qubit(), Qubit()]
+        cr1 = ClassicalRegister(2, "c1")
+        cr2 = ClassicalRegister(2, "c2")
+        cr3 = ClassicalRegister(3, "c3")
+        loose = Clbit()
+        test = QuantumCircuit(qubits, cr1, cr2, cr3, [loose])
+        with test.switch(cr1) as case_outer:
+            with case_outer(0), test.switch(loose) as case_inner, case_inner(False):
+                test.x(0)
+            with case_outer(1), test.switch(cr2) as case_inner, case_inner(0):
+                test.x(1)
+
+        body0_0 = QuantumCircuit([qubits[0]], [loose])
+        body0_0.x(qubits[0])
+        body0 = QuantumCircuit([qubits[0], qubits[1]], cr1, cr2, [loose])
+        body0.switch(
+            loose,
+            [(False, body0_0)],
+            [qubits[0]],
+            [loose],
+        )
+
+        body1_0 = QuantumCircuit([qubits[1]], cr2)
+        body1_0.x(qubits[1])
+        body1 = QuantumCircuit([qubits[0], qubits[1]], cr1, cr2, [loose])
+        body1.switch(
+            cr2,
+            [(0, body1_0)],
+            [qubits[1]],
+            list(cr2),
+        )
+
+        expected = QuantumCircuit(qubits, cr1, cr2, cr3, [loose])
+        expected.switch(
+            cr1,
+            [(0, body0), (1, body1)],
+            [qubits[0], qubits[1]],
+            list(cr1) + list(cr2) + [loose],
+        )
+
+        self.assertEqual(canonicalize_control_flow(test), canonicalize_control_flow(expected))
+
+    def test_switch_expr_nested(self):
+        """Individual labels switch test."""
+        qubits = [Qubit(), Qubit(), Qubit()]
+        cr1 = ClassicalRegister(2, "c1")
+        cr2 = ClassicalRegister(2, "c2")
+        cr3 = ClassicalRegister(3, "c3")
+        loose = Clbit()
+        test = QuantumCircuit(qubits, cr1, cr2, cr3, [loose])
+        with test.switch(expr.bit_and(cr1, 2)) as case_outer:
+            with case_outer(0), test.switch(expr.lift(loose)) as case_inner, case_inner(False):
+                test.x(0)
+            with case_outer(1), test.switch(expr.bit_and(cr2, 2)) as case_inner, case_inner(0):
+                test.x(1)
+
+        body0_0 = QuantumCircuit([qubits[0]], [loose])
+        body0_0.x(qubits[0])
+        body0 = QuantumCircuit([qubits[0], qubits[1]], cr1, cr2, [loose])
+        body0.switch(
+            expr.lift(loose),
+            [(False, body0_0)],
+            [qubits[0]],
+            [loose],
+        )
+
+        body1_0 = QuantumCircuit([qubits[1]], cr2)
+        body1_0.x(qubits[1])
+        body1 = QuantumCircuit([qubits[0], qubits[1]], cr1, cr2, [loose])
+        body1.switch(
+            expr.bit_and(cr2, 2),
+            [(0, body1_0)],
+            [qubits[1]],
+            list(cr2),
+        )
+
+        expected = QuantumCircuit(qubits, cr1, cr2, cr3, [loose])
+        expected.switch(
+            expr.bit_and(cr1, 2),
+            [(0, body0), (1, body1)],
+            [qubits[0], qubits[1]],
+            list(cr1) + list(cr2) + [loose],
         )
 
         self.assertEqual(canonicalize_control_flow(test), canonicalize_control_flow(expected))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This is generally relatively straightforwards; anywhere where we examine the resources used by an operation, we need to update to account for classical resources potentially being tied up in `ControlFlowOp` fields in `Expr` nodes as well.

This also has the side effect of fixing a bug where a nested `SwitchCaseOp.target` wasn't considered in the scope building for _all_ control-flow operations, which could incorrectly cause some registers to be missed in outer scopes.


### Details and comments

Fix #10398.
Close #10228.
Depends on #10367.

Additional feature changelog in #10331.

