### PR TITLE
Drop Python-3.7 pin on `importlib-metadata`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,3 @@ typing-extensions; python_version<'3.11'
 # multiplication in version 0.10 wich breaks parameter assignment test
 # (can be removed once issue is fix)
 symengine>=0.9, <0.10; platform_machine == 'x86_64' or platform_machine == 'aarch64' or platform_machine == 'ppc64le' or platform_machine == 'amd64' or platform_machine == 'arm64'
-
-# Hack around stevedore being broken by importlib_metadata 5.0; we need to pin
-# the requirements rather than the constraints if we need to cut a release
-# before stevedore is fixed.  `importlib_metadata` is not (currently) a direct
-# requirement of Terra.
-importlib_metadata<5.0; python_version<'3.8'


### PR DESCRIPTION
### Summary

The current release branch of Terra could never match this requirement any more, so it's not needed.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Introduced in #8828.
