### PR TITLE
[WIP] Added support for 0 qubit gate visualization (I.e. global phase gate)

### DIFF
--- a/qiskit/visualization/circuit/_utils.py
+++ b/qiskit/visualization/circuit/_utils.py
@@ -472,8 +472,6 @@ def _get_layered_instructions(
             if wire in clbits:
                 clbits.remove(wire)
 
-    # nodes = [[node for node in layer if len(node.qargs) == 0 or any(q in qubits for q in node.qargs)] for layer in nodes] -> remove when confirm not needed
-
     return qubits, clbits, nodes
 
 
@@ -556,12 +554,16 @@ class _LayerSpooler(list):
                 for node in dag_nodes:
                     self.add(node, current_index)
 
-        i = 0
         # adds operators that don't work on any bit
+        zero_operator_count = 0
         for node in dag.topological_op_nodes():
             if node.num_qubits == 0 and node.num_clbits == 0:
-                self.insert(i, [node])
-                i += 1  # used to ensure order matches that of which the user added the gates
+                self.insert(
+                    zero_operator_count, [node]
+                )  # adds to start of circuit -> gates don't have layer information
+                zero_operator_count += (
+                    1  # used to ensure order matches that of which the user added the gates
+                )
 
     def is_found_in(self, node, nodes):
         """Is any qreq in node found in any of nodes?"""

--- a/qiskit/visualization/circuit/_utils.py
+++ b/qiskit/visualization/circuit/_utils.py
@@ -472,7 +472,7 @@ def _get_layered_instructions(
             if wire in clbits:
                 clbits.remove(wire)
 
-    nodes = [[node for node in layer if any(q in qubits for q in node.qargs)] for layer in nodes]
+    # nodes = [[node for node in layer if len(node.qargs) == 0 or any(q in qubits for q in node.qargs)] for layer in nodes] -> remove when confirm not needed
 
     return qubits, clbits, nodes
 
@@ -555,6 +555,13 @@ class _LayerSpooler(list):
                 dag_nodes = _sorted_nodes(dag_layer)
                 for node in dag_nodes:
                     self.add(node, current_index)
+
+        i = 0
+        # adds operators that don't work on any bit
+        for node in dag.topological_op_nodes():
+            if node.num_qubits == 0 and node.num_clbits == 0:
+                self.insert(i, [node])
+                i += 1  # used to ensure order matches that of which the user added the gates
 
     def is_found_in(self, node, nodes):
         """Is any qreq in node found in any of nodes?"""

--- a/qiskit/visualization/circuit/latex.py
+++ b/qiskit/visualization/circuit/latex.py
@@ -419,7 +419,7 @@ class QCircuitImage:
                     elif isinstance(op, ControlledGate):
                         num_cols_op = self._build_ctrl_gate(op, gate_text, wire_list, column)
                     elif len(wire_list) == 0 and not node.cargs:
-                        num_cols_op = self._build_zero_qubit_gate(op, gate_text, column)
+                        num_cols_op = self._build_zero_qubit_gate(gate_text, column)
                     else:
                         num_cols_op = self._build_multi_gate(
                             op, gate_text, wire_list, cwire_list, column
@@ -429,23 +429,20 @@ class QCircuitImage:
 
             column += num_cols_layer
 
-    def _build_zero_qubit_gate(self, op, gate_text, col):
-        """Add a multiple wire gate to the _latex list"""
-        cwire_start = len(self._qubits)
+    def _build_zero_qubit_gate(self, gate_text, col):
+        """Add a zero qubit wire gate to the _latex list
+        Code is mainly from `_build_multi_gate` with wire
+        numbering removed
+        """
         num_cols_op = 1
         wire_list = [self._wire_map[qarg] for qarg in self._qubits]
         wire_min = min(wire_list)
         wire_max = max(wire_list)
 
-        wire_ind = wire_list.index(wire_min)
         self._latex[wire_min][col] = f"\\multigate{{{wire_max - wire_min}}}{{{gate_text}}}"
         for wire in range(wire_min + 1, wire_max + 1):
-            if wire < cwire_start:
-                ghost_box = f"\\ghost{{{gate_text}}}"
-            else:
-                ghost_box = f"\\cghost{{{gate_text}}}"
+            self._latex[wire][col] = f"\\ghost{{{gate_text}}}"
 
-            self._latex[wire][col] = ghost_box
         return num_cols_op
 
     def _build_multi_gate(self, op, gate_text, wire_list, cwire_list, col):

--- a/qiskit/visualization/circuit/latex.py
+++ b/qiskit/visualization/circuit/latex.py
@@ -416,9 +416,10 @@ class QCircuitImage:
 
                     if len(wire_list) == 1 and not node.cargs:
                         self._latex[wire_list[0]][column] = f"\\gate{{{gate_text}}}"
-
                     elif isinstance(op, ControlledGate):
                         num_cols_op = self._build_ctrl_gate(op, gate_text, wire_list, column)
+                    elif len(wire_list) == 0 and not node.cargs:
+                        num_cols_op = self._build_zero_qubit_gate(op, gate_text, column)
                     else:
                         num_cols_op = self._build_multi_gate(
                             op, gate_text, wire_list, cwire_list, column
@@ -427,6 +428,25 @@ class QCircuitImage:
                 num_cols_layer = max(num_cols_layer, num_cols_op)
 
             column += num_cols_layer
+
+    def _build_zero_qubit_gate(self, op, gate_text, col):
+        """Add a multiple wire gate to the _latex list"""
+        cwire_start = len(self._qubits)
+        num_cols_op = 1
+        wire_list = [self._wire_map[qarg] for qarg in self._qubits]
+        wire_min = min(wire_list)
+        wire_max = max(wire_list)
+
+        wire_ind = wire_list.index(wire_min)
+        self._latex[wire_min][col] = f"\\multigate{{{wire_max - wire_min}}}{{{gate_text}}}"
+        for wire in range(wire_min + 1, wire_max + 1):
+            if wire < cwire_start:
+                ghost_box = f"\\ghost{{{gate_text}}}"
+            else:
+                ghost_box = f"\\cghost{{{gate_text}}}"
+
+            self._latex[wire][col] = ghost_box
+        return num_cols_op
 
     def _build_multi_gate(self, op, gate_text, wire_list, cwire_list, col):
         """Add a multiple wire gate to the _latex list"""

--- a/qiskit/visualization/circuit/matplotlib.py
+++ b/qiskit/visualization/circuit/matplotlib.py
@@ -1128,6 +1128,7 @@ class MatplotlibDrawer:
 
                 # draws zero_operands
                 elif node_data[node].zero_operand == True:
+                    print(type(op))
                     self._zero_operand_gate(node, node_data, glob_data)
 
                 # draw multi-qubit gate as final default

--- a/qiskit/visualization/circuit/matplotlib.py
+++ b/qiskit/visualization/circuit/matplotlib.py
@@ -773,11 +773,14 @@ class MatplotlibDrawer:
                         else:
                             c_indxs.append(wire_map[carg])
 
+                # special case for 0 qubit, 0 cbit gates
                 if len(node.qargs) == 0 and len(node.cargs) == 0:
                     for qarg in self._qubits:
-                        q_indxs.append(wire_map[qarg])
-                    glob_data["next_x_index"] = 0  # temp
-                    node_data[node].zero_operand = True
+                        q_indxs.append(
+                            wire_map[qarg]
+                        )  # generate a map with all qubits to reserve space in drawing
+                    glob_data["next_x_index"] = 0  # sets gate to be before first layer
+                    node_data[node].zero_qubit_gate = True
 
                 flow_op = isinstance(node.op, ControlFlowOp)
 
@@ -1126,10 +1129,9 @@ class MatplotlibDrawer:
                 elif isinstance(op, ControlledGate) or mod_control:
                     self._control_gate(node, node_data, glob_data, mod_control)
 
-                # draws zero_operands
-                elif node_data[node].zero_operand == True:
-                    print(type(op))
-                    self._zero_operand_gate(node, node_data, glob_data)
+                # draws zero qubit gate
+                elif node_data[node].zero_qubit_gate is True:
+                    self._zero_qubit_gate(node, node_data, glob_data)
 
                 # draw multi-qubit gate as final default
                 else:
@@ -1458,11 +1460,11 @@ class MatplotlibDrawer:
                 zorder=PORDER_TEXT,
             )
 
-    def _zero_operand_gate(self, node, node_data, glob_data, xy=None):
-        """Draw a zero-qubit zero_operand"""
-        op = node.op
-        if xy is None:
-            xy = node_data[node].q_xy
+    def _zero_qubit_gate(self, node, node_data, glob_data):
+        """Draw a zero-qubit operand
+        Code is similar to `_multiqubit_gate()` with wire labellings removed
+        """
+        xy = node_data[node].q_xy
 
         xpos = min(x[0] for x in xy)
         ypos = min(y[1] for y in xy)
@@ -2092,4 +2094,4 @@ class NodeData:
         self.circ_num = 0  # Which block is it in op.blocks
 
         # used for zero_operands only
-        self.zero_operand = False
+        self.zero_qubit_gate = False

--- a/qiskit/visualization/circuit/matplotlib.py
+++ b/qiskit/visualization/circuit/matplotlib.py
@@ -113,6 +113,8 @@ class MatplotlibDrawer:
         self._qubits = qubits
         self._clbits = clbits
         self._nodes = nodes
+        
+        
         self._scale = 1.0 if scale is None else scale
 
         self._style = style
@@ -262,6 +264,7 @@ class MatplotlibDrawer:
         # glob_data contains global values used throughout, "n_lines", "x_offset", "next_x_index",
         # "patches_mod", "subfont_factor"
         glob_data = {}
+        
 
         glob_data["patches_mod"] = patches
         plt_mod = plt
@@ -758,7 +761,7 @@ class MatplotlibDrawer:
                 for qarg in node.qargs:
                     if qarg in self._qubits:
                         q_indxs.append(wire_map[qarg])
-
+                
                 # get clbit indexes
                 c_indxs = []
                 for carg in node.cargs:
@@ -772,6 +775,12 @@ class MatplotlibDrawer:
                         else:
                             c_indxs.append(wire_map[carg])
 
+                if len(node.qargs) == 0 and len(node.cargs) == 0:
+                    for qarg in self._qubits:
+                        q_indxs.append(wire_map[qarg])
+                    glob_data["next_x_index"] = 0 #temp
+                    node_data[node].zero_operand = True
+                
                 flow_op = isinstance(node.op, ControlFlowOp)
 
                 # qubit coordinates
@@ -1070,7 +1079,6 @@ class MatplotlibDrawer:
             # draw the gates in this layer
             for node in layer:
                 op = node.op
-
                 self._get_colors(node, node_data)
 
                 if verbose:
@@ -1120,6 +1128,10 @@ class MatplotlibDrawer:
                 elif isinstance(op, ControlledGate) or mod_control:
                     self._control_gate(node, node_data, glob_data, mod_control)
 
+                #draws zero_operands
+                elif node_data[node].zero_operand == True:
+                    self._zero_operand_gate(node, node_data, glob_data)
+                    
                 # draw multi-qubit gate as final default
                 else:
                     self._multiqubit_gate(node, node_data, glob_data)
@@ -1447,6 +1459,59 @@ class MatplotlibDrawer:
                 zorder=PORDER_TEXT,
             )
 
+    def _zero_operand_gate(self, node, node_data, glob_data, xy=None):
+        """Draw a zero-qubit zero_operand"""
+        op = node.op
+        if xy is None:
+            xy = node_data[node].q_xy
+        
+        xpos = min(x[0] for x in xy)
+        ypos = min(y[1] for y in xy)
+        ypos_max = max(y[1] for y in xy)
+ 
+
+        wid = max(node_data[node].width + 0.21, WID)
+        qubit_span = abs(ypos) - abs(ypos_max)
+        height = HIG + qubit_span
+
+        box = glob_data["patches_mod"].Rectangle(
+            xy=(xpos - 0.5 * wid, ypos - 0.5 * HIG),
+            width=wid,
+            height=height,
+            fc=node_data[node].fc,
+            ec=node_data[node].ec,
+            linewidth=self._lwidth15,
+            zorder=PORDER_GATE,
+        )
+        self._ax.add_patch(box)
+
+        if node_data[node].gate_text:
+            gate_ypos = ypos + 0.5 * qubit_span
+            if node_data[node].param_text:
+                gate_ypos = ypos + 0.4 * height
+                self._ax.text(
+                    xpos,
+                    ypos + 0.2 * height,
+                    node_data[node].param_text,
+                    ha="center",
+                    va="center",
+                    fontsize=self._style["sfs"],
+                    color=node_data[node].sc,
+                    clip_on=True,
+                    zorder=PORDER_TEXT,
+                )
+            self._ax.text(
+                xpos,
+                gate_ypos,
+                node_data[node].gate_text,
+                ha="center",
+                va="center",
+                fontsize=self._style["fs"],
+                color=node_data[node].gt,
+                clip_on=True,
+                zorder=PORDER_TEXT,
+            )
+    
     def _multiqubit_gate(self, node, node_data, glob_data, xy=None):
         """Draw a gate covering more than one qubit"""
         op = node.op
@@ -2027,3 +2092,6 @@ class NodeData:
         self.indexset = ()  # List of indices used for ForLoopOp
         self.jump_values = []  # List of jump values used for SwitchCaseOp
         self.circ_num = 0  # Which block is it in op.blocks
+
+        #used for zero_operands only
+        self.zero_operand = False

--- a/qiskit/visualization/circuit/matplotlib.py
+++ b/qiskit/visualization/circuit/matplotlib.py
@@ -113,8 +113,7 @@ class MatplotlibDrawer:
         self._qubits = qubits
         self._clbits = clbits
         self._nodes = nodes
-        
-        
+
         self._scale = 1.0 if scale is None else scale
 
         self._style = style
@@ -264,7 +263,6 @@ class MatplotlibDrawer:
         # glob_data contains global values used throughout, "n_lines", "x_offset", "next_x_index",
         # "patches_mod", "subfont_factor"
         glob_data = {}
-        
 
         glob_data["patches_mod"] = patches
         plt_mod = plt
@@ -761,7 +759,7 @@ class MatplotlibDrawer:
                 for qarg in node.qargs:
                     if qarg in self._qubits:
                         q_indxs.append(wire_map[qarg])
-                
+
                 # get clbit indexes
                 c_indxs = []
                 for carg in node.cargs:
@@ -778,9 +776,9 @@ class MatplotlibDrawer:
                 if len(node.qargs) == 0 and len(node.cargs) == 0:
                     for qarg in self._qubits:
                         q_indxs.append(wire_map[qarg])
-                    glob_data["next_x_index"] = 0 #temp
+                    glob_data["next_x_index"] = 0  # temp
                     node_data[node].zero_operand = True
-                
+
                 flow_op = isinstance(node.op, ControlFlowOp)
 
                 # qubit coordinates
@@ -1128,10 +1126,10 @@ class MatplotlibDrawer:
                 elif isinstance(op, ControlledGate) or mod_control:
                     self._control_gate(node, node_data, glob_data, mod_control)
 
-                #draws zero_operands
+                # draws zero_operands
                 elif node_data[node].zero_operand == True:
                     self._zero_operand_gate(node, node_data, glob_data)
-                    
+
                 # draw multi-qubit gate as final default
                 else:
                     self._multiqubit_gate(node, node_data, glob_data)
@@ -1464,11 +1462,10 @@ class MatplotlibDrawer:
         op = node.op
         if xy is None:
             xy = node_data[node].q_xy
-        
+
         xpos = min(x[0] for x in xy)
         ypos = min(y[1] for y in xy)
         ypos_max = max(y[1] for y in xy)
- 
 
         wid = max(node_data[node].width + 0.21, WID)
         qubit_span = abs(ypos) - abs(ypos_max)
@@ -1511,7 +1508,7 @@ class MatplotlibDrawer:
                 clip_on=True,
                 zorder=PORDER_TEXT,
             )
-    
+
     def _multiqubit_gate(self, node, node_data, glob_data, xy=None):
         """Draw a gate covering more than one qubit"""
         op = node.op
@@ -2093,5 +2090,5 @@ class NodeData:
         self.jump_values = []  # List of jump values used for SwitchCaseOp
         self.circ_num = 0  # Which block is it in op.blocks
 
-        #used for zero_operands only
+        # used for zero_operands only
         self.zero_operand = False

--- a/qiskit/visualization/circuit/matplotlib.py
+++ b/qiskit/visualization/circuit/matplotlib.py
@@ -780,7 +780,6 @@ class MatplotlibDrawer:
                             wire_map[qarg]
                         )  # generate a map with all qubits to reserve space in drawing
                     glob_data["next_x_index"] = 0  # sets gate to be before first layer
