### PR TITLE
[WIP] `TwoQubitDiscreteDecomposer` based on Solovay-Kitaev

### DIFF
--- a/test/python/synthesis/test_synthesis.py
+++ b/test/python/synthesis/test_synthesis.py
@@ -64,6 +64,7 @@ from qiskit.synthesis.two_qubit.two_qubit_decompose import (
     two_qubit_cnot_decompose,
     TwoQubitBasisDecomposer,
     TwoQubitControlledUDecomposer,
+    TwoQubitDiscreteDecomposer,
     decompose_two_qubit_product_gate,
 )
 from qiskit._accelerate.two_qubit_decompose import two_qubit_decompose_up_to_diagonal
@@ -1579,6 +1580,34 @@ class TestTwoQubitControlledUDecompose(CheckDecompositions):
             decomp.rxx_equivalent_gate.name, decomp_cpy.rxx_equivalent_gate.name, msg=msg_base
         )
         self.assertEqual(decomp.euler_basis, decomp_cpy.euler_basis, msg=msg_base)
+
+    def test_discrete(self):
+        """Test TwoQubitDiscreteDecomposer """
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.s(1)
+        qc.t(0)
+        qc.cx(0, 1)
+        qc.t(1)
+        qc.h(1)
+        qc.cx(1, 0)
+        qc.h(0)
+        qc.s(1)
+        qc.t(0)
+
+        unitary = Operator(qc).to_matrix()
+        decomposer = TwoQubitDiscreteDecomposer()
+        circ = decomposer(unitary)
+        # print(circ)
+        self.assertAlmostEqual(Operator(unitary), Operator(circ))
+
+        for seed in range(10):
+            unitary = random_unitary(4, seed=seed)
+            circ = decomposer(unitary)
+            # print(circ.count_ops())
+            np.testing.assert_allclose(
+                Operator(unitary).to_matrix(), Operator(circ).to_matrix(), atol=1e-1
+            )
 
 
 class TestDecomposeProductRaises(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
close #14170

Basic two-qubit unitary decomposer into a discrete basis gate set (Clifford+T), based on the one-qubit Solovay-Kitaev decomposer.
Currently it supports only CX gate as a two-qubit gate. This can be extended to other two-qubit gates which are both Clifford and KAK, e.g. CZ and ECR.
However, it outputs a decomposition which has too many T gates, and is therefore less accurate.
This code is written in Python, but can be easily ported to rust after https://github.com/Qiskit/qiskit/pull/14203.
It's also better to merge https://github.com/Qiskit/qiskit/pull/14225 first.

### Details and comments
The framework is similar to the [`TwoQubitControlledUDecomposer`](https://docs.quantum.ibm.com/api/qiskit/qiskit.synthesis.TwoQubitControlledUDecomposer):
- Decompose the unitary into four 1-qubit unitaries and a canonical 2-qubit gate
- Decompose the canonical 2-qubit gate into RXX-RYY-RZZ
- Decompose each of the RXX/RYY/RZZ into two CX gates, 1-qubit Clifford gates and an RZ gate
- Decompose the 1-qubit gates using [Solovay-Kitaev decomposer](https://docs.quantum.ibm.com/api/qiskit/qiskit.synthesis.SolovayKitaevDecomposition)

