### PR TITLE
Pin sphinx version to less than 7.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -31,7 +31,7 @@ ddt>=1.2.0,!=1.4.0,!=1.4.3
 # components of Terra use some of its optional dependencies in order to document
 # themselves.  These are the requirements that are _only_ required for the docs
 # build, and are not used by Terra itself.
-Sphinx>=6.0
+Sphinx>=6.0,<7.2
 qiskit-sphinx-theme~=1.14.0
 sphinx-design>=0.2.0
 sphinx-remove-toctrees


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The recent Sphinx 7.2 release is causing errors during docs jobs around the furo style sheet. There seems to be a compatibility issue between furo, qiskit_sphinx_theme, and this new Sphinx release. While the issue is getting resolved this commit pins the sphinx version we use in CI and for local docs builds to avoid the new release.

### Details and comments

See https://github.com/sphinx-doc/sphinx/issues/11608 for details