-                    node_data[node].zero_qubit_gate = True
 
                 flow_op = isinstance(node.op, ControlFlowOp)
 
@@ -1130,7 +1129,7 @@ class MatplotlibDrawer:
                     self._control_gate(node, node_data, glob_data, mod_control)
 
                 # draws zero qubit gate
-                elif node_data[node].zero_qubit_gate is True:
+                elif len(node.qargs) == 0 and len(node.cargs) == 0:
                     self._zero_qubit_gate(node, node_data, glob_data)
 
                 # draw multi-qubit gate as final default
@@ -2092,6 +2091,3 @@ class NodeData:
         self.indexset = ()  # List of indices used for ForLoopOp
         self.jump_values = []  # List of jump values used for SwitchCaseOp
         self.circ_num = 0  # Which block is it in op.blocks
-
-        # used for zero_operands only
-        self.zero_qubit_gate = False

--- a/qiskit/visualization/circuit/text.py
+++ b/qiskit/visualization/circuit/text.py
@@ -1236,7 +1236,7 @@ class TextDrawing:
         elif len(node.qargs) >= 2 and not node.cargs:
             layer.set_qu_multibox(node.qargs, gate_text, conditional=conditional)
         elif len(node.qargs) == 0 and not node.cargs:
-            layer.set_qu_operandbox(gate_text)
+            layer.set_zero_qubit_operandbox(gate_text)
         elif node.qargs and node.cargs:
             layer._set_multibox(
                 gate_text,
@@ -1689,6 +1689,14 @@ class Layer:
         self,
         label,
     ):
