### PR TITLE
Improve `%qiskit_version_table` Jupyter magic

### DIFF
--- a/qiskit/tools/jupyter/version_table.py
+++ b/qiskit/tools/jupyter/version_table.py
@@ -36,7 +36,14 @@ class VersionTable(Magics):
         html += "<table>"
         html += "<tr><th>Software</th><th>Version</th></tr>"
 
-        packages = {}
+        packages = {"qiskit": None}
+
+        packages["qiskit-terra"] = qiskit.__version__
+
+        qiskit_modules = {module.split(".")[0] for module in modules.keys() if "qiskit" in module}
+
+        for qiskit_module in qiskit_modules:
+            packages[qiskit_module] = getattr(modules[qiskit_module], "__version__", None)
 
         from importlib.metadata import metadata, PackageNotFoundError
 
@@ -45,14 +52,9 @@ class VersionTable(Magics):
         except PackageNotFoundError:
             packages["qiskit"] = None
 
-        packages["qiskit-terra"] = qiskit.__version__
-
-        qiskit_modules = {module.split(".")[0] for module in modules.keys() if "qiskit" in module}
-        for qiskit_module in qiskit_modules:
-            packages[qiskit_module] = getattr(modules[qiskit_module], "__version__", None)
-
         for name, version in packages.items():
-            html += f"<tr><td><code>{name}</code></td><td>{version}</td></tr>"
+            if name == "qiskit" or version:
+                html += f"<tr><td><code>{name}</code></td><td>{version}</td></tr>"
 
         html += "<tr><th colspan='2'>System information</th></tr>"
 


### PR DESCRIPTION
After merging https://github.com/Qiskit/qiskit-terra/pull/10242, the current magic looks like this:

![Screenshot 2023-07-20 at 13 42 35](https://github.com/Qiskit/qiskit-terra/assets/766693/28fccb89-db25-42c8-a749-43bf777ddf69)

With this PR, it looks like this:
![Screenshot 2023-07-20 at 13 43 15](https://github.com/Qiskit/qiskit-terra/assets/766693/30cb46a9-11a2-4175-8482-1c306570a693)
