### PR TITLE
Make current Dependabot ignores explicit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,24 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "cargo" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "cargo"
+    directory: "/"
     schedule:
       interval: "daily"
     labels:
       - "Rust"
       - "dependencies"
       - "Changelog: None"
+    ignore:
+      # Faer has historically made major breaking changes between minor versions, so it's easier to
+      # do things manually ourselves.
+      - "faer"
+      - "faer-ext"
+      # nalgebra 0.34 bumped its MSRV to 1.87, which is too high for us.
+      - "nalgebra"
+      # Used by the experimental OQ3 exporter at a time when we were expecting to make updates
+      # manually to this.
+      - "oq3_semantics"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     groups:
@@ -25,3 +31,10 @@ updates:
       - "type: qa"
       - "dependencies"
       - "Changelog: None"
+    ignore:
+      # This semi-reliably requires us to make manual changes to the wheel-build rules, so it's more
+      # convenient to do it all ourselves.
+      - "pypa/cibuildwheel"
+      # The version of this is used as a cutesy way to select the Rust version instead of doing
+      # things with an Actions input.
+      - "dtolnay/rust-toolchain"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,15 +12,17 @@ updates:
       - "dependencies"
       - "Changelog: None"
     ignore:
-      # Faer has historically made major breaking changes between minor versions, so it's easier to
+      # faer has historically made major breaking changes between minor versions, so it's easier to
       # do things manually ourselves.
-      - "faer"
-      - "faer-ext"
+      - { dependency-name: "faer", versions: ["0.19.4"] }
+      - { dependency-name: "faer-ext", versions: [">0.2.0"] }
       # nalgebra 0.34 bumped its MSRV to 1.87, which is too high for us.
-      - "nalgebra"
+      - { dependency-name: "nalgebra", versions: [">0.33.2"] }
       # Used by the experimental OQ3 exporter at a time when we were expecting to make updates
       # manually to this.
-      - "oq3_semantics"
+      - { dependency-name: "oq3_semantics", versions: [">0.0.7"] }
+      # hashbrown 0.13.0 bumped the MSRV to 1.61
+      - { dependency-name: "hashbrown", versions: [">0.12.3"] }
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -37,7 +39,7 @@ updates:
     ignore:
       # This semi-reliably requires us to make manual changes to the wheel-build rules, so it's more
       # convenient to do it all ourselves.
-      - "pypa/cibuildwheel"
+      - { dependency-name: "pypa/cibuildwheel", versions: [">3.0.1"] }
       # The version of this is used as a cutesy way to select the Rust version instead of doing
       # things with an Actions input.
-      - "dtolnay/rust-toolchain"
+      - { dependency-name: "dtolnay/rust-toolchain", versions: [">1.7.0"] }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,7 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "cargo" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "cargo"
+    directory: "/"
     schedule:
       interval: "weekly"
     groups:
@@ -16,6 +11,17 @@ updates:
       - "Rust"
       - "dependencies"
       - "Changelog: None"
+    ignore:
+      # Faer has historically made major breaking changes between minor versions, so it's easier to
+      # do things manually ourselves.
+      - "faer"
+      - "faer-ext"
+      # nalgebra 0.34 bumped its MSRV to 1.87, which is too high for us.
+      - "nalgebra"
+      # Used by the experimental OQ3 exporter at a time when we were expecting to make updates
+      # manually to this.
+      - "oq3_semantics"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     groups:
@@ -28,3 +34,10 @@ updates:
       - "type: qa"
       - "dependencies"
       - "Changelog: None"
+    ignore:
+      # This semi-reliably requires us to make manual changes to the wheel-build rules, so it's more
+      # convenient to do it all ourselves.
+      - "pypa/cibuildwheel"
+      # The version of this is used as a cutesy way to select the Rust version instead of doing
+      # things with an Actions input.
+      - "dtolnay/rust-toolchain"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
     ignore:
       # faer has historically made major breaking changes between minor versions, so it's easier to
       # do things manually ourselves.
-      - { dependency-name: "faer", versions: ["0.19.4"] }
+      - { dependency-name: "faer", versions: [">0.19.4"] }
       - { dependency-name: "faer-ext", versions: [">0.2.0"] }
       # nalgebra 0.34 bumped its MSRV to 1.87, which is too high for us.
       - { dependency-name: "nalgebra", versions: [">0.33.2"] }


### PR DESCRIPTION
Make current Dependabot ignores explicit

We have several dependencies in Dependabot ignored, which we did by issuing Dependabot commands in the relevant PRs. This moves all the currently active ignores into the config file, so we can release the existing hidden ignores and rely on the configuration to do it.

This commit is just intending to make every current rule explicit in the history. We should follow up with changes to fix any problems in the configuration; clearly the justifications of some of these rules are long out of date.

I triggered dependabot to give the explicit ignore conditions on separate PRs (since dependabot only comments on PRs it opened), and included links in each comment to the relevant "ignore" command, to show the justifications transplanted into comments in this commit. For the two groups, there are a small chain of comments behind each link:

- `cargo`: <https://github.com/Qiskit/qiskit/pull/16721#issuecomment-5240713024>
- `github_actions`: <https://github.com/Qiskit/qiskit/pull/14999#issuecomment-5240989346>


### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code: