### PR TITLE
Expand `Expr` integer type-width inference to all binary operations

### DIFF
--- a/qiskit/circuit/classical/expr/constructors.py
+++ b/qiskit/circuit/classical/expr/constructors.py
@@ -240,28 +240,30 @@ Bool())
     return Unary(Unary.Op.LOGIC_NOT, operand, operand.type)
 
 
-def _binary_bitwise(op: Binary.Op, left: typing.Any, right: typing.Any) -> Expr:
-    # Inference for integer literals is slightly different here as a convenience, since the bitwise
-    # binary operations require operands of the same width.
-    if not (isinstance(left, int) or isinstance(right, int)):
+def _lift_binary_operands(left: typing.Any, right: typing.Any) -> tuple[Expr, Expr]:
+    """Lift two binary operands simultaneously, inferring the widths of integer literals in either
+    position to match the other operand."""
+    left_int = isinstance(left, int) and not isinstance(left, bool)
+    right_int = isinstance(right, int) and not isinstance(right, bool)
+    if not (left_int or right_int):
         left = lift(left)
         right = lift(right)
-    elif isinstance(left, int):
+    elif not right_int:
         right = lift(right)
         if right.type.kind is types.Uint:
             if left.bit_length() > right.type.width:
                 raise TypeError(
-                    f"integer literal '{left}' is wider than the other bitwise operand '{right}'"
+                    f"integer literal '{left}' is wider than the other operand '{right}'"
                 )
             left = Value(left, right.type)
         else:
             left = lift(left)
-    elif isinstance(right, int):
+    elif not left_int:
         left = lift(left)
         if left.type.kind is types.Uint:
             if right.bit_length() > left.type.width:
                 raise TypeError(
-                    f"integer literal '{right}' is wider than the other bitwise operand '{left}'"
+                    f"integer literal '{right}' is wider than the other operand '{left}'"
                 )
             right = Value(right, left.type)
         else:
@@ -271,6 +273,11 @@ def _binary_bitwise(op: Binary.Op, left: typing.Any, right: typing.Any) -> Expr:
         uint = types.Uint(max(left.bit_length(), right.bit_length(), 1))
         left = Value(left, uint)
         right = Value(right, uint)
+    return left, right
+
+
+def _binary_bitwise(op: Binary.Op, left: typing.Any, right: typing.Any) -> Expr:
+    left, right = _lift_binary_operands(left, right)
     type: types.Type
     if left.type.kind is right.type.kind is types.Bool:
         type = types.Bool()
@@ -381,8 +388,7 @@ def logic_or(left: typing.Any, right: typing.Any, /) -> Expr:
 
 
 def _equal_like(op: Binary.Op, left: typing.Any, right: typing.Any) -> Expr:
-    left = lift(left)
-    right = lift(right)
+    left, right = _lift_binary_operands(left, right)
     if left.type.kind is not right.type.kind:
         raise TypeError(f"invalid types for '{op}': '{left.type}' and '{right.type}'")
     type = types.greater(left.type, right.type)
@@ -426,8 +432,7 @@ Uint(3))
 
 
 def _binary_relation(op: Binary.Op, left: typing.Any, right: typing.Any) -> Expr:
-    left = lift(left)
-    right = lift(right)
+    left, right = _lift_binary_operands(left, right)
     if left.type.kind is not right.type.kind or left.type.kind is types.Bool:
         raise TypeError(f"invalid types for '{op}': '{left.type}' and '{right.type}'")
     type = types.greater(left.type, right.type)

--- a/test/python/circuit/classical/test_expr_constructors.py
+++ b/test/python/circuit/classical/test_expr_constructors.py
@@ -163,11 +163,11 @@ class TestExprConstructors(QiskitTestCase):
         (expr.bit_xor, ClassicalRegister(3), ClassicalRegister(3)),
         (expr.logic_and, Clbit(), True),
         (expr.logic_or, False, ClassicalRegister(3)),
-        (expr.equal, ClassicalRegister(3), 255),
-        (expr.not_equal, ClassicalRegister(3), 255),
-        (expr.less, ClassicalRegister(3), 2),
+        (expr.equal, ClassicalRegister(8), 255),
+        (expr.not_equal, ClassicalRegister(8), 255),
+        (expr.less, ClassicalRegister(3), 6),
         (expr.less_equal, ClassicalRegister(3), 5),
-        (expr.greater, 2, ClassicalRegister(3)),
+        (expr.greater, 4, ClassicalRegister(3)),
         (expr.greater_equal, ClassicalRegister(3), 5),
     )
     @ddt.unpack
@@ -327,7 +327,7 @@ class TestExprConstructors(QiskitTestCase):
             function(7, cr),
             expr.Binary(
                 opcode,
-                expr.Cast(expr.Value(7, types.Uint(3)), types.Uint(8), implicit=False),
+                expr.Value(7, types.Uint(8)),
                 expr.Var(cr, types.Uint(8)),
                 types.Bool(),
             ),
@@ -373,7 +373,7 @@ class TestExprConstructors(QiskitTestCase):
             function(12, cr),
             expr.Binary(
                 opcode,
-                expr.Cast(expr.Value(12, types.Uint(4)), types.Uint(8), implicit=False),
+                expr.Value(12, types.Uint(8)),
                 expr.Var(cr, types.Uint(8)),
                 types.Bool(),
             ),


### PR DESCRIPTION
### Summary

This expands the inference on integer widths that was previously only done in the bitwise operations to all binary operations, to reduce the number of cast nodes that will be inserted.  This is mostly a quality-of-life improvement (for us as well), because there's not really a need to include casts when we could just have our integer literals start off at the correct size.

In the immediate term, this is useful for OpenQASM 3 export for the IBM QSS stack, which doesn't support explicit casting yet.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

This turned up during my testing of our capabilities against the QSS stack.