### PR TITLE
Fix UnassignedDurationError of update_from_instruction_schedule_map

### DIFF
--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -43,7 +43,7 @@ from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.instruction_durations import InstructionDurations
 from qiskit.transpiler.timing_constraints import TimingConstraints
 from qiskit.providers.exceptions import BackendPropertyError
-from qiskit.pulse.exceptions import PulseError
+from qiskit.pulse.exceptions import PulseError, UnassignedDurationError
 from qiskit.utils.deprecation import deprecate_arg, deprecate_func
 from qiskit.exceptions import QiskitError
 
@@ -500,7 +500,11 @@ class Target(Mapping):
                     # It only copies user-provided calibration from the inst map.
                     # Backend defined entry must already exist in Target.
                     if self.dt is not None:
-                        duration = entry.get_schedule().duration * self.dt
+                        try:
+                            duration = entry.get_schedule().duration * self.dt
+                        except UnassignedDurationError:
+                            # duration of schedule is parameterized
+                            duration = None
                     else:
                         duration = None
                     props = InstructionProperties(

--- a/releasenotes/notes/fix-update-from-instruction-schedule-map-d1cba4e4db4b679e.yaml
+++ b/releasenotes/notes/fix-update-from-instruction-schedule-map-d1cba4e4db4b679e.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed an failure of :meth:`.Target.update_from_instruction_schedule_map` when
+    the argument ``inst_map`` is parametrized.
+

--- a/releasenotes/notes/fix-update-from-instruction-schedule-map-d1cba4e4db4b679e.yaml
+++ b/releasenotes/notes/fix-update-from-instruction-schedule-map-d1cba4e4db4b679e.yaml
@@ -2,5 +2,5 @@
 fixes:
   - |
     Fixed an failure of :meth:`.Target.update_from_instruction_schedule_map` when
-    the argument ``inst_map`` has parametrized schedules.
+    the argument ``inst_map`` has schedule with unassigned duration.
 

--- a/releasenotes/notes/fix-update-from-instruction-schedule-map-d1cba4e4db4b679e.yaml
+++ b/releasenotes/notes/fix-update-from-instruction-schedule-map-d1cba4e4db4b679e.yaml
@@ -2,5 +2,5 @@
 fixes:
   - |
     Fixed an failure of :meth:`.Target.update_from_instruction_schedule_map` when
-    the argument ``inst_map`` is parametrized.
+    the argument ``inst_map`` has parametrized schedules.
 

--- a/test/python/transpiler/test_target.py
+++ b/test/python/transpiler/test_target.py
@@ -1210,7 +1210,7 @@ Instructions:
         target.update_from_instruction_schedule_map(inst_map, {"sx": SXGate()})
         self.assertEqual(inst_map, target.instruction_schedule_map())
 
-    def test_update_from_instruction_schedule_map_with_parameter(self):
+    def test_update_from_instruction_schedule_map_with_schedule_parameter(self):
         self.pulse_target.dt = None
         inst_map = InstructionScheduleMap()
         duration = Parameter("duration")

--- a/test/python/transpiler/test_target.py
+++ b/test/python/transpiler/test_target.py
@@ -1210,6 +1210,20 @@ Instructions:
         target.update_from_instruction_schedule_map(inst_map, {"sx": SXGate()})
         self.assertEqual(inst_map, target.instruction_schedule_map())
 
+    def test_update_from_instruction_schedule_map_with_parameter(self):
+        self.pulse_target.dt = None
+        inst_map = InstructionScheduleMap()
+        duration = Parameter("duration")
+
+        with pulse.build(name="sx_q0") as custom_sx:
+            pulse.play(pulse.Constant(duration, 0.2), pulse.DriveChannel(0))
+
+        inst_map.add("sx", 0, custom_sx, ["duration"])
+
+        target = Target(dt=3e-7)
+        target.update_from_instruction_schedule_map(inst_map, {"sx": SXGate()})
+        self.assertEqual(inst_map, target.instruction_schedule_map())
+
     def test_update_from_instruction_schedule_map_update_schedule(self):
         self.pulse_target.dt = None
         inst_map = InstructionScheduleMap()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Update_from_instruction_schedule_map failed when the duration of schedules is treated as a parameter.
I added try.. except statement and set duration `None` when the duration is the parameter.

### Details and comments


