### PR TITLE
Methods are documented on class pages

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,6 +1,5 @@
 {#
-   The general principle of this is that we manually document attributes here in
-   the same file, but give all methods their own page.  By default, we document
+   We show all the class's methods and attributes on the same page. By default, we document
    all methods, including those defined by parent classes.
 -#}
 
@@ -9,33 +8,24 @@
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}
-{#-
-   Avoid having autodoc populate the class with the members we're about to
-   summarize to avoid duplication.
-#}
    :no-members:
    :show-inheritance:
-{#
-   Methods all get their own separate page, with their names and the first lines
-   of their docstrings tabulated.  The documentation from `__init__` is
-   automatically included in the standard class documentation, so we don't want
-   to repeat it.
--#}
-{% block methods_summary %}{% set wanted_methods = (methods | reject('==', '__init__') | list) %}{% if wanted_methods %}
-   .. rubric:: Methods
 
-   .. autosummary::
-      :nosignatures:
-      :toctree: ../stubs/
-{% for item in wanted_methods %}
-      ~{{ name }}.{{ item }}
-{%- endfor %}
-{% endif %}{% endblock %}
-
-{% block attributes_summary %}{% if attributes %}
+{% block attributes_summary %}
+  {% if attributes %}
    .. rubric:: Attributes
-{# Attributes should all be summarized directly on the same page. -#}
-{% for item in attributes %}
+    {% for item in attributes %}
    .. autoattribute:: {{ item }}
-{%- endfor %}
-{% endif %}{% endblock -%}
+    {%- endfor %}
+  {% endif %}
+{% endblock -%}
+
+{% block methods_summary %}
+  {% set wanted_methods = (methods | reject('==', '__init__') | list) %}
+  {% if wanted_methods %}
+   .. rubric:: Methods
+    {% for item in wanted_methods %}
+   .. automethod:: {{ item }}
+    {%- endfor %}
+  {% endif %}
+{% endblock %}

--- a/docs/_templates/autosummary/class_no_inherited_members.rst
+++ b/docs/_templates/autosummary/class_no_inherited_members.rst
@@ -1,38 +1,28 @@
-{#
-   This is very similar to the default class template, except this one is used
-   when we don't want to generate any inherited methods.
--#}
+{# This is identical to class.rst, except for the filtering in `set wanted_methods`. -#}
 
 {{ objname | escape | underline }}
 
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}
-{#-
-   Avoid having autodoc populate the class with the members we're about to
-   summarize to avoid duplication.
-#}
    :no-members:
    :show-inheritance:
-{#
-   Methods all get their own separate page, with their names and the first lines
-   of their docstrings tabulated.
--#}
-{% block methods_summary %}{% set wanted_methods = (methods | reject('in', inherited_members) | reject('==', '__init__') | list) %}{% if wanted_methods %}
-   .. rubric:: Methods Defined Here
 
-   .. autosummary::
-      :nosignatures:
-      :toctree: ../stubs/
-{% for item in wanted_methods %}
-      ~{{ name }}.{{ item }}
-{%- endfor %}
-{% endif %}{% endblock %}
-
-{% block attributes_summary %}{% if attributes %}
+{% block attributes_summary %}
+  {% if attributes %}
    .. rubric:: Attributes
-{# Attributes should all be summarized directly on the same page. -#}
-{% for item in attributes %}
+    {% for item in attributes %}
    .. autoattribute:: {{ item }}
-{%- endfor %}
-{% endif %}{% endblock -%}
+    {%- endfor %}
+  {% endif %}
+{% endblock -%}
+
+{% block methods_summary %}
+  {% set wanted_methods = (methods | reject('in', inherited_members) | reject('==', '__init__') | list) %}
+  {% if wanted_methods %}
+   .. rubric:: Methods
+    {% for item in wanted_methods %}
+   .. automethod:: {{ item }}
+    {%- endfor %}
+  {% endif %}
+{% endblock %}

--- a/qiskit/algorithms/optimizers/nft.py
+++ b/qiskit/algorithms/optimizers/nft.py
@@ -106,9 +106,10 @@ def nakanishi_fujii_todo(
             `OptimizeResult` for a description of other attributes.
     Notes:
         In this optimization method, the optimization function have to satisfy
-        three conditions written in [1].
+        three conditions written in [2]_.
+
     References:
-        .. [1] K. M. Nakanishi, K. Fujii, and S. Todo. 2019.
+        .. [2] K. M. Nakanishi, K. Fujii, and S. Todo. 2019.
         Sequential minimal optimization for quantum-classical hybrid algorithms.
         arXiv preprint arXiv:1903.12166.
     """

--- a/qiskit/providers/backend.py
+++ b/qiskit/providers/backend.py
@@ -88,6 +88,7 @@ class BackendV1(Backend, ABC):
         private methods:
 
         .. automethod:: _default_options
+           :noindex:
         """
         self._configuration = configuration
         self._options = self._default_options()


### PR DESCRIPTION
Currently, methods have their own HTML page. This PR changes them to live on the class page.

Motivations:

1. Speed up our docs build. Before: 8 minutes, 20 seconds. After: 4 minutes, 30 seconds.
2. Better user experience. While it's true we sometimes have very long method entries, most of our methods are small and it's a frustrating user experience to have to change pages so much. Compare this to e.g. Python docs, where the entire module is documented on a single page. An IBM design team suggested we make this change.

A follow-up will move functions to their module page, rather than dedicated pages.

### No redirects

We decided it's not worth adding redirects for method pages. Sphinx will already properly update all cross-references to the right place, and we don't expect there to be many external links to method pages.