### PR TITLE
Fix `deepcopy` for new-style `Bit`

### DIFF
--- a/qiskit/circuit/bit.py
+++ b/qiskit/circuit/bit.py
@@ -13,6 +13,7 @@
 """
 Quantum bit and Classical bit objects.
 """
+import copy
 
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.utils.deprecation import deprecate_func
@@ -125,5 +126,15 @@ class Bit:
         # Bits are immutable.
         return self
 
-    def __deepcopy__(self, _memo):
-        return self
+    def __deepcopy__(self, memo=None):
+        if (self._register, self._index) == (None, None):
+            return self
+
+        # Old-style bits need special handling for now, since some code seems
+        # to rely on their registers getting deep-copied.
+        bit = type(self).__new__(type(self))
+        bit._register = copy.deepcopy(self._register, memo)
+        bit._index = self._index
+        bit._hash = self._hash
+        bit._repr = self._repr
+        return bit

--- a/qiskit/circuit/bit.py
+++ b/qiskit/circuit/bit.py
@@ -120,3 +120,10 @@ class Bit:
             return self._repr == other._repr
         except AttributeError:
             return False
+
+    def __copy__(self):
+        # Bits are immutable.
+        return self
+
+    def __deepcopy__(self, _memo):
+        return self

--- a/releasenotes/notes/fix-bit-copy-4b2f7349683f616a.yaml
+++ b/releasenotes/notes/fix-bit-copy-4b2f7349683f616a.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed an issue with copying circuits with new-style :class:`.Clbit`\ s and
+    :class:`.Qubit`\ s (bits without registers) where references to these bits
+    from the containing circuit could be broken, causing issues with
+    serialization and circuit visualization.

--- a/test/python/circuit/test_bit.py
+++ b/test/python/circuit/test_bit.py
@@ -13,7 +13,7 @@
 # pylint: disable=missing-function-docstring
 
 """Test library of quantum circuits."""
-
+import copy
 from unittest import mock
 
 from qiskit.test import QiskitTestCase
@@ -57,6 +57,25 @@ class TestBitClass(QiskitTestCase):
 
         self.assertNotEqual(bit.Bit(test_reg, 0), bit.Bit(reg_difftype, 0))
 
+    def test_old_style_bit_deepcopy(self):
+        """Verify deep-copies of bits are equal but not the same instance."""
+        test_reg = mock.MagicMock(size=3, name="foo")
+        test_reg.__str__.return_value = "Register(3, 'foo')"
+
+        bit1 = bit.Bit(test_reg, 0)
+        bit2 = copy.deepcopy(bit1)
+
+        self.assertIsNot(bit1, bit2)
+        self.assertIsNot(bit1._register, bit2._register)
+        self.assertEqual(bit1, bit2)
+
+    def test_old_style_bit_copy(self):
+        """Verify copies of bits are the same instance."""
+        bit1 = bit.Bit()
+        bit2 = copy.copy(bit1)
+
+        self.assertIs(bit1, bit2)
+
 
 class TestNewStyleBit(QiskitTestCase):
     """Test behavior of new-style bits."""
@@ -65,7 +84,21 @@ class TestNewStyleBit(QiskitTestCase):
         """Verify we can create a bit outside the context of a register."""
         self.assertIsInstance(bit.Bit(), bit.Bit)
 
-    def test_newstyle_bit_equality(self):
+    def test_new_style_bit_deepcopy(self):
+        """Verify deep-copies of bits are the same instance."""
+        bit1 = bit.Bit()
+        bit2 = copy.deepcopy(bit1)
+
+        self.assertIs(bit1, bit2)
+
+    def test_new_style_bit_copy(self):
+        """Verify copies of bits are the same instance."""
+        bit1 = bit.Bit()
+        bit2 = copy.copy(bit1)
+
+        self.assertIs(bit1, bit2)
+
+    def test_new_style_bit_equality(self):
         """Verify bits instances are equal only to themselves."""
         bit1 = bit.Bit()
         bit2 = bit.Bit()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Overrides the default behavior of `copy` and `deepcopy` for `Bit` to return `self` for new-style bits.


### Details and comments
We choose this behavior because `Bit`s are immutable, and it allows us to deep-copy new-style bits while maintaining equality between the original and the copy. For old-style bits, we leave the behavior unchanged, since some existing code appears to depend on `_register` getting deep-copied.

Note that we now return `self` when shallow-copying old-style bits, which we can do safely since `Bit`s themselves are immutable.

Resolves #10409.
