### PR TITLE
Diagonal  now supports sparse input (dict)

### DIFF
--- a/qiskit/circuit/library/__init__.py
+++ b/qiskit/circuit/library/__init__.py
@@ -492,6 +492,7 @@ from ..reset import Reset
 from .blueprintcircuit import BlueprintCircuit
 from .generalized_gates import (
     Diagonal,
+    _dict_to_list,
     MCMT,
     MCMTVChain,
     Permutation,

--- a/qiskit/circuit/library/generalized_gates/__init__.py
+++ b/qiskit/circuit/library/generalized_gates/__init__.py
@@ -12,7 +12,7 @@
 
 """The circuit library module on generalized gates."""
 
-from .diagonal import Diagonal
+from .diagonal import Diagonal, _dict_to_list
 from .permutation import Permutation, PermutationGate
 from .mcmt import MCMT, MCMTVChain
 from .gms import GMS, MSGate

--- a/qiskit/circuit/library/generalized_gates/diagonal.py
+++ b/qiskit/circuit/library/generalized_gates/diagonal.py
@@ -71,21 +71,22 @@ class Diagonal(QuantumCircuit):
     `arXiv:0406176 <https://arxiv.org/pdf/quant-ph/0406176.pdf>`_
     """
 
-    def __init__(self, diag: list[complex] | np.ndarray) -> None:
+    def __init__(self, diag_dict: dict) -> None:
         """Create a new Diagonal circuit.
 
         Args:
-            diag: list of the 2^k diagonal entries (for a diagonal gate on k qubits).
+            diag: dict of the diagonal entries which are not 1.
 
         Raises:
-            CircuitError: if the list of the diagonal entries or the qubit list is in bad format;
-                if the number of diagonal entries is not 2^k, where k denotes the number of qubits
+            CircuitError: if the dictionary of the diagonal entries are in bad format;
+                          if absolute value of any entry is not 1.
         """
-        if not isinstance(diag, (list, np.ndarray)):
-            raise CircuitError("Diagonal entries must be in a list or numpy array.")
+        diag = _dict_to_list(diag_dict)
+        if not isinstance(diag_dict, dict):
+            raise CircuitError("Diagonal entries must be dictionary.")
         num_qubits = np.log2(len(diag))
-        if num_qubits < 1 or not num_qubits.is_integer():
-            raise CircuitError("The number of diagonal entries is not a positive power of 2.")
+        # if num_qubits < 1 or not num_qubits.is_integer():
+        # raise CircuitError("The number of diagonal entries is not a positive power of 2.")
         if not np.allclose(np.abs(diag), 1, atol=_EPS):
             raise CircuitError("A diagonal element does not have absolute value one.")
 
@@ -121,3 +122,20 @@ def _extract_rz(phi1, phi2):
     phase = (phi1 + phi2) / 2.0
     z_angle = phi2 - phi1
     return phase, z_angle
+
+
+# Returns size of Diagonal or 2^k
+def _exp_two(n: int) -> int:
+    i = 1
+    while i <= n:
+        i *= 2
+    return i
+
+
+# Convert dictionary to list
+def _dict_to_list(d: dict) -> list:
+    diag_list = [1] * _exp_two(max(d))
+    for i in range(len(diag_list)):
+        if i in d:
+            diag_list[i] = d[i]
+    return diag_list

--- a/releasenotes/notes/diagonal_class_sparse_input-ace4c68537963766.yaml
+++ b/releasenotes/notes/diagonal_class_sparse_input-ace4c68537963766.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Introduced sparse inputs in :class:`.circuit.library.Diagonal(diag)` objects. 
+    For scalability, input type is changed to dictionary type. For more refer to:
+    `#10567 <https://github.com/Qiskit/qiskit-terra/issues/10567>`
+    

--- a/test/python/circuit/library/test_diagonal.py
+++ b/test/python/circuit/library/test_diagonal.py
@@ -17,7 +17,7 @@ from ddt import ddt, data
 import numpy as np
 
 from qiskit.test.base import QiskitTestCase
-from qiskit.circuit.library import Diagonal
+from qiskit.circuit.library import Diagonal, _dict_to_list
 from qiskit.quantum_info import Statevector, Operator
 from qiskit.quantum_info.operators.predicates import matrix_equal
 
@@ -37,8 +37,12 @@ class TestDiagonalGate(QiskitTestCase):
     )
     def test_diag_gate(self, phases):
         """Test correctness of diagonal decomposition."""
-        diag = [np.exp(1j * ph) for ph in phases]
-        qc = Diagonal(diag)
+        diag_dict = {}
+        for ph in phases:
+            i = np.random.randint(0, 16)
+            diag_dict[i] = np.exp(1j * ph)
+        diag = _dict_to_list(diag_dict)
+        qc = Diagonal(diag_dict)
         simulated_diag = Statevector(Operator(qc).data.diagonal()).data
         ref_diag = Statevector(diag).data
 


### PR DESCRIPTION
It fixes #10567 
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Changed `list` type to `dict` in `qiskit.circuit.library.Diagonal(diag)`.

### Details and comments


