### PR TITLE
Add 1% tolerance to visual tests

### DIFF
--- a/test/visual/mpl/circuit/test_circuit_matplotlib_drawer.py
+++ b/test/visual/mpl/circuit/test_circuit_matplotlib_drawer.py
@@ -97,7 +97,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_calibrations(self):
         """Test calibrations annotations
@@ -126,7 +126,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_calibrations_with_control_gates(self):
         """Test calibrations annotations
@@ -163,7 +163,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_calibrations_with_swap_and_reset(self):
         """Test calibrations annotations
@@ -200,7 +200,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_calibrations_with_rzz_and_rxx(self):
         """Test calibrations annotations
@@ -236,7 +236,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_no_ops(self):
         """Test circuit with no ops.
@@ -253,7 +253,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_long_name(self):
         """Test to see that long register names can be seen completely
@@ -281,7 +281,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_multi_underscore_reg_names(self):
         """Test that multi-underscores in register names display properly"""
@@ -312,8 +312,8 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_PREFIX,
         )
 
-        self.assertEqual(ratio, 1)
-        self.assertEqual(ratio2, 1)
+        self.assertGreaterEqual(ratio, 0.99)
+        self.assertGreaterEqual(ratio2, 0.99)
 
     def test_conditional(self):
         """Test that circuits with conditionals draw correctly"""
@@ -336,7 +336,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_bit_conditional_with_cregbundle(self):
         """Test that circuits with single bit conditionals draw correctly
@@ -360,7 +360,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_bit_conditional_no_cregbundle(self):
         """Test that circuits with single bit conditionals draw correctly
@@ -384,7 +384,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_partial_barrier(self):
         """Test plotting of partial barriers."""
@@ -409,7 +409,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_barriers(self):
         """Test to see that plotting barriers works.
@@ -454,8 +454,8 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_PREFIX,
         )
 
-        self.assertEqual(ratio, 1)
-        self.assertEqual(ratio2, 1)
+        self.assertGreaterEqual(ratio, 0.99)
+        self.assertGreaterEqual(ratio2, 0.99)
 
     def test_no_barriers_false(self):
         """Generate the same circuit as test_plot_barriers but without the barrier commands
@@ -476,7 +476,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_fold_minus1(self):
         """Test to see that fold=-1 is no folding"""
@@ -497,7 +497,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_fold_4(self):
         """Test to see that fold=4 is folding"""
@@ -518,7 +518,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_big_gates(self):
         """Test large gates with params"""
@@ -555,7 +555,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_cnot(self):
         """Test different cnot gates (ccnot, mcx, etc)"""
@@ -578,7 +578,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_cz(self):
         """Test Z and Controlled-Z Gates"""
@@ -600,7 +600,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_pauli_clifford(self):
         """Test Pauli(green) and Clifford(blue) gates"""
@@ -630,7 +630,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_creg_initial(self):
         """Test cregbundle and initial state options"""
@@ -662,8 +662,8 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_PREFIX,
         )
 
-        self.assertEqual(ratio, 1)
-        self.assertEqual(ratio2, 1)
+        self.assertGreaterEqual(ratio, 0.99)
+        self.assertGreaterEqual(ratio2, 0.99)
 
     def test_r_gates(self):
         """Test all R gates"""
@@ -688,7 +688,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_ctrl_labels(self):
         """Test control labels"""
@@ -712,7 +712,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_cswap_rzz(self):
         """Test controlled swap and rzz gates"""
@@ -731,7 +731,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_ghz_to_gate(self):
         """Test controlled GHZ to_gate circuit"""
@@ -755,7 +755,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_scale(self):
         """Tests scale
@@ -795,9 +795,9 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_PREFIX,
         )
 
-        self.assertEqual(ratio, 1)
-        self.assertEqual(ratio2, 1)
-        self.assertEqual(ratio3, 1)
+        self.assertGreaterEqual(ratio, 0.99)
+        self.assertGreaterEqual(ratio2, 0.99)
+        self.assertGreaterEqual(ratio3, 0.99)
 
     def test_pi_param_expr(self):
         """Test pi in circuit with parameter expression."""
@@ -815,7 +815,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_partial_layout(self):
         """Tests partial_layout
@@ -841,7 +841,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_init_reset(self):
         """Test reset and initialize with 1 and 2 qubits"""
@@ -860,7 +860,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_with_global_phase(self):
         """Tests with global phase"""
@@ -877,7 +877,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_alternative_colors(self):
         """Tests alternative color schemes"""
@@ -923,7 +923,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
                 ratios.append(ratio)
 
         for ratio in ratios:
