### PR TITLE
Relax pin on `qiskit-aer==0.12.0` in CI

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -2,10 +2,6 @@
 # 4.0+. The pin can be removed after nbformat is updated.
 jsonschema==3.2.0
 
-# Aer 0.12.1 has a bad value in the results output that prevents pickling.
-# Remove pin once https://github.com/Qiskit/qiskit-aer/pull/1845 is released.
-qiskit-aer==0.12.0
-
 # Numpy 1.25 deprecated some behaviours that we used, and caused the isometry
 # tests to flake. See https://github.com/Qiskit/qiskit-terra/issues/10305,
 # remove pin when resolving that.


### PR DESCRIPTION
### Summary

With the release of Aer 0.12.2, the CI problems we were having caused by non-picklability of the Aer `Result` objects are now be resolved.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

See #10270 for the initial pin.
