### PR TITLE
Disable cron runs on `stable/0.23`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,13 +19,6 @@ pr:
     include:
       - '*'
 
-schedules:
-  - cron: "20 6 * * *"
-    displayName: "Complete matrix test"
-    branches:
-      include: [ "main", "stable/*" ]
-    always: false  # Only run if the code changed since the last cron sync.
-
 
 # Configuration.  In theory a manual trigger on the Azure website or embedding
 # this pipeline as a template can override these, but we're not interested in


### PR DESCRIPTION
We no longer need to be running nightly CI on the 0.23.x series, since it is no longer supported.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


