### PR TITLE
Fixed  qiskit.transpiler.passes.DynamicalDecoupling depreciation note

### DIFF
--- a/qiskit/transpiler/passes/scheduling/dynamical_decoupling.py
+++ b/qiskit/transpiler/passes/scheduling/dynamical_decoupling.py
@@ -92,7 +92,7 @@ class DynamicalDecoupling(TransformationPass):
 
     @deprecate_func(
         additional_msg=(
-            "Instead, use :class:`~.DynamicalDecouplingPadding`, which performs the same "
+            "Instead, use :class:`~.PadDynamicalDecoupling`, which performs the same "
             "function but requires scheduling and alignment analysis passes to run prior to it."
         ),
         since="0.21.0",


### PR DESCRIPTION
It fixes #10442
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Replaced `DynamicalDecouplingPadding` to `PadDynamicalDecoupling`.


### Details and comments


