### PR TITLE
Remove cyclic-definition handling from `Clifford.from_circuit`

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -12,7 +12,6 @@
 """
 Circuit simulation for the Clifford class.
 """
-import copy
 import numpy as np
 
 from qiskit.circuit import Barrier, Delay, Gate

--- a/releasenotes/notes/clifford-no-circuly-c7c4a1c9c5472af7.yaml
+++ b/releasenotes/notes/clifford-no-circuly-c7c4a1c9c5472af7.yaml
@@ -1,0 +1,9 @@
+---
+upgrade:
+  - |
+    :meth:`.Clifford.from_circuit` will no longer attempt to resolve instructions whose
+    :attr:`~.circuit.Instruction.definition` fields are mutually recursive with some other object.
+    Such recursive definitions are already a violation of the strictly hierarchical ordering that
+    the :attr:`~.circuit.Instruction.definition` field requires, and code should not rely on this
+    being possible at all.  If you want to define equivalences that are permitted to have (mutual)
+    cycles, use an :class:`.EquivalenceLibrary`.

--- a/test/python/quantum_info/operators/symplectic/test_clifford.py
+++ b/test/python/quantum_info/operators/symplectic/test_clifford.py
@@ -555,39 +555,6 @@ class TestCliffordGates(QiskitTestCase):
         expected_clifford = Clifford.from_dict(expected_clifford_dict)
         self.assertEqual(combined_clifford, expected_clifford)
 
-    def test_from_gate_with_cyclic_definition(self):
-        """Test if a Clifford can be created from gate with cyclic definition"""
-
-        class MyHGate(HGate):
-            """Custom HGate class for test"""
-
-            def __init__(self):
-                super().__init__()
-                self.name = "my_h"
-
-            def _define(self):
-                qc = QuantumCircuit(1, name=self.name)
-                qc.s(0)
-                qc.append(MySXGate(), [0])
-                qc.s(0)
-                self.definition = qc
-
-        class MySXGate(SXGate):
-            """Custom SXGate class for test"""
-
-            def __init__(self):
-                super().__init__()
-                self.name = "my_sx"
-
-            def _define(self):
-                qc = QuantumCircuit(1, name=self.name)
-                qc.sdg(0)
-                qc.append(MyHGate(), [0])
-                qc.sdg(0)
-                self.definition = qc
-
-        Clifford(MyHGate())
-
 
 @ddt
 class TestCliffordSynthesis(QiskitTestCase):


### PR DESCRIPTION
### Summary

This reliance on `RecursionError` could lead to CPython crashing, when the user had raised the recursion limit beyond what their operating system could actually support in terms of Python frames.  This was particularly an issue with Windows when in a context that `jedi` is active (such as in an IPython session, or if `seaborn` was imported), since `jedi` unilaterally sets the recursion limit to 3000, while CPython tends to overflow the stack on Windows at around 2700 frames.

Recursive `definition` fields are not valid data in the Qiskit model, as the definition is supposed to be hierarchical, and a decomposition in terms of gates that do not involve the current one in any form.  For defining equivalences that may involve cycles, one should use the `EquivalenceLibrary` objects that Terra manages, and the transpiler takes advantage of via the `BasisTranslator`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Close #10415.  @itoko, you might want to look at this, since I don't know if you had a use-case in mind for the original recursion handling.

This should fix the CI problems that #8967 and #10208 have encountered.