-            self.assertEqual(ratio, 1)
+            self.assertGreaterEqual(ratio, 0.99)
 
     def test_reverse_bits(self):
         """Tests reverse_bits parameter"""
@@ -942,7 +942,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_bw(self):
         """Tests black and white style parameter"""
@@ -965,7 +965,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_user_style(self):
         """Tests loading a user style"""
@@ -1014,7 +1014,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_subfont_change(self):
         """Tests changing the subfont size"""
@@ -1036,7 +1036,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_meas_condition(self):
         """Tests measure with a condition"""
@@ -1057,7 +1057,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_reverse_bits_condition(self):
         """Tests reverse_bits with a condition and gate above"""
@@ -1094,8 +1094,8 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_PREFIX,
         )
 
-        self.assertEqual(ratio, 1)
-        self.assertEqual(ratio2, 1)
+        self.assertGreaterEqual(ratio, 0.99)
+        self.assertGreaterEqual(ratio2, 0.99)
 
     def test_style_custom_gates(self):
         """Tests style for custom gates"""
@@ -1132,7 +1132,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_6095(self):
         """Tests controlled-phase gate style
@@ -1155,7 +1155,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_instruction_1q_1c(self):
         """Tests q0-cr0 instruction on a circuit"""
@@ -1175,7 +1175,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_instruction_3q_3c_circ1(self):
         """Tests q0-q1-q2-cr_20-cr0-cr1 instruction on a circuit"""
@@ -1196,7 +1196,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_instruction_3q_3c_circ2(self):
         """Tests q3-q0-q2-cr0-cr1-cr_20 instruction on a circuit"""
@@ -1217,7 +1217,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_instruction_3q_3c_circ3(self):
         """Tests q3-q1-q2-cr_31-cr1-cr_30 instruction on a circuit"""
@@ -1239,7 +1239,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_overwide_gates(self):
         """Test gates don't exceed width of default fold"""
@@ -1258,7 +1258,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_one_bit_regs(self):
         """Test registers with only one bit display without number"""
@@ -1280,7 +1280,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_user_ax_subplot(self):
         """Test for when user supplies ax for a subplot"""
@@ -1309,7 +1309,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_figwidth(self):
         """Test style dict 'figwidth'"""
@@ -1330,7 +1330,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_registerless_one_bit(self):
         """Test circuit with one-bit registers and registerless bits."""
@@ -1349,7 +1349,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_measures_with_conditions(self):
         """Test that a measure containing a condition displays"""
@@ -1384,8 +1384,8 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_PREFIX,
         )
 
-        self.assertEqual(ratio, 1)
-        self.assertEqual(ratio2, 1)
+        self.assertGreaterEqual(ratio, 0.99)
+        self.assertGreaterEqual(ratio2, 0.99)
 
     def test_conditions_measures_with_bits(self):
         """Test that gates with conditions and measures work with bits"""
@@ -1417,8 +1417,8 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_PREFIX,
         )
 
-        self.assertEqual(ratio, 1)
-        self.assertEqual(ratio2, 1)
+        self.assertGreaterEqual(ratio, 0.99)
+        self.assertGreaterEqual(ratio2, 0.99)
 
     def test_conditional_gates_right_of_measures_with_bits(self):
         """Test that gates with conditions draw to right of measures when same bit"""
@@ -1440,7 +1440,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_conditions_with_bits_reverse(self):
         """Test that gates with conditions work with bits reversed"""
@@ -1460,7 +1460,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_sidetext_with_condition(self):
         """Test that sidetext gates align properly with conditions"""
@@ -1479,7 +1479,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_fold_with_conditions(self):
         """Test that gates with conditions draw correctly when folding"""
@@ -1514,7 +1514,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_idle_wires_barrier(self):
         """Test that idle_wires False works with barrier"""
@@ -1532,7 +1532,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_wire_order(self):
         """Test the wire_order option"""
@@ -1560,7 +1560,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_barrier_label(self):
         """Test the barrier label"""
@@ -1582,7 +1582,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
 
 if __name__ == "__main__":

--- a/test/visual/mpl/graph/test_graph_matplotlib_drawer.py
+++ b/test/visual/mpl/graph/test_graph_matplotlib_drawer.py
@@ -115,7 +115,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_state_hinton(self):
         """test plot_state_hinton"""
@@ -137,7 +137,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_state_qsphere(self):
         """test for plot_state_qsphere"""
@@ -159,7 +159,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_state_city(self):
         """test for plot_state_city"""
@@ -181,7 +181,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_state_paulivec(self):
         """test for plot_state_paulivec"""
