### PR TITLE
Fix repository_owner condition docs_deploy gha job

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build:
-    if: github.repository_owner == "Qiskit"
+    if: github.repository_owner == 'Qiskit'
     name: Build
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue in the job definition for the new docs deployment job added in #10610. The new jobs are conditioned to only execute from the Qiskit/qiskit-terra repo. However that line is being flagged as a syntax error in github. This seems to be due to the double quotes used for `"Qiskit"`. A similar condition exists on the pre-existing github actions jobs but they use a single quote instead of a double and they function correctly. This commit updates the condition to used single quotes to match the working syntax in other jobs.

### Details and comments