### PR TITLE
Consistent typehints for ``NLocal`` family

### DIFF
--- a/qiskit/circuit/library/evolved_operator_ansatz.py
+++ b/qiskit/circuit/library/evolved_operator_ansatz.py
@@ -41,7 +41,7 @@ class EvolvedOperatorAnsatz(NLocal):
         name: str = "EvolvedOps",
         parameter_prefix: str | Sequence[str] = "t",
         initial_state: QuantumCircuit | None = None,
-        flatten: Optional[bool] = None,
+        flatten: bool | None = None,
     ):
         """
         Args:

--- a/qiskit/circuit/library/evolved_operator_ansatz.py
+++ b/qiskit/circuit/library/evolved_operator_ansatz.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 from collections.abc import Sequence
-from typing import Optional
 
 import numpy as np
 

--- a/qiskit/circuit/library/n_local/efficient_su2.py
+++ b/qiskit/circuit/library/n_local/efficient_su2.py
@@ -81,9 +81,9 @@ class EfficientSU2(TwoLocal):
         num_qubits: int | None = None,
         su2_gates: str
         | type
-        | Instruction
+        | qiskit.circuit.Instruction
         | QuantumCircuit
-        | list[str | type | Instruction | QuantumCircuit]
+        | list[str | type | qiskit.circuit.Instruction | QuantumCircuit]
         | None = None,
         entanglement: str | list[list[int]] | Callable[[int], list[int]] = "reverse_linear",
         reps: int = 3,

--- a/qiskit/circuit/library/n_local/efficient_su2.py
+++ b/qiskit/circuit/library/n_local/efficient_su2.py
@@ -12,6 +12,9 @@
 
 """The EfficientSU2 2-local circuit."""
 
+from __future__ import annotations
+from collections.abc import Callable
+
 from numpy import pi
 
 from qiskit.circuit import QuantumCircuit, Instruction

--- a/qiskit/circuit/library/n_local/efficient_su2.py
+++ b/qiskit/circuit/library/n_local/efficient_su2.py
@@ -12,7 +12,6 @@
 
 """The EfficientSU2 2-local circuit."""
 
-from typing import Union, Optional, List, Tuple, Callable, Any
 from numpy import pi
 
 from qiskit.circuit import QuantumCircuit, Instruction
@@ -76,28 +75,24 @@ class EfficientSU2(TwoLocal):
 
     def __init__(
         self,
-        num_qubits: Optional[int] = None,
-        su2_gates: Optional[
-            Union[
-                str,
-                type,
-                Instruction,
-                QuantumCircuit,
-                List[Union[str, type, Instruction, QuantumCircuit]],
-            ]
-        ] = None,
-        entanglement: Union[str, List[List[int]], Callable[[int], List[int]]] = "reverse_linear",
+        num_qubits: int | None = None,
+        su2_gates: str
+        | type
+        | Instruction
+        | QuantumCircuit
+        | list[str | type | Instruction | QuantumCircuit]
+        | None = None,
+        entanglement: str | list[list[int]] | Callable[[int], list[int]] = "reverse_linear",
         reps: int = 3,
         skip_unentangled_qubits: bool = False,
         skip_final_rotation_layer: bool = False,
         parameter_prefix: str = "θ",
         insert_barriers: bool = False,
-        initial_state: Optional[Any] = None,
+        initial_state: QuantumCircuit | None = None,
         name: str = "EfficientSU2",
-        flatten: Optional[bool] = None,
+        flatten: bool | None = None,
     ) -> None:
-        """Create a new EfficientSU2 2-local circuit.
-
+        """
         Args:
             num_qubits: The number of qubits of the EfficientSU2 circuit.
             reps: Specifies how often the structure of a rotation layer followed by an entanglement
@@ -151,7 +146,7 @@ class EfficientSU2(TwoLocal):
         )
 
     @property
-    def parameter_bounds(self) -> List[Tuple[float, float]]:
+    def parameter_bounds(self) -> list[tuple[float, float]]:
         """Return the parameter bounds.
 
         Returns:

--- a/qiskit/circuit/library/n_local/efficient_su2.py
+++ b/qiskit/circuit/library/n_local/efficient_su2.py
@@ -87,7 +87,7 @@ class EfficientSU2(TwoLocal):
         | type
         | qiskit.circuit.Instruction
         | QuantumCircuit
