### PR TITLE
limiting matrix-based commutativity check

### DIFF
--- a/qiskit/circuit/commutation_checker.py
+++ b/qiskit/circuit/commutation_checker.py
@@ -65,10 +65,19 @@ class CommutationChecker:
         return ("fallback", str(params))
 
     def commute(
-        self, op1: Operation, qargs1: List, cargs1: List, op2: Operation, qargs2: List, cargs2: List
-    ):
+        self,
+        op1: Operation,
+        qargs1: List,
+        cargs1: List,
+        op2: Operation,
+        qargs2: List,
+        cargs2: List,
+        max_num_qubits: int = 3,
+    ) -> bool:
         """
-        Checks if two Operations commute.
+        Checks if two Operations commute. The return value of `True` means that the operations truly commute,
+        and the return value of `False` means that either the operations do not commute or that the commutation
+        check was skipped (for example, when the operations have conditions or have too many qubits).
 
         Args:
             op1: first operation.
@@ -77,6 +86,8 @@ class CommutationChecker:
             op2: second operation.
             qargs2: second operation's qubits.
             cargs2: second operation's clbits.
+            max_num_qubits: the maximum number of qubits to consider, the check may be skipped if
+                the number of qubits for either operation exceeds this amount.
 
         Returns:
             bool: whether two operations commute.
@@ -104,6 +115,10 @@ class CommutationChecker:
         intersection_c = set(cargs1).intersection(set(cargs2))
         if not (intersection_q or intersection_c):
             return True
+
+        # Skip the check if the number of qubits for either operation is too large
+        if len(qargs1) > max_num_qubits or len(qargs2) > max_num_qubits:
+            return False
 
         # These lines are adapted from commutation_analysis, which is more restrictive than the
         # check from dag_dependency when considering nodes with "_directive".  It would be nice to

--- a/qiskit/circuit/commutation_checker.py
+++ b/qiskit/circuit/commutation_checker.py
@@ -75,9 +75,10 @@ class CommutationChecker:
         max_num_qubits: int = 3,
     ) -> bool:
         """
-        Checks if two Operations commute. The return value of `True` means that the operations truly commute,
-        and the return value of `False` means that either the operations do not commute or that the commutation
-        check was skipped (for example, when the operations have conditions or have too many qubits).
+        Checks if two Operations commute. The return value of `True` means that the operations
+        truly commute, and the return value of `False` means that either the operations do not
+        commute or that the commutation check was skipped (for example, when the operations
+        have conditions or have too many qubits).
 
         Args:
             op1: first operation.
