### PR TITLE
Move metapackage shim for combined releases

### DIFF
--- a/.azure/lint-linux.yml
+++ b/.azure/lint-linux.yml
@@ -35,7 +35,7 @@ jobs:
           set -e
           source test-job/bin/activate
           echo "Running black, any errors reported can be fixed with 'tox -eblack'"
-          black --check qiskit test tools examples setup.py
+          black --check qiskit test tools examples setup.py qiskit_pkg/setup.py
           echo "Running rustfmt check, any errors reported can be fixed with 'cargo fmt'"
           cargo fmt --check
         displayName: "Formatting"
@@ -44,7 +44,7 @@ jobs:
           set -e
           source test-job/bin/activate
           echo "Running ruff"
-          ruff qiskit test tools examples setup.py
+          ruff qiskit test tools examples setup.py qiskit_pkg/setup.py
           echo "Running pylint"
           pylint -rn qiskit test tools
           echo "Running Cargo Clippy"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include LICENSE.txt
+include extras.json
 include requirements.txt
 include qiskit/qasm/libs/*.inc
 include qiskit/VERSION.txt

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Qiskit Terra
+# Qiskit
 [![License](https://img.shields.io/github/license/Qiskit/qiskit-terra.svg?style=popout-square)](https://opensource.org/licenses/Apache-2.0)<!--- long-description-skip-begin -->[![Release](https://img.shields.io/github/release/Qiskit/qiskit-terra.svg?style=popout-square)](https://github.com/Qiskit/qiskit-terra/releases)[![Downloads](https://img.shields.io/pypi/dm/qiskit-terra.svg?style=popout-square)](https://pypi.org/project/qiskit-terra/)[![Coverage Status](https://coveralls.io/repos/github/Qiskit/qiskit-terra/badge.svg?branch=main)](https://coveralls.io/github/Qiskit/qiskit-terra?branch=main)[![Minimum rustc 1.61.0](https://img.shields.io/badge/rustc-1.61.0+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)<!--- long-description-skip-end -->
 
 **Qiskit** is an open-source framework for working with noisy quantum computers at the level of pulses, circuits, and algorithms.
 
-This library is the core component of Qiskit, **Terra**, which contains the building blocks for creating
-and working with quantum circuits, programs, and algorithms. It also contains a compiler that supports
-different quantum computers and a common interface for running programs on different quantum computer architectures.
+This Qiskit contains the building blocks for creating and working with quantum circuits, programs, and algorithms. It also
+contains a compiler that supports different quantum computers and a common interface for running programs on different quantum
+computer architectures.
 
 For more details on how to use Qiskit you can refer to the documentation located here:
 
@@ -14,7 +14,7 @@ https://qiskit.org/documentation/
 
 ## Installation
 
-We encourage installing Qiskit via ``pip``. The following command installs the core Qiskit components, including Terra.
+We encourage installing Qiskit via ``pip``.
 
 ```bash
 pip install qiskit
@@ -24,7 +24,7 @@ Pip will handle all dependencies automatically and you will always install the l
 
 To install from source, follow the instructions in the [documentation](https://qiskit.org/documentation/contributing_to_qiskit.html#install-install-from-source-label).
 
-## Creating Your First Quantum Program in Qiskit Terra
+## Creating Your First Quantum Program in Qiskit
 
 Now that Qiskit is installed, it's time to begin working with Qiskit. To do this
 we create a `QuantumCircuit` object to define a basic quantum program.
@@ -94,7 +94,7 @@ on how to get access and use these systems.
 
 ## Contribution Guidelines
 
-If you'd like to contribute to Qiskit Terra, please take a look at our
+If you'd like to contribute to Qiskit, please take a look at our
 [contribution guidelines](CONTRIBUTING.md). This project adheres to Qiskit's [code of conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
 
 We use [GitHub issues](https://github.com/Qiskit/qiskit-terra/issues) for tracking requests and bugs. Please
@@ -109,7 +109,7 @@ Now you're set up and ready to check out some of the other examples from our
 
 ## Authors and Citation
 
-Qiskit Terra is the work of [many people](https://github.com/Qiskit/qiskit-terra/graphs/contributors) who contribute
+Qiskit is the work of [many people](https://github.com/Qiskit/qiskit-terra/graphs/contributors) who contribute
 to the project at different levels. If you use Qiskit, please cite as per the included [BibTeX file](CITATION.bib).
 
 ## Changelog and Release Notes

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -262,3 +262,21 @@ stages:
               env:
                 TWINE_USERNAME: "qiskit"
                 TWINE_PASSWORD: $(TWINE_PASSWORD)
+        - job: 'qiskit-pkg'
+          pool: {vmImage: 'ubuntu-latest'}
+          steps:
+            - task: UsePythonVersion@0
+            - bash: |
+                set -e
+                python -m pip install --upgrade pip build
+                cd qiskit_pkg
+                python -m build .
+            - task: PublishBuildArtifacts@1
+              inputs: {pathtoPublish: 'dist'}
+              condition: succeededOrFailed()
+            - bash: |
+                python -m pip install --upgrade twine
+                twine upload dist/*
+              env:
+                TWINE_USERNAME: "qiskit"
+                TWINE_PASSWORD: $(TWINE_PASSWORD)

--- a/extras.json
+++ b/extras.json
@@ -1,0 +1,6 @@
+{
+  "qasm3-import": ["qiskit-qasm3-import>=0.1.0"],
+  "visualization": ["matplotlib>=3.3", "ipywidgets>=7.3.0", "pydot", "pillow>=4.2.1", "pylatexenc>=1.4", "seaborn>=0.9.0", "pygments>=2.4"],
+  "crosstalk-pass": ["z3-solver>=4.7"],
+  "csp-layout-pass": ["python-constraint>=1.4"]
+}

--- a/qiskit_pkg/LICENSE.txt
+++ b/qiskit_pkg/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/qiskit_pkg/MANIFEST.in
+++ b/qiskit_pkg/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE.txt
+include extras.json
+include README

--- a/qiskit_pkg/README.md
+++ b/qiskit_pkg/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/qiskit_pkg/extras.json
+++ b/qiskit_pkg/extras.json
@@ -1,0 +1,1 @@
+../extras.json

--- a/qiskit_pkg/setup.py
+++ b/qiskit_pkg/setup.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# This file is the setup.py file for the qiskit package. Because python
+# packaging doesn't offer a mechanism to have qiskit supersede qiskit-terra
+# and cleanly upgrade from one to the other, there needs to be a separate
+# package always needs
+
+import json
+import os
+
+from setuptools import setup
+
+README_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md")
+with open(README_PATH) as readme_file:
+    README = readme_file.read()
+
+EXTRAS_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "extras.json")
+with open(EXTRAS_PATH) as fd:
+    extras_dict = json.load(fd)
+
+extras_dict["all"] = [pkg for requirements in extras_dict.values() for pkg in requirements]
+
+requirements = ["qiskit-terra==0.45.0"]
+
+setup(
+    name="qiskit",
+    version="0.45.0",
+    description="Software for developing quantum computing programs",
+    long_description=README,
+    long_description_content_type="text/markdown",
+    url="https://qiskit.org/",
+    author="Qiskit Development Team",
+    author_email="hello@qiskit.org",
+    license="Apache 2.0",
+    py_modules=[],
+    packages=[],
+    classifiers=[
+        "Environment :: Console",
+        "License :: OSI Approved :: Apache Software License",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Science/Research",
+        "Operating System :: Microsoft :: Windows",
+        "Operating System :: MacOS",
+        "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Topic :: Scientific/Engineering",
+    ],
+    keywords="qiskit sdk quantum",
+    install_requires=requirements,
+    project_urls={
+        "Bug Tracker": "https://github.com/Qiskit/qiskit/issues",
+        "Documentation": "https://qiskit.org/documentation/",
+        "Source Code": "https://github.com/Qiskit/qiskit",
+    },
+    include_package_data=True,
+    python_requires=">=3.8",
+    extras_require=extras_dict,
+)

--- a/releasenotes/notes/remove-toqm-optional-extra-90e974b64ec4a3bd.yaml
+++ b/releasenotes/notes/remove-toqm-optional-extra-90e974b64ec4a3bd.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    The ``toqm`` optional setuptools extra that previously enabled running
+    ``pip install qiskit-terra[topm]`` has been removed as nothing in the
+    Qiskit code base is currently using that package anymore. If you'd like
+    to use the qiskit TOQM transpiler plugin you should install the
+    ``qiskit-toqm`` package directly.

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@
 
 "The Qiskit Terra setup file."
 
+import json
 import os
 import re
 from setuptools import setup, find_packages
@@ -36,25 +37,11 @@ with open(README_PATH) as readme_file:
 # it's an editable installation.
 rust_debug = True if os.getenv("RUST_DEBUG") == "1" else None
 
+with open("extras.json") as fd:
+    extras_dict = json.load(fd)
 
-qasm3_import_extras = [
-    "qiskit-qasm3-import>=0.1.0",
-]
-visualization_extras = [
-    "matplotlib>=3.3",
-    "ipywidgets>=7.3.0",
-    "pydot",
-    "pillow>=4.2.1",
-    "pylatexenc>=1.4",
-    "seaborn>=0.9.0",
-    "pygments>=2.4",
-]
-z3_requirements = [
-    "z3-solver>=4.7",
-]
-bip_requirements = ["cplex", "docplex"]
-csp_requirements = ["python-constraint>=1.4"]
-toqm_requirements = ["qiskit-toqm>=0.1.0"]
+extras_dict["all"] = [pkg for requirements in extras_dict.values() for pkg in requirements]
+
 
 setup(
     name="qiskit-terra",
@@ -86,17 +73,7 @@ setup(
     install_requires=REQUIREMENTS,
     include_package_data=True,
     python_requires=">=3.8",
-    extras_require={
-        "qasm3-import": qasm3_import_extras,
-        "visualization": visualization_extras,
-        "bip-mapper": bip_requirements,
-        "crosstalk-pass": z3_requirements,
-        "csp-layout-pass": csp_requirements,
-        "toqm": toqm_requirements,
-        # Note: 'all' only includes extras that are stable and work on the majority of Python
-        # versions and OSes supported by Terra. You have to ask for anything else explicitly.
-        "all": visualization_extras + z3_requirements + csp_requirements + qasm3_import_extras,
-    },
+    extras_require=extras_dict,
     project_urls={
         "Bug Tracker": "https://github.com/Qiskit/qiskit-terra/issues",
         "Documentation": "https://qiskit.org/documentation/",

--- a/tox.ini
+++ b/tox.ini
@@ -24,8 +24,8 @@ commands =
 [testenv:lint]
 basepython = python3
 commands =
-  ruff check qiskit test tools examples setup.py
-  black --check {posargs} qiskit test tools examples setup.py
+  ruff check qiskit test tools examples setup.py qiskit_pkg/setup.py
+  black --check {posargs} qiskit test tools examples setup.py qiskit_pkg/setup.py
   pylint -rn qiskit test tools
   # This line is commented out until #6649 merges. We can't run this currently
   # via tox because tox doesn't support globbing
@@ -39,8 +39,8 @@ commands =
 basepython = python3
 allowlist_externals = git
 commands =
-  ruff check qiskit test tools examples setup.py
-  black --check {posargs} qiskit test tools examples setup.py
+  ruff check qiskit test tools examples setup.py qiskit_pkg/setup.py
+  black --check {posargs} qiskit test tools examples setup.py qiskit_pkg/setup.py
   -git fetch -q https://github.com/Qiskit/qiskit-terra.git :lint_incr_latest
   python {toxinidir}/tools/pylint_incr.py -rn -j4 -sn --paths :/qiskit/*.py :/test/*.py :/tools/*.py
   python {toxinidir}/tools/pylint_incr.py -rn -j4 -sn --disable='invalid-name,missing-module-docstring,redefined-outer-name' --paths :(glob,top)examples/python/*.py
@@ -50,7 +50,7 @@ commands =
   reno lint
 
 [testenv:black]
-commands = black {posargs} qiskit test tools examples setup.py
+commands = black {posargs} qiskit test tools examples setup.py qiskit_pkg/setup.py
 
 [testenv:coverage]
 basepython = python3


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Now that Qiskit 0.44.0 has been released, the Qiskit project is now what was formerly qiskit-terra. However, because Python packaging lacks a clean mechanism to enable one package superseding another we're not able to stop shipping a qiskit-terra package that owns the qiskit python namespace without introducing a lot of potential user friction. So moving forward the qiskit project will release 2 packages an inner qiskit-terra which still contains all the library code and public facing qiskit package which installs that inner package  only. To enable this workflow this commit migrates the metapackage setup.py into the terra repository and setups build automation to publish a qiskit package in addition to the inner terra package on each release tag.

### Details and comments