### PR TITLE
Implemented a type check in copy method of QuantumCircuit class

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2180,33 +2180,39 @@ class QuantumCircuit:
         """Copy the circuit.
 
         Args:
-          name (str): name to be given to the copied circuit. If None, then the name stays the same
+          name (str): name to be given to the copied circuit. If None, then the name stays the same.
+                      raises an error if type of name is not string or None type
 
         Returns:
           QuantumCircuit: a deepcopy of the current circuit, with the specified name
         """
-        cpy = self.copy_empty_like(name)
+        if isinstance(name, (type(" "), type(None))):
+            cpy = self.copy_empty_like(name)
 
-        operation_copies = {
-            id(instruction.operation): instruction.operation.copy() for instruction in self._data
-        }
-
-        cpy._parameter_table = ParameterTable(
-            {
-                param: ParameterReferences(
-                    (operation_copies[id(operation)], param_index)
-                    for operation, param_index in self._parameter_table[param]
-                )
-                for param in self._parameter_table
+            operation_copies = {
+                id(instruction.operation): instruction.operation.copy()
+                for instruction in self._data
             }
-        )
 
-        cpy._data = [
-            instruction.replace(operation=operation_copies[id(instruction.operation)])
-            for instruction in self._data
-        ]
+            cpy._parameter_table = ParameterTable(
+                {
+                    param: ParameterReferences(
+                        (operation_copies[id(operation)], param_index)
+                        for operation, param_index in self._parameter_table[param]
+                    )
+                    for param in self._parameter_table
+                }
+            )
 
-        return cpy
+            cpy._data = [
+                instruction.replace(operation=operation_copies[id(instruction.operation)])
+                for instruction in self._data
+            ]
+
+            return cpy
+        else:
+            # Raising error if type of name of copied circuit is not of string or None type
+            raise TypeError("The name of the copied circuit must be of 'string' or 'None' type")
 
     def copy_empty_like(self, name: str | None = None) -> "QuantumCircuit":
         """Return a copy of self with the same structure but empty.

--- a/releasenotes/notes/implement-type-check-in-copy-method-of-QuantumCircuit-class-ef18c8e0a5c4cb8d.yaml
+++ b/releasenotes/notes/implement-type-check-in-copy-method-of-QuantumCircuit-class-ef18c8e0a5c4cb8d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Forced a type check on 'name' argument in copy method of QuantumCircuit class hence fixing issues that may rise due to unsupported/unwanted types.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Forces the arguments to be of string or None type for copy method of QuantumCircuit Class hence solving issues that may rise due to unsupported/unwanted types.


### Details and comments
The code checks if the 'name' argument is of string or None type.
If 'name' is of string or None type, Then the following code creates a copy of the provided circuit.
Else, It raises a TypeError.

Closes #10487

