### PR TITLE
Fix VF2Layout passes with ideal gate in Target

### DIFF
--- a/qiskit/transpiler/passes/layout/vf2_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_layout.py
@@ -145,10 +145,21 @@ class VF2Layout(AnalysisPass):
         # Filter qubits without any supported operations. If they don't support any operations
         # They're not valid for layout selection
         if self.target is not None:
-            has_operations = set(itertools.chain.from_iterable(self.target.qargs))
-            to_remove = set(range(len(cm_nodes))).difference(has_operations)
-            if to_remove:
-                cm_graph.remove_nodes_from([cm_nodes[i] for i in to_remove])
+            has_none = False
+            has_operations = set()
+            for qarg in self.target.qargs:
+                if qarg is None:
+                    has_none = True
+                else:
+                    has_operations.update(qarg)
+            # If there are defined operations or if has_operations is empty and there are
+            # no globally defined gates. If has_none was true and there are no operations
+            # defined that means all operations are supported on all qubits and there is
+            # nothing to remove.
+            if has_operations or not has_none:
+                to_remove = set(range(len(cm_nodes))).difference(has_operations)
+                if to_remove:
+                    cm_graph.remove_nodes_from([cm_nodes[i] for i in to_remove])
 
         # To avoid trying to over optimize the result by default limit the number
         # of trials based on the size of the graphs. For circuits with simple layouts

--- a/qiskit/transpiler/passes/layout/vf2_post_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_post_layout.py
@@ -222,10 +222,21 @@ class VF2PostLayout(AnalysisPass):
             # mode the node matcher will not match since none of the circuit ops
             # will match the cmap ops.
             if not self.strict_direction:
-                has_operations = set(itertools.chain.from_iterable(self.target.qargs))
-                to_remove = set(cm_graph.node_indices()).difference(has_operations)
+                has_none = False
+            has_operations = set()
+            for qarg in self.target.qargs:
+                if qarg is None:
+                    has_none = True
+                else:
+                    has_operations.update(qarg)
+            # If there are defined operations or if has_operations is empty and there are
+            # no globally defined gates. If has_none was true and there are no operations
+            # defined that means all operations are supported on all qubits and there is
+            # nothing to remove.
+            if has_operations or not has_none:
+                to_remove = set(range(len(cm_nodes))).difference(has_operations)
                 if to_remove:
-                    cm_graph.remove_nodes_from(list(to_remove))
+                    cm_graph.remove_nodes_from([cm_nodes[i] for i in to_remove])
         else:
             cm_graph, cm_nodes = vf2_utils.shuffle_coupling_graph(
                 self.coupling_map, self.seed, self.strict_direction

--- a/releasenotes/notes/fix-vf2-ideal-gate-eaf6f96d31f6989b.yaml
+++ b/releasenotes/notes/fix-vf2-ideal-gate-eaf6f96d31f6989b.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Fixed an issue in the :class:`~.VF2Layout` and :class:`~.VF2PostLayout`
+    transpiler passes when run with a :class:`~.Target` containing an ideal
+    globally implemented gate. Previously, in cases where the
+    :class:`~.Target` contained a gate represented with properties set to
+    ``None`` which was used to indicate an ideal globally implemented gate
+    (such as in ideal simulation) the passes would error trying to compute
+    which qubits have operations on them.
+    Fixed `#10604 <https://github.com/Qiskit/qiskit-terra/issues/10604>`__


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue in the VF2Layout and VF2PostLayout passes. Previously, when detecting which qubits had operations on it was not correctly handling the situation when the qargs in the target contained None. This is a valid value for the Target as it represent an ideal gate on all qubits (e.g. from a simulator). This commit fixes that by skipping the None, as that is how the operation checking is handled elsewhere.

### Details and comments

Fixes #10604