@@ -92,6 +93,8 @@ class CommutationChecker:
         Returns:
             bool: whether two operations commute.
         """
+        # pylint: disable=too-many-return-statements
+
         # We don't support commutation of conditional gates for now due to bugs in
         # CommutativeCancellation.  See gh-8553.
         if (

--- a/releasenotes/notes/add-limits-in-commutation-checker-66a1b9e90921621f.yaml
+++ b/releasenotes/notes/add-limits-in-commutation-checker-66a1b9e90921621f.yaml
@@ -1,9 +1,14 @@
 ---
-fixes:
+features:
   - |
-    The maximum number of qubits to consider for matrix multiplication-based commutativity check
-    in :class:`~.CommutationChecker` is now limited to 3 by default. This avoids trying to
+    Added a new option ``max_num_qubits`` to :meth:`qiskit.circuit.CommutationChecker.commute`
+    that specifies the maximum number of qubits to consider for the more expensive
+    matrix multiplication-based commutativity check. This avoids trying to
     internally allocate arrays of size :math:`2^N \times 2^N`. Simpler versions of commutativity
     check (for instance, two quantum operations commute when they are over disjoint sets of qubits)
     continue to work without this limit.
+fixes:
+  - |
+    The maximum number of qubits to consider for matrix multiplication-based commutativity check
+    in :class:`~.CommutationChecker` is now limited to 3 by default.
     Fixed `#10488 <https://github.com/Qiskit/qiskit-terra/issues/10488>`__

--- a/releasenotes/notes/add-limits-in-commutation-checker-66a1b9e90921621f.yaml
+++ b/releasenotes/notes/add-limits-in-commutation-checker-66a1b9e90921621f.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    The maximum number of qubits to consider for matrix multiplication-based commutativity check
+    in :class:`~.CommutationChecker` is now limited to 3 by default. This avoids trying to
+    internally allocate arrays of size :math:`2^N \times 2^N`. Simpler versions of commutativity
+    check (for instance, two quantum operations commute when they are over disjoint sets of qubits)
+    continue to work without this limit.
+    Fixed `#10488 <https://github.com/Qiskit/qiskit-terra/issues/10488>`__

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -367,10 +367,14 @@ class TestCommutationChecker(QiskitTestCase):
         """Test that checking wide gates does not lead to memory problems."""
         res = CommutationChecker().commute(MCXGate(29), list(range(30)), [], XGate(), [0], [])
         self.assertFalse(res)
+        res = CommutationChecker().commute(XGate(), [0], [], MCXGate(29), list(range(30)), [])
+        self.assertFalse(res)
 
     def test_wide_gates_over_disjoint_qubits(self):
         """Test that wide gates still commute when they are over disjoint sets of qubits."""
         res = CommutationChecker().commute(MCXGate(29), list(range(30)), [], XGate(), [30], [])
+        self.assertTrue(res)
+        res = CommutationChecker().commute(XGate(), [30], [], MCXGate(29), list(range(30)), [])
         self.assertTrue(res)
 
 

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -25,6 +25,7 @@ from qiskit.circuit.library import (
     XGate,
     CXGate,
     CCXGate,
+    MCXGate,
     RZGate,
     Measure,
     Barrier,
@@ -361,6 +362,16 @@ class TestCommutationChecker(QiskitTestCase):
         qargs = [Qubit() for _ in [None] * 8]
         res = CommutationChecker().commute(XGate(), qargs[:1], [], XGate().control(7), qargs, [])
         self.assertFalse(res)
+
+    def test_wide_gates_over_nondisjoint_qubits(self):
+        """Test that checking wide gates does not lead to memory problems."""
+        res = CommutationChecker().commute(MCXGate(29), list(range(30)), [], XGate(), [0], [])
+        self.assertFalse(res)
+
+    def test_wide_gates_over_disjoint_qubits(self):
+        """Test that wide gates still commute when they are over disjoint sets of qubits."""
+        res = CommutationChecker().commute(MCXGate(29), list(range(30)), [], XGate(), [30], [])
+        self.assertTrue(res)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #10488.

The matrix-based commutativity check in `CommutationChecker` requires to construct `2^N x 2^N` matrices, leading to memory problems when `N` is large. 

I have added a new argument `max_num_qubits` to `CommutationChecker::commute` that allows to skip the commutativity check if the number of qubits of either operation exceeds this amount.

Note that simpler versions of the commutativity check not involving matrix multiplication continue to work as before (e.g., two quantum operations over disjoint sets of qubits commute regardless of the number of qubits).

### Details and comments

This actually changes the behavior of commutation checking when the number of qubits is in the range from 4 to 12 (when the matrices could be constructed and multiplied). However personally I don't think we will be missing a lot of optimization opportunities. I am even thinking that we should maybe limit `max_num_qubits` to 2, what are your thoughts on this?

Implementation-wise, I was a bit unsure whether to make `max_num_qubits` to be a global constant, or to pass it as the argument to `CommutationChecker::__init__`, or to pass it as the argument to `CommutationChecker::commute` (this is what I have chosen at the moment). I can see a potential use-case of having the same instance of `CommutationChecker`, and then first doing some optimizations based on a lighter-weight version of the check, and then possibly more optimizations based on heavier-weight version of the check (the same instance allows to use the cached results from previous calls).
