### PR TITLE
Add missing `atol` argument to floating-point test

### DIFF
--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -615,7 +615,7 @@ class TestSparsePauliOpMethods(QiskitTestCase):
         if value == 0:
             np.testing.assert_array_equal(value_mat, target.astype(complex))
         else:
-            np.testing.assert_allclose(value_mat, target)
+            np.testing.assert_allclose(value_mat, target, atol=1e-8)
         np.testing.assert_array_equal(op.paulis.phase, np.zeros(op.size))
         target = spp_op.to_matrix() * value
         op = spp_op * value


### PR DESCRIPTION
### Summary

The other assertion in this test has the `atol` parameter, but this one is missing it, which can occasionally lead to off-by-one-bit differences in the complex multiplication outputs.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->



### Details and comments

The test `test.python.quantum_info.operators.symplectic.test_sparse_pauli_op.TestSparsePauliOpMethods.test_mul` has been flaky in CI since #10264, due to a pre-existing missing `atol` parameter.