+        """Sets the zero qubit operand box.
+
+        Args:
+            label (str): Custom gate label
+
+        Returns:
+            List: all qubit indicies
+        """
 
         bit_indices = sorted(i for i, x in enumerate(self.qubits) if x in self.qubits)
         wire_label_len = len(str(len(self.qubits) - 1))

--- a/qiskit/visualization/circuit/text.py
+++ b/qiskit/visualization/circuit/text.py
@@ -1685,7 +1685,7 @@ class Layer:
             )
         return bit_indices
 
-    def _set_operandbox(
+    def _set_zero_qubit_operandbox(
         self,
         label,
     ):
@@ -1842,23 +1842,18 @@ class Layer:
             controlled_edge=controlled_edge,
         )
 
-    def set_qu_operandbox(
+    def set_zero_qubit_operandbox(
         self,
         label,
     ):
-        """Sets the multi qubit box.
+        """Sets the zero-qubit operand box
 
         Args:
-            bits (list[int]): A list of affected bits.
             label (string): The label for the multi qubit box.
-            top_connect (char): None or a char connector on the top
-            bot_connect (char): None or a char connector on the bottom
-            conditional (bool): If the box has a conditional
-            controlled_edge (list): A list of bit that are controlled (to draw them at the edge)
         Return:
             List: A list of indexes of the box.
         """
-        return self._set_operandbox(label)
+        return self._set_zero_qubit_operandbox(label)
 
     def connect_with(self, wire_char):
         """Connects the elements in the layer using wire_char.

--- a/releasenotes/notes/zero-qubit-gate-visualization-b9633abad72667a8.yaml
+++ b/releasenotes/notes/zero-qubit-gate-visualization-b9633abad72667a8.yaml
@@ -1,0 +1,6 @@
+---
+features_visualization:
+  - |
+    Added `_build_zero_qubit_gate` in latex.py, `_zero_qubit_gate` in matplotlib.py and `_set_zero_qubit_operandbox` in text.py
+    Modified _utils.py to allow 0 qubits to be passed onto visualizer
+    To allow for zero qubit operations to be rendered, specifically :class:`.GlobalPhaseGate`

--- a/test/python/visualization/test_circuit_latex.py
+++ b/test/python/visualization/test_circuit_latex.py
@@ -448,7 +448,8 @@ class TestLatexSourceGenerator(QiskitVisualizationTestCase):
         self.assertEqualToReference(filename)
 
     def test_globalphasegate(self):
-        pass #TODO!
+        """Test correct render of GlobalPhaseGate"""
+        pass  # TODO!
 
     def test_scale(self):
         """Tests scale

--- a/test/python/visualization/test_circuit_latex.py
+++ b/test/python/visualization/test_circuit_latex.py
@@ -447,6 +447,9 @@ class TestLatexSourceGenerator(QiskitVisualizationTestCase):
 
         self.assertEqualToReference(filename)
 
+    def test_globalphasegate(self):
+        pass #TODO!
+
     def test_scale(self):
         """Tests scale
         See: https://github.com/Qiskit/qiskit-terra/issues/4179"""

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -827,6 +827,9 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit.append(CPhaseGate(pi / 2), [qr[2], qr[0]])
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
+    def test_text_globalphasegate(self):
+        pass #TODO!
+
     def test_text_cu1_condition(self):
         """Test cu1 with condition"""
         expected = "\n".join(

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -828,7 +828,8 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_globalphasegate(self):
-        pass #TODO!
+        """Test correct render of GlobalPhaseGate"""
+        pass  # TODO!
 
     def test_text_cu1_condition(self):
         """Test cu1 with condition"""

--- a/test/python/visualization/test_utils.py
+++ b/test/python/visualization/test_utils.py
@@ -61,6 +61,9 @@ class TestVisualizationUtils(QiskitTestCase):
         self.assertEqual(
             exp, [[(op.name, op.qargs, op.cargs) for op in ops] for ops in layered_ops]
         )
+        
+    def test_get_layered_instructions_zero_qubit_gates(self):
+        pass #TODO!
 
     def test_get_layered_instructions_reverse_bits(self):
         """_get_layered_instructions with reverse_bits=True"""

--- a/test/python/visualization/test_utils.py
+++ b/test/python/visualization/test_utils.py
@@ -61,9 +61,10 @@ class TestVisualizationUtils(QiskitTestCase):
         self.assertEqual(
             exp, [[(op.name, op.qargs, op.cargs) for op in ops] for ops in layered_ops]
         )
-        
+
     def test_get_layered_instructions_zero_qubit_gates(self):
-        pass #TODO!
+        """_get_layered_instructions with a 0 qubit instruction"""
+        pass  # TODO!
 
     def test_get_layered_instructions_reverse_bits(self):
         """_get_layered_instructions with reverse_bits=True"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary
Implemented #9962 , allowing for 0 qubit gates to be visualized on all 3 circuit drawers. This adds new functions in each drawer, but they are essentially the same as the multiple qubit gate with the labelling removed.


### Details and comments
Provides the following outputs based off of this code:
```python3
backend = GenericBackendV2(num_qubits=5)
circ = QuantumCircuit(5)
circ.h(0)
circ.cx(3,2)
circ.append(GlobalPhaseGate(np.pi))
circ.append(GlobalPhaseGate(5 * np.pi))
circ.append(GlobalPhaseGate(5 * np.pi, label="U"))
circ.x(0)
display(circ.draw('mpl'))
```

![text_ex](https://github.com/user-attachments/assets/e2b4185d-ffd3-474a-835e-22084dc26b5a)
![latex_ex](https://github.com/user-attachments/assets/a59c2500-534f-4a3f-b1b1-8e8d3caedfb6)
![mpl_ex](https://github.com/user-attachments/assets/5d4be27c-8c29-43d4-8599-ab7a12d13b54)