@@ -203,7 +203,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_histogram(self):
         """for testing the plot_histogram"""
@@ -222,7 +222,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_histogram_with_rest(self):
         """test plot_histogram with 2 datasets and number_to_keep"""
@@ -238,7 +238,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_histogram_2_sets_with_rest(self):
         """test plot_histogram with 2 datasets and number_to_keep"""
@@ -257,7 +257,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_histogram_color(self):
         """Test histogram with single color"""
@@ -274,7 +274,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_histogram_multiple_colors(self):
         """Test histogram with multiple custom colors"""
@@ -298,7 +298,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_histogram_hamming(self):
         """Test histogram with hamming distance"""
@@ -315,7 +315,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_histogram_value_sort(self):
         """Test histogram with sorting by value"""
@@ -332,7 +332,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_histogram_desc_value_sort(self):
         """Test histogram with sorting by descending value"""
@@ -354,7 +354,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_histogram_legend(self):
         """Test histogram with legend"""
@@ -376,7 +376,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_histogram_title(self):
         """Test histogram with title"""
@@ -393,7 +393,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_1_qubit_gate_map(self):
         """Test plot_gate_map using 1 qubit backend"""
@@ -411,7 +411,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_5_qubit_gate_map(self):
         """Test plot_gate_map using 5 qubit backend"""
@@ -429,7 +429,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_7_qubit_gate_map(self):
         """Test plot_gate_map using 7 qubit backend"""
@@ -447,7 +447,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_16_qubit_gate_map(self):
         """Test plot_gate_map using 16 qubit backend"""
@@ -465,7 +465,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_27_qubit_gate_map(self):
         """Test plot_gate_map using 27 qubit backend"""
@@ -483,7 +483,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_65_qubit_gate_map(self):
         """test for plot_gate_map using 65 qubit backend"""
@@ -501,7 +501,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_figsize(self):
         """Test figsize parameter of plot_gate_map"""
@@ -519,7 +519,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_qubit_size(self):
         """Test qubit_size parameter of plot_gate_map"""
@@ -537,7 +537,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_qubit_color(self):
         """Test qubit_color parameter of plot_gate_map"""
@@ -555,7 +555,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_qubit_labels(self):
         """Test qubit_labels parameter of plot_gate_map"""
@@ -575,7 +575,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_line_color(self):
         """Test line_color parameter of plot_gate_map"""
@@ -593,7 +593,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_font_color(self):
         """Test font_color parameter of plot_gate_map"""
@@ -611,7 +611,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_coupling_map(self):
         """Test plot_coupling_map"""
@@ -635,7 +635,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
     def test_plot_bloch_multivector_figsize_improvements(self):
         """test bloch sphere figsize, font_size, title_font_size and title_pad
@@ -670,7 +670,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertEqual(ratio, 1)
+        self.assertGreaterEqual(ratio, 0.99)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the recently merged #9961 the visual comparison tests were re-added to run a visual diff on the visualization output against a known reference image. These improved tests provide us missing coverage and have already found potential bugs in proposed changes, see:

https://github.com/Qiskit/qiskit-terra/pull/10208#discussion_r1260234421

However, the comparison were looking for a 100% match between the reference image and the generated output. In an ideal world we'd be able to rely on this. But in practice an exact comparisons of the images are quite flaky. This is because the actual visualization output is a function of not only our python code in Qiskit, but also upstream python dependencies (such as matplotlib, seaborn, etc) and more importantly those libraries leverage many system libraries and packages. This includes the C libraries for image formats (e.g. libpng), but also things like fonts. A version bump in our CI image's package versions can cause subtle differences in the output of visualizations. The CI images are controlled by Microsoft/Github and isn't something we we can't really depend on being constant forever (even if we used docker for a base test image the upstream images we would build off of that aren't 100% fixed either and could cause similar issues). We've had numerous issues with this in the past with image comparison tests (especially when you start running them cross-platform which isn't the case here) and is why we've oscillated between having them in the test suite and not throughout the development history of Qiskit.

This commit adds a 1% tolerance to the comparison ratio so instead of needing  a 100% match a 99% match is good enough. While this does technically reduce the coverage and a potentially invalid image could slip in that 1% difference, the chance of that happening are fairly unlikely especially weighed against the likelihood of a system change causing a CI blockage (which happened within one day of merging #9961). The only other option is to disable these tests as voting in the CI job, which would all but remove their utility because they will likely go stale (as the testing harness before this did). We may still end up making them non-voting anyway despite the coverage gains if we can't reliably run the tests in CI.

### Details and comments


