### PR TITLE
Update deprecated textbook URL in phase estimation docstring

### DIFF
--- a/qiskit/circuit/library/phase_estimation.py
+++ b/qiskit/circuit/library/phase_estimation.py
@@ -44,7 +44,7 @@ class PhaseEstimation(QuantumCircuit):
          Cambridge University Press, New York, NY, USA.
 
     [3]: Qiskit
-        `textbook <https://qiskit.org/textbook/ch-algorithms/quantum-phase-estimation.html>`_
+        `textbook <https://learn.qiskit.org/course/ch-algorithms/quantum-phase-estimation>`_
 
     """
 


### PR DESCRIPTION
### Summary
The previous Qiskit textbook URL referenced in the phase estimation docstring is no longer reachable. This commit updates the URL to point to the current location of the relevant textbook recourse.

### Details and comments
Resolves #10535
No functional code changes; only the docstring was changed.

Old URL: https://qiskit.org/textbook/ch-algorithms/quantum-phase-estimation.html
New URL: https://learn.qiskit.org/course/ch-algorithms/quantum-phase-estimation




