### PR TITLE
Slightly optimize ParameterVector construction

### DIFF
--- a/qiskit/circuit/parameter.py
+++ b/qiskit/circuit/parameter.py
@@ -50,6 +50,8 @@ class Parameter(ParameterExpression):
            bc.draw('mpl')
     """
 
+    __slots__ = ("_name", "_uuid", "_hash")
+
     def __new__(cls, name, uuid=None):  # pylint: disable=unused-argument
         # Parameter relies on self._uuid being set prior to other attributes
         # (e.g. symbol_map) which may depend on self._uuid for Parameter's hash


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit optimizes the construction code for the ParameterVector and ParameterVectorElement classes. The construction of these objects was primarily dominated by the UUID construction time. This is because each element in the vector was calling uuid4() to generate a random unique identifier for each Parameter element. However, we don't need a truly random identifier as we just need to avoid collisions with identically named elements. So instead of calling uuid4() n times this commit opts to call uuid4() once and then just use an index offset of that value. This is slightly faster because we don't need to need run the full uuid4 algorithm each time and instead just wrap an integer in uuid object. While this does slightly increase the change of a collision between identically named ParameterVectors, in practice it should still be sufficiently rare. At the same time the classes are slotted to speed up attribute access and shrink the memory footprint of using these objects.

The geometric mean of the wall time of creating 10x 2424000 element ParameterVector objects goes from 15.702722168587812 sec. on main to 13.738723886030732 sec. with this commit. While not a huge improvement it is a consistent incremental gain that doesn't require any data model changes. To make the classes significantly faster we'll likely need to change the data model for Parameter, ParameterVector, etc to facilitate faster creation.

### Details and comments