-        | list[str | type | qiskit.circuit.Instruction, QuantumCircuit]
+        | list[str | type | qiskit.circuit.Instruction | QuantumCircuit]
         | None = None,
         entanglement: str | list[list[int]] | Callable[[int], list[int]] = "reverse_linear",
         reps: int = 3,

--- a/qiskit/circuit/library/n_local/efficient_su2.py
+++ b/qiskit/circuit/library/n_local/efficient_su2.py
@@ -13,13 +13,17 @@
 """The EfficientSU2 2-local circuit."""
 
 from __future__ import annotations
+import typing
 from collections.abc import Callable
 
 from numpy import pi
 
-from qiskit.circuit import QuantumCircuit, Instruction
+from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.library.standard_gates import RYGate, RZGate, CXGate
 from .two_local import TwoLocal
+
+if typing.TYPE_CHECKING:
+    import qiskit  # pylint: disable=cyclic-import
 
 
 class EfficientSU2(TwoLocal):
@@ -83,7 +87,7 @@ class EfficientSU2(TwoLocal):
         | type
         | qiskit.circuit.Instruction
         | QuantumCircuit
-        | list[str | type | qiskit.circuit.Instruction | QuantumCircuit]
+        | list[str | type | qiskit.circuit.Instruction, QuantumCircuit]
         | None = None,
         entanglement: str | list[list[int]] | Callable[[int], list[int]] = "reverse_linear",
         reps: int = 3,

--- a/qiskit/circuit/library/n_local/excitation_preserving.py
+++ b/qiskit/circuit/library/n_local/excitation_preserving.py
@@ -12,7 +12,8 @@
 
 """The ExcitationPreserving 2-local circuit."""
 
-from typing import Union, Optional, List, Tuple, Callable, Any
+from __future__ import annotations
+from collections.abc import Callable
 from numpy import pi
 
 from qiskit.circuit import QuantumCircuit, Parameter
@@ -90,20 +91,19 @@ class ExcitationPreserving(TwoLocal):
 
     def __init__(
         self,
-        num_qubits: Optional[int] = None,
+        num_qubits: int | None = None,
         mode: str = "iswap",
-        entanglement: Union[str, List[List[int]], Callable[[int], List[int]]] = "full",
+        entanglement: str | list[list[int]] | Callable[[int], list[int]] = "full",
         reps: int = 3,
         skip_unentangled_qubits: bool = False,
         skip_final_rotation_layer: bool = False,
         parameter_prefix: str = "θ",
         insert_barriers: bool = False,
-        initial_state: Optional[Any] = None,
+        initial_state: QuantumCircuit | None = None,
         name: str = "ExcitationPreserving",
-        flatten: Optional[bool] = None,
+        flatten: bool | None = None,
     ) -> None:
-        """Create a new ExcitationPreserving 2-local circuit.
-
+        """
         Args:
             num_qubits: The number of qubits of the ExcitationPreserving circuit.
             mode: Choose the entangler mode, can be `'iswap'` or `'fsim'`.
@@ -167,7 +167,7 @@ class ExcitationPreserving(TwoLocal):
         )
 
     @property
