### PR TITLE
Increase heuristic effort for sabre

### DIFF
--- a/crates/accelerate/src/sabre_swap/mod.rs
+++ b/crates/accelerate/src/sabre_swap/mod.rs
@@ -47,7 +47,7 @@ use swap_map::SwapMap;
 
 const BEST_EPSILON: f64 = 1e-10; // Epsilon used in minimum-score calculations.
 
-const EXTENDED_SET_SIZE: usize = 20; // Size of lookahead window.
+const EXTENDED_SET_SIZE: usize = 72; // Size of lookahead window.
 const DECAY_RATE: f64 = 0.001; // Decay coefficient for penalizing serial swaps.
 const DECAY_RESET_INTERVAL: u8 = 5; // How often to reset all decay rates to 1.
 const EXTENDED_SET_WEIGHT: f64 = 0.5; // Weight of lookahead window compared to front_layer.

--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -150,10 +150,10 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
     elif layout_method == "sabre":
         _improve_layout = SabreLayout(
             coupling_map_layout,
-            max_iterations=2,
+            max_iterations=10,
             seed=seed_transpiler,
-            swap_trials=5,
-            layout_trials=5,
+            swap_trials=25,
+            layout_trials=25,
             skip_routing=pass_manager_config.routing_method is not None
             and routing_method != "sabre",
         )

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -140,10 +140,10 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
     elif layout_method == "sabre":
         _choose_layout_1 = SabreLayout(
             coupling_map_layout,
-            max_iterations=2,
+            max_iterations=10,
             seed=seed_transpiler,
-            swap_trials=10,
-            layout_trials=10,
+            swap_trials=50,
+            layout_trials=50,
             skip_routing=pass_manager_config.routing_method is not None
             and routing_method != "sabre",
         )

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -146,10 +146,10 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
     elif layout_method == "sabre":
         _choose_layout_1 = SabreLayout(
             coupling_map_layout,
-            max_iterations=4,
+            max_iterations=20,
             seed=seed_transpiler,
-            swap_trials=20,
-            layout_trials=20,
+            swap_trials=100,
+            layout_trials=100,
             skip_routing=pass_manager_config.routing_method is not None
             and routing_method != "sabre",
         )


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit increases the heuristic effort for sabre layout and routing. This is made through 2 changes, the first is the depth of the internal lookahead heuristic used in sabre swap has been increased from 20 to 72. This is just a stop-gap for a potential reworking of the lookahead heuristic. In local testing for larger backends and deeper circuits in this is showing better output results than the current default of 20 without any runtime impact. The other aspect is that the trial counts for each optimization level > 0 is increased 5x. This has a runtime cost, but it the performance of the rust sabre implementation is fast enough that even running the algorithm with more trials it is not a bottleneck for typical compilation.

### Details and comments

Related to #10160