### PR TITLE
Disable Numpy-style docstring handling in Napoleon

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,7 @@ extensions = [
     "reno.sphinxext",
     "sphinx_design",
     "matplotlib.sphinxext.plot_directive",
-    "sphinx.ext.doctest"
+    "sphinx.ext.doctest",
 ]
 
 templates_path = ["_templates"]
@@ -123,6 +123,12 @@ autosummary_filename_map = {
 }
 
 autoclass_content = "both"
+
+# We only use Google-style docstrings, and allowing Napoleon to parse Numpy-style docstrings both
+# slows down the build (a little) and can sometimes result in _regular_ section headings in
+# module-level documentation being converted into surprising things.
+napoleon_google_docstring = True
+napoleon_numpy_docstring = False
 
 
 # -- Options for Doctest --------------------------------------------------------


### PR DESCRIPTION
### Summary

We only use Google-style docstrings, so disabling the Numpy-style parsing gives us a bit of speed boost in the documentation build.  More importantly, it fixes an issue where headings whose names clashed with a specially handled keyword such as

        Examples
        ========

used in module-level documentation as true sections would get translated into `rubric` elements, so would lose their section-heading status, confusing the toctree structure and the output display.

I noticed this in the `qiskit.qasm2` module-level documentation, but it's possible that it appeared elsewhere as well.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

At the time of writing, see [the built documentation for `qiskit.qasm2`](https://qiskit.org/documentation/apidoc/qasm2.html).  The section heading "Examples" is correct in the source code, but has not produced a proper section here:

<img width="722" alt="Screenshot 2023-08-03 at 17 38 56" src="https://github.com/Qiskit/qiskit-terra/assets/5968590/d0ccb541-4d40-4e01-8e1a-3e061e05073d">

This PR fixes that, so it appears at the same level as "Errors" and appears in the toctree, etc.