### PR TITLE
Reduce use of legacy `CircuitInstruction` formats

### DIFF
--- a/qiskit/algorithms/gradients/reverse/derive_circuit.py
+++ b/qiskit/algorithms/gradients/reverse/derive_circuit.py
@@ -137,8 +137,8 @@ def derive_circuit(
 
     summands, op_context = [], []
     for i, op in enumerate(circuit.data):
-        gate = op[0]
-        op_context += [op[1:]]
+        gate = op.operation
+        op_context.append((op.qubits, op.clbits))
         if parameter in gate.params:
             coeffs_and_grads = gradient_lookup(gate)
             summands += [coeffs_and_grads]

--- a/qiskit/algorithms/gradients/reverse/split_circuits.py
+++ b/qiskit/algorithms/gradients/reverse/split_circuits.py
@@ -44,7 +44,7 @@ def split(
                 if isinstance(param, ParameterExpression) and len(param.parameters) > 0
             ]
         else:
-            if inst[0].definition is not None:
+            if inst.operation.definition is not None:
                 free_inst_params = inst.operation.definition.parameters
             else:
                 free_inst_params = {}

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -441,22 +441,21 @@ class QuantumCircuit:
         """
         self._calibrations = defaultdict(dict, calibrations)
 
-    def has_calibration_for(self, instr_context: tuple):
+    def has_calibration_for(self, instruction: CircuitInstruction):
         """Return True if the circuit has a calibration defined for the instruction context. In this
         case, the operation does not need to be translated to the device basis.
         """
-        instr, qargs, _ = instr_context
-        if not self.calibrations or instr.name not in self.calibrations:
+        if not self.calibrations or instruction.operation.name not in self.calibrations:
             return False
-        qubits = tuple(self.qubits.index(qubit) for qubit in qargs)
+        qubits = tuple(self.qubits.index(qubit) for qubit in instruction.qubits)
         params = []
-        for p in instr.params:
+        for p in instruction.operation.params:
             if isinstance(p, ParameterExpression) and not p.parameters:
                 params.append(float(p))
             else:
                 params.append(p)
         params = tuple(params)
-        return (qubits, params) in self.calibrations[instr.name]
+        return (qubits, params) in self.calibrations[instruction.operation.name]
 
     @property
     def metadata(self) -> dict:

--- a/qiskit/quantum_info/synthesis/qsd.py
+++ b/qiskit/quantum_info/synthesis/qsd.py
@@ -233,23 +233,22 @@ def _apply_a2(circ):
     ccirc = transpile(circ, basis_gates=["u", "cx", "qsd2q"], optimization_level=0)
     ind2q = []
     # collect 2q instrs
-    for i, instr_context in enumerate(ccirc.data):
-        instr, _, _ = instr_context
-        if instr.name == "qsd2q":
+    for i, instruction in enumerate(ccirc.data):
+        if instruction.operation.name == "qsd2q":
             ind2q.append(i)
     # rolling over diagonals
     ind2 = None  # lint
     for ind1, ind2 in zip(ind2q[0:-1:], ind2q[1::]):
         # get neigboring 2q gates separated by controls
-        instr1, qargs, cargs = ccirc.data[ind1]
-        mat1 = Operator(instr1).data
-        instr2, _, _ = ccirc.data[ind2]
-        mat2 = Operator(instr2).data
+        instr1 = ccirc.data[ind1]
+        mat1 = Operator(instr1.operation).data
+        instr2 = ccirc.data[ind2]
+        mat2 = Operator(instr2.operation).data
         # rollover
         dmat, qc2cx = decomposer(mat1)
-        ccirc.data[ind1] = (qc2cx.to_gate(), qargs, cargs)
+        ccirc.data[ind1] = instr1.replace(operation=qc2cx.to_gate())
         mat2 = mat2 @ dmat
-        ccirc.data[ind2] = (qiskit.extensions.unitary.UnitaryGate(mat2), qargs, cargs)
+        ccirc.data[ind2] = instr2.replace(qiskit.extensions.unitary.UnitaryGate(mat2))
     qc3 = two_qubit_decompose.two_qubit_cnot_decompose(mat2)
-    ccirc.data[ind2] = (qc3.to_gate(), qargs, cargs)
+    ccirc.data[ind2] = ccirc.data[ind2].replace(operation=qc3.to_gate())
     return ccirc

--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -334,12 +334,12 @@ class BasisTranslator(TransformationPass):
 
     @_extract_basis.register
     def _(self, circ: QuantumCircuit):
-        for instr_context in circ.data:
-            instr, _, _ = instr_context
-            if not circ.has_calibration_for(instr_context):
-                yield (instr.name, instr.num_qubits)
-            if isinstance(instr, ControlFlowOp):
-                for block in instr.blocks:
+        for instruction in circ.data:
+            operation = instruction.operation
+            if not circ.has_calibration_for(instruction):
+                yield (operation.name, operation.num_qubits)
+            if isinstance(operation, ControlFlowOp):
+                for block in operation.blocks:
                     yield from self._extract_basis(block)
 
     def _extract_basis_target(

--- a/test/python/circuit/test_circuit_load_from_qpy.py
+++ b/test/python/circuit/test_circuit_load_from_qpy.py
@@ -1251,7 +1251,7 @@ class TestLoadFromQPY(QiskitTestCase):
             fd.seek(0)
             new_circ = load(fd)[0]
         self.assertEqual(qc, new_circ)
-        self.assertEqual(qc.data[0][0].ctrl_state, new_circ.data[0][0].ctrl_state)
+        self.assertEqual(qc.data[0].operation.ctrl_state, new_circ.data[0].operation.ctrl_state)
         self.assertDeprecatedBitProperties(qc, new_circ)
 
     def test_standard_control_gates(self):

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -1165,7 +1165,7 @@ class TestCircuitOperations(QiskitTestCase):
 
         expected = QuantumCircuit([a, b, c, d], [x, y, z])
         for instruction in instructions():
-            expected.append(*instruction)
+            expected.append(instruction.operation, instruction.qubits, instruction.clbits)
 
         self.assertEqual(circuit, expected)
         self.assertEqual(circuit_tuples, expected)
@@ -1215,7 +1215,7 @@ class TestCircuitOperations(QiskitTestCase):
 
         expected = QuantumCircuit([a, b], global_phase=0.1)
         for instruction in instructions():
-            expected.append(*instruction)
+            expected.append(instruction.operation, instruction.qubits, instruction.clbits)
 
         self.assertEqual(circuit, expected)
         self.assertEqual(circuit.name, "test")

--- a/test/python/transpiler/test_clifford_passes.py
+++ b/test/python/transpiler/test_clifford_passes.py
@@ -84,14 +84,14 @@ class TestCliffordPasses(QiskitTestCase):
 
         # Check that there are indeed two Clifford objects in the circuit,
         # and that these are not gates.
-        cliffords = [inst for inst, _, _ in qc.data if isinstance(inst, Clifford)]
-        gates = [inst for inst, _, _ in qc.data if isinstance(inst, Gate)]
+        cliffords = [inst.operation for inst in qc.data if isinstance(inst.operation, Clifford)]
+        gates = [inst.operation for inst in qc.data if isinstance(inst.operation, Gate)]
         self.assertEqual(len(cliffords), 2)
         self.assertEqual(len(gates), 4)
 
         # Check that calling QuantumCircuit's decompose(), no Clifford objects remain
         qc2 = qc.decompose()
-        cliffords2 = [inst for inst, _, _ in qc2.data if isinstance(inst, Clifford)]
+        cliffords2 = [inst.operation for inst in qc2.data if isinstance(inst.operation, Clifford)]
         self.assertEqual(len(cliffords2), 0)
 
     def test_can_construct_operator(self):
@@ -167,8 +167,10 @@ class TestCliffordPasses(QiskitTestCase):
         # Add this Clifford to a Quantum Circuit, and check that it remains a Clifford
         circ0 = QuantumCircuit(4)
         circ0.append(cliff, [0, 1, 2])
-        circ0_cliffords = [inst for inst, _, _ in circ0.data if isinstance(inst, Clifford)]
-        circ0_gates = [inst for inst, _, _ in circ0.data if isinstance(inst, Gate)]
+        circ0_cliffords = [
+            inst.operation for inst in circ0.data if isinstance(inst.operation, Clifford)
+        ]
+        circ0_gates = [inst.operation for inst in circ0.data if isinstance(inst.operation, Gate)]
         self.assertEqual(len(circ0_cliffords), 1)
         self.assertEqual(len(circ0_gates), 0)
 
@@ -183,8 +185,10 @@ class TestCliffordPasses(QiskitTestCase):
 
         # Check that converted DAG to a circuit also preserves Clifford.
         circ1 = dag_to_circuit(dag0)
-        circ1_cliffords = [inst for inst, _, _ in circ1.data if isinstance(inst, Clifford)]
-        circ1_gates = [inst for inst, _, _ in circ1.data if isinstance(inst, Gate)]
+        circ1_cliffords = [
+            inst.operation for inst in circ1.data if isinstance(inst.operation, Clifford)
+        ]
+        circ1_gates = [inst.operation for inst in circ1.data if isinstance(inst.operation, Gate)]
         self.assertEqual(len(circ1_cliffords), 1)
         self.assertEqual(len(circ1_gates), 0)
 


### PR DESCRIPTION
### Summary

This removes (as best as our test suite touches) all uses of the implicit legacy tuple form of `CircuitInstruction` that have crept in since ea02667 (gh-8093).  The changes are largely just mechanical over to the new form.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

This PR doesn't propose the deprecation of the legacy interface yet.  At the very least, that should come early in the cycle for a Terra version, and we know there to be uses in downstream Qiskit projects (Aer and Experiments each have a couple of fairly minor instances) that we can mitigate first.