-    def parameter_bounds(self) -> List[Tuple[float, float]]:
+    def parameter_bounds(self) -> list[tuple[float, float]]:
         """Return the parameter bounds.
 
         Returns:

--- a/qiskit/circuit/library/n_local/n_local.py
+++ b/qiskit/circuit/library/n_local/n_local.py
@@ -12,10 +12,10 @@
 
 """The n-local circuit class."""
 
-from __future__ import annotations
-
 import typing
-from typing import Union, Optional, Any, Sequence, Callable, Mapping
+from __future__ import annotations
+from collections.abc import Callable, Mapping
+
 from itertools import combinations
 
 import numpy
@@ -90,10 +90,9 @@ class NLocal(BlueprintCircuit):
         skip_unentangled_qubits: bool = False,
         initial_state: QuantumCircuit | None = None,
         name: str | None = "nlocal",
-        flatten: Optional[bool] = None,
+        flatten: bool | None = None,
     ) -> None:
-        """Create a new n-local circuit.
-
+        """
         Args:
             num_qubits: The number of qubits of the circuit.
             rotation_blocks: The blocks used in the rotation layers. If multiple are passed,
@@ -122,9 +121,6 @@ class NLocal(BlueprintCircuit):
                 for anything besides visualization its **strongly** recommended
                 to set this flag to ``True`` to avoid a large performance
                 overhead for parameter binding.
-
-        Examples:
-            TODO
 
         Raises:
             ValueError: If ``reps`` parameter is less than or equal to 0.
@@ -289,17 +285,9 @@ class NLocal(BlueprintCircuit):
     @property
     def entanglement(
         self,
-    ) -> Union[
-        str,
-        list[str],
-        list[list[str]],
-        list[int],
-        list[list[int]],
-        list[list[list[int]]],
-        list[list[list[list[int]]]],
-        Callable[[int], str],
-        Callable[[int], list[list[int]]],
-    ]:
+    ) -> str | list[str] | list[list[str]] | list[int] | list[list[int]] | list[
+        list[list[int]]
+    ] | list[list[list[list[int]]]] | Callable[[int], str] | Callable[[int], list[list[int]]]:
         """Get the entanglement strategy.
 
         Returns:
@@ -311,19 +299,16 @@ class NLocal(BlueprintCircuit):
     @entanglement.setter
     def entanglement(
         self,
-        entanglement: Optional[
-            Union[
-                str,
-                list[str],
-                list[list[str]],
-                list[int],
-                list[list[int]],
-                list[list[list[int]]],
-                list[list[list[list[int]]]],
-                Callable[[int], str],
-                Callable[[int], list[list[int]]],
-            ]
-        ],
+        entanglement: str
+        | list[str]
+        | list[list[str]]
+        | list[int]
+        | list[list[int]]
+        | list[list[list[int]]]
+        | list[list[list[list[int]]]]
+        | Callable[[int], str]
+        | Callable[[int], list[list[int]]]
+        | None,
     ) -> None:
         """Set the entanglement strategy.
 
@@ -730,7 +715,7 @@ class NLocal(BlueprintCircuit):
 
     def add_layer(
         self,
-        other: Union["NLocal", qiskit.circuit.Instruction, QuantumCircuit],
+        other: QuantumCircuit | qiskit.circuit.Instruction,
         entanglement: list[int] | str | list[list[int]] | None = None,
         front: bool = False,
     ) -> "NLocal":

--- a/qiskit/circuit/library/n_local/n_local.py
+++ b/qiskit/circuit/library/n_local/n_local.py
@@ -12,9 +12,9 @@
 
 """The n-local circuit class."""
 
-import typing
 from __future__ import annotations
-from collections.abc import Callable, Mapping
+import typing
+from collections.abc import Callable, Mapping, Sequence
 
 from itertools import combinations
 
@@ -203,7 +203,7 @@ class NLocal(BlueprintCircuit):
         self._invalidate()
         self._flatten = flatten
 
-    def _convert_to_block(self, layer: Any) -> QuantumCircuit:
+    def _convert_to_block(self, layer: typing.Any) -> QuantumCircuit:
         """Try to convert ``layer`` to a QuantumCircuit.
 
         Args:

--- a/qiskit/circuit/library/n_local/qaoa_ansatz.py
+++ b/qiskit/circuit/library/n_local/qaoa_ansatz.py
@@ -41,7 +41,7 @@ class QAOAAnsatz(EvolvedOperatorAnsatz):
         initial_state: QuantumCircuit | None = None,
         mixer_operator=None,
         name: str = "QAOA",
