### PR TITLE
Change 1q UnitaryGate definition to use U instead of U3

### DIFF
--- a/qiskit/extensions/unitary.py
+++ b/qiskit/extensions/unitary.py
@@ -21,7 +21,7 @@ from qiskit.circuit import QuantumCircuit
 from qiskit.circuit import QuantumRegister, Qubit
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit._utils import _compute_control_matrix
-from qiskit.circuit.library.standard_gates import U3Gate
+from qiskit.circuit.library.standard_gates import UGate
 from qiskit.extensions.quantum_initializer import isometry
 from qiskit.quantum_info.operators.predicates import matrix_equal
 from qiskit.quantum_info.operators.predicates import is_unitary_matrix
@@ -29,7 +29,7 @@ from qiskit.quantum_info.synthesis.one_qubit_decompose import OneQubitEulerDecom
 from qiskit.quantum_info.synthesis.two_qubit_decompose import two_qubit_cnot_decompose
 from qiskit.extensions.exceptions import ExtensionError
 
-_DECOMPOSER1Q = OneQubitEulerDecomposer("U3")
+_DECOMPOSER1Q = OneQubitEulerDecomposer("U")
 
 
 class UnitaryGate(Gate):
@@ -125,7 +125,7 @@ class UnitaryGate(Gate):
             q = QuantumRegister(1, "q")
             qc = QuantumCircuit(q, name=self.name)
             theta, phi, lam, global_phase = _DECOMPOSER1Q.angles_and_phase(self.to_matrix())
-            qc._append(U3Gate(theta, phi, lam), [q[0]], [])
+            qc._append(UGate(theta, phi, lam), [q[0]], [])
             qc.global_phase = global_phase
             self.definition = qc
         elif self.num_qubits == 2:

--- a/releasenotes/notes/unitary-u-not-u3-0a32c2d968f7890e.yaml
+++ b/releasenotes/notes/unitary-u-not-u3-0a32c2d968f7890e.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    the definition of UnitaryGate for single qubit unitaries is now in terms of UGate instead of the legacy U3Gate class

--- a/test/python/circuit/test_circuit_qasm.py
+++ b/test/python/circuit/test_circuit_qasm.py
@@ -348,7 +348,7 @@ ecr q[1],q[0];
         qasm = qc.qasm()
         expected = """OPENQASM 2.0;
 include "qelib1.inc";
-gate unitary q0 { u3(0,0,0) q0; }
+gate unitary q0 { u(0,0,0) q0; }
 qreg q[1];
 unitary q[0];
 """
@@ -367,9 +367,9 @@ unitary q[0];
         expected = re.compile(
             r"""OPENQASM 2.0;
 include "qelib1.inc";
-gate unitary q0 { u3\(0,0,0\) q0; }
-gate (?P<u1>unitary_[0-9]*) q0 { u3\(pi,-pi/2,pi/2\) q0; }
-gate (?P<u2>unitary_[0-9]*) q0 { u3\(0,pi/2,pi/2\) q0; }
+gate unitary q0 { u\(0,0,0\) q0; }
+gate (?P<u1>unitary_[0-9]*) q0 { u\(pi,-pi/2,pi/2\) q0; }
+gate (?P<u2>unitary_[0-9]*) q0 { u\(0,pi/2,pi/2\) q0; }
 gate custom q0 { (?P=u2) q0; }
 qreg q\[2\];
 unitary q\[0\];

--- a/test/python/circuit/test_unitary.py
+++ b/test/python/circuit/test_unitary.py
@@ -217,7 +217,7 @@ class TestUnitaryCircuit(QiskitTestCase):
         expected_qasm = (
             "OPENQASM 2.0;\n"
             'include "qelib1.inc";\n'
-            "gate unitary q0 { u3(0,0,0) q0; }\n"
+            "gate unitary q0 { u(0,0,0) q0; }\n"
             "qreg q0[2];\ncreg c0[1];\n"
             "x q0[0];\n"
             "unitary q0[0];\n"
@@ -241,7 +241,7 @@ class TestUnitaryCircuit(QiskitTestCase):
         expected_qasm = (
             "OPENQASM 2.0;\n"
             'include "qelib1.inc";\n'
-            "gate unitary q0 { u3(0,0,0) q0; }\n"
+            "gate unitary q0 { u(0,0,0) q0; }\n"
             "qreg q0[2];\ncreg c0[1];\n"
             "x q0[0];\n"
             "unitary q0[0];\n"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Replaced U3 with U gate so that when I decompose it uses U not U3 as U is the gate going forward. 

### Details and comments


