### PR TITLE
Fix documentation of `SwitchCaseOp`

### DIFF
--- a/qiskit/circuit/__init__.py
+++ b/qiskit/circuit/__init__.py
@@ -296,9 +296,41 @@ Control Flow Operations
 
 The :class:`.SwitchCaseOp` also understands a special value:
 
-.. py:data: CASE_DEFAULT
-    Used as a possible "label" in a :class:`.SwitchCaseOp` to represent the default case.  This will
-    always match, if it is tried.
+.. py:data:: CASE_DEFAULT
+
+   A special object that represents the "default" case of a switch statement.  If you use this as a
+   case target, it must be the last case, and will match anything that wasn't already matched.  For
+   example::
+
+       from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
+       from qiskit.circuit import SwitchCaseOp, CASE_DEFAULT
+
+       body0 = QuantumCircuit(2, 2)
+       body0.x(0)
+       body1 = QuantumCircuit(2, 2)
+       body1.z(0)
+       body2 = QuantumCircuit(2, 2)
+       body2.cx(0, 1)
+
+       qr, cr = QuantumRegister(2), ClassicalRegister(2)
+       qc = QuantumCircuit(qr, cr)
+       qc.switch(cr, [(0, body0), (1, body1), (CASE_DEFAULT, body2)], qr, cr)
+
+   When using the builder interface of :meth:`.QuantumCircuit.switch`, this can also be accessed as
+   the ``DEFAULT`` attribute of the bound case-builder object, such as::
+
+       from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
+
+       qr, cr = QuantumRegister(2), ClassicalRegister(2)
+       qc = QuantumCircuit(qr, cr)
+       with qc.switch(cr) as case:
+           with case(0):
+               qc.x(0)
+           with case(1):
+               qc.z(0)
+           with case(case.DEFAULT):
+               qc.cx(0, 1)
+
 
 Parametric Quantum Circuits
 ---------------------------

--- a/qiskit/circuit/controlflow/switch_case.py
+++ b/qiskit/circuit/controlflow/switch_case.py
@@ -41,8 +41,7 @@ CASE_DEFAULT = _DefaultCaseType()
 """A special object that represents the "default" case of a switch statement.  If you use this
 as a case target, it must be the last case, and will match anything that wasn't already matched.
 When using the builder interface of :meth:`.QuantumCircuit.switch`, this can also be accessed as the
-``DEFAULT`` attribute of the bound case-builder object.
-"""
+``DEFAULT`` attribute of the bound case-builder object."""
 
 
 class SwitchCaseOp(ControlFlowOp):
@@ -51,12 +50,12 @@ class SwitchCaseOp(ControlFlowOp):
     be used to represent a default condition.
 
     This is the low-level interface for creating a switch-case statement; in general, the circuit
-    method :meth:`.QuantumCircuit.switch_case` should be used as a context manager to access the
+    method :meth:`.QuantumCircuit.switch` should be used as a context manager to access the
     builder interface.  At the low level, you must ensure that all the circuit blocks contain equal
     numbers of qubits and clbits, and that the order the virtual bits of the containing circuit
     should be bound is the same for all blocks.  This will likely mean that each circuit block is
     wider than its natural width, as each block must span the union of all the spaces covered by
-    _any_ of the blocks.
+    *any* of the blocks.
 
     Args:
         target: the runtime value to switch on.


### PR DESCRIPTION
### Summary

The class page for the `SwitchCaseOp` had some broken hyperlinks, and the documentation of the switch `CASE_DEFAULT` object was broken.  This fixes both, and adds some more explicit examples of usage of the `CASE_DEFAULT` object, with some overlap of what was already in `QuantumCircuit.switch`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #10458