-        flatten: Optional[bool] = None,
+        flatten: bool | None = None,
     ):
         r"""
         Args:

--- a/qiskit/circuit/library/n_local/qaoa_ansatz.py
+++ b/qiskit/circuit/library/n_local/qaoa_ansatz.py
@@ -14,7 +14,6 @@
 
 # pylint: disable=cyclic-import
 from __future__ import annotations
-from typing import Optional
 
 import numpy as np
 

--- a/qiskit/circuit/library/n_local/real_amplitudes.py
+++ b/qiskit/circuit/library/n_local/real_amplitudes.py
@@ -119,7 +119,7 @@ class RealAmplitudes(TwoLocal):
     def __init__(
         self,
         num_qubits: int | None = None,
-        entanglement: str | list[list[int]] | Callable[[int], list[int]] = "full",
+        entanglement: str | list[list[int]] | Callable[[int], list[int]] = "reverse_linear",
         reps: int = 3,
         skip_unentangled_qubits: bool = False,
         skip_final_rotation_layer: bool = False,

--- a/qiskit/circuit/library/n_local/real_amplitudes.py
+++ b/qiskit/circuit/library/n_local/real_amplitudes.py
@@ -17,6 +17,7 @@ from collections.abc import Callable
 
 import numpy as np
 
+from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.library.standard_gates import RYGate, CXGate
 from .two_local import TwoLocal
 
@@ -118,13 +119,7 @@ class RealAmplitudes(TwoLocal):
     def __init__(
         self,
         num_qubits: int | None = None,
-        entanglement_blocks: str
-        | list[str]
-        | type
-        | list[type]
-        | QuantumCircuit
-        | list[QuantumCircuit]
-        | None = None,
+        entanglement: str | list[list[int]] | Callable[[int], list[int]] = "full",
         reps: int = 3,
         skip_unentangled_qubits: bool = False,
         skip_final_rotation_layer: bool = False,
@@ -185,7 +180,7 @@ class RealAmplitudes(TwoLocal):
         )
 
     @property
-    def parameter_bounds(self) -> List[Tuple[float, float]]:
+    def parameter_bounds(self) -> list[tuple[float, float]]:
         """Return the parameter bounds.
 
         Returns:

--- a/qiskit/circuit/library/n_local/real_amplitudes.py
+++ b/qiskit/circuit/library/n_local/real_amplitudes.py
@@ -12,7 +12,9 @@
 
 """The real-amplitudes 2-local circuit."""
 
-from typing import Union, Optional, List, Tuple, Callable, Any
+from __future__ import annotations
+from collections.abc import Callable
+
 import numpy as np
 
 from qiskit.circuit.library.standard_gates import RYGate, CXGate
@@ -115,19 +117,24 @@ class RealAmplitudes(TwoLocal):
 
     def __init__(
         self,
-        num_qubits: Optional[int] = None,
-        entanglement: Union[str, List[List[int]], Callable[[int], List[int]]] = "reverse_linear",
+        num_qubits: int | None = None,
+        entanglement_blocks: str
+        | list[str]
+        | type
+        | list[type]
+        | QuantumCircuit
+        | list[QuantumCircuit]
+        | None = None,
         reps: int = 3,
         skip_unentangled_qubits: bool = False,
         skip_final_rotation_layer: bool = False,
         parameter_prefix: str = "θ",
         insert_barriers: bool = False,
-        initial_state: Optional[Any] = None,
+        initial_state: QuantumCircuit | None = None,
         name: str = "RealAmplitudes",
-        flatten: Optional[bool] = None,
+        flatten: bool | None = None,
     ) -> None:
-        """Create a new RealAmplitudes 2-local circuit.
-
+        """
         Args:
             num_qubits: The number of qubits of the RealAmplitudes circuit.
             reps: Specifies how often the structure of a rotation layer followed by an entanglement

--- a/qiskit/circuit/library/n_local/two_local.py
+++ b/qiskit/circuit/library/n_local/two_local.py
@@ -13,7 +13,7 @@
 """The two-local gate circuit."""
 
 from __future__ import annotations
-from typing import Union, Optional, List, Callable, Any, Sequence
+from collections.abc import Callable
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.circuit import Gate, Instruction, Parameter
@@ -158,25 +158,32 @@ class TwoLocal(NLocal):
 
     def __init__(
         self,
-        num_qubits: Optional[int] = None,
-        rotation_blocks: Optional[
-            Union[str, List[str], type, List[type], QuantumCircuit, List[QuantumCircuit]]
-        ] = None,
-        entanglement_blocks: Optional[
-            Union[str, List[str], type, List[type], QuantumCircuit, List[QuantumCircuit]]
-        ] = None,
-        entanglement: Union[str, List[List[int]], Callable[[int], List[int]]] = "full",
+        num_qubits: int | None = None,
+        rotation_blocks: str
+        | list[str]
+        | type
+        | list[type]
+        | QuantumCircuit
+        | list[QuantumCircuit]
+        | None = None,
+        entanglement_blocks: str
+        | list[str]
+        | type
+        | list[type]
+        | QuantumCircuit
+        | list[QuantumCircuit]
+        | None = None,
+        entanglement: str | list[list[int]] | Callable[[int], list[int]] = "full",
         reps: int = 3,
         skip_unentangled_qubits: bool = False,
         skip_final_rotation_layer: bool = False,
         parameter_prefix: str = "θ",
         insert_barriers: bool = False,
-        initial_state: Optional[Any] = None,
+        initial_state: QuantumCircuit | None = None,
         name: str = "TwoLocal",
-        flatten: Optional[bool] = None,
+        flatten: bool | None = None,
     ) -> None:
