### PR TITLE
Force decimal points in OpenQASM 2 floats

### DIFF
--- a/qiskit/circuit/tools/pi_check.py
+++ b/qiskit/circuit/tools/pi_check.py
@@ -167,12 +167,11 @@ def pi_check(inpt, eps=1e-9, output="text", ndigits=None):
                 str_out = f"{neg_str}{numer}/{denom}{pi}"
             return str_out
 
-        # Nothing found
-        if ndigits is None:
-            str_out = "{}".format(single_inpt)
-        else:
-            str_out = "{:.{}g}".format(single_inpt, ndigits)
-        return str_out
+        # Nothing found.  The '#' forces a decimal point to be included, which OQ2 needs, but other
+        # formats don't really.
+        if output == "qasm":
+            return f"{single_inpt:#}" if ndigits is None else f"{single_inpt:#.{ndigits}g}"
+        return f"{single_inpt}" if ndigits is None else f"{single_inpt:.{ndigits}g}"
 
     complex_inpt = complex(inpt)
     real, imag = map(normalize, [complex_inpt.real, complex_inpt.imag])

--- a/releasenotes/notes/qasm2-float-decimal-76b44281d9249f7a.yaml
+++ b/releasenotes/notes/qasm2-float-decimal-76b44281d9249f7a.yaml
@@ -2,7 +2,7 @@
 fixes:
   - |
     Angles in the OpenQASM 2 exporter (:func:`.QuantumCircuit.qasm`) will now always include a
-    decimal point, for example in the case of ``1.e-5``.  This is required by the letter of the
+    decimal point, for example in the case of ``1.e-5``.  This is required by a strict interpretation of the
     floating-point-literal specification in OpenQASM 2.  Qiskit's OpenQASM 2 parser
     (:func:`.qasm2.load` and :func:`~.qasm2.loads`) is more permissive by default, and will allow
     ``1e-5`` without the decimal point unless in ``strict`` mode.

--- a/releasenotes/notes/qasm2-float-decimal-76b44281d9249f7a.yaml
+++ b/releasenotes/notes/qasm2-float-decimal-76b44281d9249f7a.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Angles in the OpenQASM 2 exporter (:func:`.QuantumCircuit.qasm`) will now always include a
+    decimal point, for example in the case of ``1.e-5``.  This is required by the letter of the
+    floating-point-literal specification in OpenQASM 2.  Qiskit's OpenQASM 2 parser
+    (:func:`.qasm2.load` and :func:`~.qasm2.loads`) is more permissive by default, and will allow
+    ``1e-5`` without the decimal point unless in ``strict`` mode.

--- a/test/python/circuit/test_circuit_qasm.py
+++ b/test/python/circuit/test_circuit_qasm.py
@@ -846,6 +846,20 @@ barrier qr1[0],qr1[1],qr2[0],qr2[1],qr2[2];
 """
         self.assertEqual(qc.qasm(), expected)
 
+    def test_small_angle_valid(self):
+        """Test that small angles do not get converted to invalid OQ2 floating-point values."""
+        # OQ2 _technically_ requires a decimal point in all floating-point values, even ones that
+        # are followed by an exponent.
+        qc = QuantumCircuit(1)
+        qc.rx(0.000001, 0)
+        expected = """\
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[1];
+rx(1.e-06) q[0];
+"""
+        self.assertEqual(qc.qasm(), expected)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Summary

The letter of the OpenQASM 2 specification has a regex defining floating-point literals that requires a decimal point, even in the presence of an exponential component.  This is unusual for most programming languages, but Qiskit's exporter should follow the spec as close as we can to increase interop.  Our parser accepts floats with an exponent and no decimal point as a minor syntax extension, unless in strict mode.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Fix #10531.