-        """Construct a new two-local circuit.
-
+        """
         Args:
             num_qubits: The number of qubits of the two-local circuit.
             rotation_blocks: The gates used in the rotation layer. Can be specified via the name of

--- a/qiskit/circuit/library/n_local/two_local.py
+++ b/qiskit/circuit/library/n_local/two_local.py
@@ -13,6 +13,7 @@
 """The two-local gate circuit."""
 
 from __future__ import annotations
+import typing
 from collections.abc import Callable, Sequence
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
@@ -45,6 +46,9 @@ from ..standard_gates import (
     CRZGate,
     CHGate,
 )
+
+if typing.TYPE_CHECKING:
+    import qiskit  # pylint: disable=cyclic-import
 
 
 class TwoLocal(NLocal):
@@ -160,18 +164,16 @@ class TwoLocal(NLocal):
         self,
         num_qubits: int | None = None,
         rotation_blocks: str
-        | list[str]
         | type
-        | list[type]
+        | qiskit.circuit.Instruction
         | QuantumCircuit
-        | list[QuantumCircuit]
+        | list[str | type | qiskit.circuit.Instruction, QuantumCircuit]
         | None = None,
         entanglement_blocks: str
-        | list[str]
         | type
-        | list[type]
+        | qiskit.circuit.Instruction
         | QuantumCircuit
-        | list[QuantumCircuit]
+        | list[str | type | qiskit.circuit.Instruction, QuantumCircuit]
         | None = None,
         entanglement: str | list[list[int]] | Callable[[int], list[int]] = "full",
         reps: int = 3,

--- a/qiskit/circuit/library/n_local/two_local.py
+++ b/qiskit/circuit/library/n_local/two_local.py
@@ -167,13 +167,13 @@ class TwoLocal(NLocal):
         | type
         | qiskit.circuit.Instruction
         | QuantumCircuit
-        | list[str | type | qiskit.circuit.Instruction, QuantumCircuit]
+        | list[str | type | qiskit.circuit.Instruction | QuantumCircuit]
         | None = None,
         entanglement_blocks: str
         | type
         | qiskit.circuit.Instruction
         | QuantumCircuit
-        | list[str | type | qiskit.circuit.Instruction, QuantumCircuit]
+        | list[str | type | qiskit.circuit.Instruction | QuantumCircuit]
         | None = None,
         entanglement: str | list[list[int]] | Callable[[int], list[int]] = "full",
         reps: int = 3,

--- a/qiskit/circuit/library/n_local/two_local.py
+++ b/qiskit/circuit/library/n_local/two_local.py
@@ -13,7 +13,7 @@
 """The two-local gate circuit."""
 
 from __future__ import annotations
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.circuit import Gate, Instruction, Parameter
@@ -240,7 +240,7 @@ class TwoLocal(NLocal):
             flatten=flatten,
         )
 
-    def _convert_to_block(self, layer: Union[str, type, Gate, QuantumCircuit]) -> QuantumCircuit:
+    def _convert_to_block(self, layer: str | type | Gate | QuantumCircuit) -> QuantumCircuit:
         """For a layer provided as str (e.g. ``'ry'``) or type (e.g. :class:`.RYGate`) this function
          returns the
          according layer type along with the number of parameters (e.g. ``(RYGate, 1)``).


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #10456 and generally use `collections.abc` over `typing`.

### Details and comments

Also makes the docs more consistent by removing the first line of the `__init__` doc and the `TODO` in the Examples section (tracked in #10480).

