### PR TITLE
[WIP] Split PyDAGCircuit from DAGCircuit

### DIFF
--- a/crates/accelerate/src/twirling.rs
+++ b/crates/accelerate/src/twirling.rs
@@ -342,7 +342,7 @@ fn generate_twirled_circuit(
         }
     }
     if optimizer_target.is_some() {
-        let mut dag = DAGCircuit::from_circuit_data(&out_circ, false, None, None, None, None)?;
+        let mut dag = DAGCircuit::from_circuit_data(&out_circ, false, None, None)?;
         run_optimize_1q_gates_decomposition(&mut dag, optimizer_target, None, None)?;
         dag_to_circuit(&dag, false)
     } else {

--- a/crates/cext/src/dag.rs
+++ b/crates/cext/src/dag.rs
@@ -125,7 +125,7 @@ pub unsafe extern "C" fn qk_dag_num_qubits(dag: *const DAGCircuit) -> u32 {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let dag = unsafe { const_ptr_as_ref(dag) };
 
-    dag.num_qubits() as u32
+    dag.qubits().len() as u32
 }
 
 /// @ingroup QkDag
@@ -154,7 +154,7 @@ pub unsafe extern "C" fn qk_dag_num_clbits(dag: *const DAGCircuit) -> u32 {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let dag = unsafe { const_ptr_as_ref(dag) };
 
-    dag.num_clbits() as u32
+    dag.clbits().len() as u32
 }
 
 /// @ingroup QkDag

--- a/crates/cext/src/transpiler/passes/basis_translator.rs
+++ b/crates/cext/src/transpiler/passes/basis_translator.rs
@@ -70,7 +70,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_basis_translator(
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let target = unsafe { const_ptr_as_ref(target) };
 
-    let dag = DAGCircuit::from_circuit_data(circ_from_ptr, false, None, None, None, None)
+    let dag = DAGCircuit::from_circuit_data(circ_from_ptr, false, None, None)
         .expect("Circuit to DAG conversion failed");
 
     let mut equiv_lib = generate_standard_equivalence_library();

--- a/crates/cext/src/transpiler/passes/commutative_cancellation.rs
+++ b/crates/cext/src/transpiler/passes/commutative_cancellation.rs
@@ -72,7 +72,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_commutative_cancellation(
             "Invalid value provided for approximation degree, only NAN or values between 0.0 and 1.0 inclusive are valid"
         );
     }
-    let mut dag = match DAGCircuit::from_circuit_data(circuit, false, None, None, None, None) {
+    let mut dag = match DAGCircuit::from_circuit_data(circuit, false, None, None) {
         Ok(dag) => dag,
         Err(_) => panic!("Internal circuit -> DAG conversion failed"),
     };

--- a/crates/cext/src/transpiler/passes/consolidate_blocks.rs
+++ b/crates/cext/src/transpiler/passes/consolidate_blocks.rs
@@ -55,7 +55,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_consolidate_blocks(
     } else {
         approximation_degree
     };
-    let mut circ_as_dag = DAGCircuit::from_circuit_data(circuit, true, None, None, None, None)
+    let mut circ_as_dag = DAGCircuit::from_circuit_data(circuit, true, None, None)
         .expect("Error while converting from CircuitData to DAGCircuit.");
 
     // Call the pass

--- a/crates/cext/src/transpiler/passes/elide_permutations.rs
+++ b/crates/cext/src/transpiler/passes/elide_permutations.rs
@@ -63,7 +63,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_elide_permutations(
 ) -> *mut TranspileLayout {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { mut_ptr_as_ref(circuit) };
-    let dag = match DAGCircuit::from_circuit_data(circuit, false, None, None, None, None) {
+    let dag = match DAGCircuit::from_circuit_data(circuit, false, None, None) {
         Ok(dag) => dag,
         Err(_e) => panic!("Internal circuit to DAG conversion failed."),
     };

--- a/crates/cext/src/transpiler/passes/gate_direction.rs
+++ b/crates/cext/src/transpiler/passes/gate_direction.rs
@@ -56,7 +56,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_check_gate_direction(
     let circuit = unsafe { const_ptr_as_ref(circuit) };
     let target = unsafe { const_ptr_as_ref(target) };
 
-    let dag = DAGCircuit::from_circuit_data(circuit, false, None, None, None, None)
+    let dag = DAGCircuit::from_circuit_data(circuit, false, None, None)
         .expect("Circuit to DAG conversion failed");
 
     check_direction_target(&dag, target).expect("Unexpected error occurred in CheckGateDirection")
@@ -102,7 +102,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_gate_direction(
     let circuit = unsafe { mut_ptr_as_ref(circuit) };
     let target = unsafe { const_ptr_as_ref(target) };
 
-    let mut dag = DAGCircuit::from_circuit_data(circuit, false, None, None, None, None)
+    let mut dag = DAGCircuit::from_circuit_data(circuit, false, None, None)
         .expect("Circuit to DAG conversion failed");
 
     fix_direction_target(&mut dag, target).expect("Unexpected error occurred in GateDirection");

--- a/crates/cext/src/transpiler/passes/inverse_cancellation.rs
+++ b/crates/cext/src/transpiler/passes/inverse_cancellation.rs
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_inverse_cancellation(
 ) {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { mut_ptr_as_ref(circuit) };
-    let mut dag = match DAGCircuit::from_circuit_data(circuit, false, None, None, None, None) {
+    let mut dag = match DAGCircuit::from_circuit_data(circuit, false, None, None) {
         Ok(dag) => dag,
         Err(_) => panic!("Internal Circuit -> DAG conversion failed"),
     };

--- a/crates/cext/src/transpiler/passes/optimize_1q_sequences.rs
+++ b/crates/cext/src/transpiler/passes/optimize_1q_sequences.rs
@@ -85,7 +85,7 @@ pub unsafe extern "C" fn qk_transpiler_standalone_optimize_1q_sequences(
     let circuit = unsafe { mut_ptr_as_ref(circuit) };
 
     // Convert the circuit to a DAG.
-    let mut circuit_as_dag = DAGCircuit::from_circuit_data(circuit, false, None, None, None, None)
+    let mut circuit_as_dag = DAGCircuit::from_circuit_data(circuit, false, None, None)
         .expect("Error while converting the circuit to a dag.");
 
     // Run the pass

--- a/crates/cext/src/transpiler/passes/remove_diagonal_gates_before_measure.rs
+++ b/crates/cext/src/transpiler/passes/remove_diagonal_gates_before_measure.rs
@@ -45,7 +45,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_remove_diagonal_gates_bef
 ) {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { mut_ptr_as_ref(circuit) };
-    let mut dag = DAGCircuit::from_circuit_data(circuit, false, None, None, None, None)
+    let mut dag = DAGCircuit::from_circuit_data(circuit, false, None, None)
         .expect("Circuit to DAG conversion failed");
     run_remove_diagonal_before_measure(&mut dag);
     let result = dag_to_circuit(&dag, false).expect("DAG to Circuit conversion failed");

--- a/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
+++ b/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
@@ -87,7 +87,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_remove_identity_equivalen
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { mut_ptr_as_ref(circuit) };
     let target = unsafe { const_ptr_as_ref(target) };
-    let mut dag = match DAGCircuit::from_circuit_data(circuit, false, None, None, None, None) {
+    let mut dag = match DAGCircuit::from_circuit_data(circuit, false, None, None) {
         Ok(dag) => dag,
         Err(e) => panic!("{}", e),
     };

--- a/crates/cext/src/transpiler/passes/sabre_layout.rs
+++ b/crates/cext/src/transpiler/passes/sabre_layout.rs
@@ -113,7 +113,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_sabre_layout(
     let circuit = unsafe { mut_ptr_as_ref(circuit) };
     let target = unsafe { const_ptr_as_ref(target) };
     let options = unsafe { const_ptr_as_ref(options) };
-    let mut dag = DAGCircuit::from_circuit_data(circuit, false, None, None, None, None)
+    let mut dag = DAGCircuit::from_circuit_data(circuit, false, None, None)
         .unwrap_or_else(|_| panic!("Internal circuit to DAG conversion failed."));
     let heuristic = heuristic::Heuristic::new(
         Some(heuristic::BasicHeuristic::new(
@@ -145,7 +145,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_sabre_layout(
         .unwrap_or_else(|_| panic!("Internal DAG to circuit conversion failed"));
     let num_input_qubits = circuit.num_qubits() as u32;
     *circuit = out_circuit;
-    let out_permutation = (0..result.num_qubits() as u32)
+    let out_permutation = (0..result.qubits().len() as u32)
         .map(|ref q| {
             Qubit(
                 final_layout

--- a/crates/cext/src/transpiler/passes/split_2q_unitaries.rs
+++ b/crates/cext/src/transpiler/passes/split_2q_unitaries.rs
@@ -56,7 +56,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_split_2q_unitaries(
 ) -> *mut TranspileLayout {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { mut_ptr_as_ref(circuit) };
-    let mut dag = match DAGCircuit::from_circuit_data(circuit, false, None, None, None, None) {
+    let mut dag = match DAGCircuit::from_circuit_data(circuit, false, None, None) {
         Ok(dag) => dag,
         Err(_e) => panic!("Internal circuit -> DAG conversion failed."),
     };

--- a/crates/cext/src/transpiler/passes/unitary_synthesis.rs
+++ b/crates/cext/src/transpiler/passes/unitary_synthesis.rs
@@ -75,7 +75,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_unitary_synthesis(
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { mut_ptr_as_ref(circuit) };
     let target = unsafe { const_ptr_as_ref(target) };
-    let mut dag = match DAGCircuit::from_circuit_data(circuit, false, None, None, None, None) {
+    let dag = match DAGCircuit::from_circuit_data(circuit, false, None, None) {
         Ok(dag) => dag,
         Err(e) => panic!("{}", e),
     };
@@ -84,9 +84,9 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_unitary_synthesis(
     } else {
         Some(approximation_degree)
     };
-    let qubit_indices = (0..dag.num_qubits()).collect();
+    let qubit_indices = (0..dag.qubits().len()).collect();
     let out_dag = match run_unitary_synthesis(
-        &mut dag,
+        &dag,
         qubit_indices,
         min_qubits,
         Some(target),

--- a/crates/cext/src/transpiler/passes/vf2.rs
+++ b/crates/cext/src/transpiler/passes/vf2.rs
@@ -333,7 +333,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_vf2_layout(
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { const_ptr_as_ref(circuit) };
     let target = unsafe { const_ptr_as_ref(target) };
-    let dag = match DAGCircuit::from_circuit_data(circuit, false, None, None, None, None) {
+    let dag = match DAGCircuit::from_circuit_data(circuit, false, None, None) {
         Ok(dag) => dag,
         Err(e) => panic!("{}", e),
     };

--- a/crates/circuit/src/dot_utils.rs
+++ b/crates/circuit/src/dot_utils.rs
@@ -18,7 +18,7 @@
 use std::collections::BTreeMap;
 use std::io::prelude::*;
 
-use crate::dag_circuit::{DAGCircuit, Wire};
+use crate::dag_circuit::{PyDAGCircuit, Wire};
 use pyo3::IntoPyObjectExt;
 use pyo3::prelude::*;
 use rustworkx_core::petgraph::visit::{
@@ -30,7 +30,7 @@ static EDGE: [&str; 2] = ["--", "->"];
 
 pub fn build_dot<T>(
     py: Python,
-    dag: &DAGCircuit,
+    dag: &PyDAGCircuit,
     file: &mut T,
     graph_attrs: Option<BTreeMap<String, String>>,
     node_attrs: Option<Py<PyAny>>,
@@ -39,7 +39,7 @@ pub fn build_dot<T>(
 where
     T: Write,
 {
-    let graph = dag.dag();
+    let graph = dag.dag_circuit.dag();
     writeln!(file, "{} {{", TYPE[graph.is_directed() as usize])?;
     if let Some(graph_attr_map) = graph_attrs {
         for (key, value) in graph_attr_map.iter() {
@@ -58,9 +58,24 @@ where
     }
     for edge in graph.edge_references() {
         let edge_weight = match edge.weight() {
-            Wire::Qubit(qubit) => dag.qubits().get(*qubit).cloned().into_bound_py_any(py)?,
-            Wire::Clbit(clbit) => dag.clbits().get(*clbit).cloned().into_bound_py_any(py)?,
-            Wire::Var(var) => dag.vars().get(*var).cloned().into_bound_py_any(py)?,
+            Wire::Qubit(qubit) => dag
+                .dag_circuit
+                .qubits()
+                .get(*qubit)
+                .cloned()
+                .into_bound_py_any(py)?,
+            Wire::Clbit(clbit) => dag
+                .dag_circuit
+                .clbits()
+                .get(*clbit)
+                .cloned()
+                .into_bound_py_any(py)?,
+            Wire::Var(var) => dag
+                .dag_circuit
+                .vars()
+                .get(*var)
+                .cloned()
+                .into_bound_py_any(py)?,
         };
         writeln!(
             file,

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -241,7 +241,7 @@ pub fn circuit(m: &Bound<PyModule>) -> PyResult<()> {
 
     m.add_class::<circuit_data::CircuitData>()?;
     m.add_class::<circuit_instruction::CircuitInstruction>()?;
-    m.add_class::<dag_circuit::DAGCircuit>()?;
+    m.add_class::<dag_circuit::PyDAGCircuit>()?;
     m.add_class::<dag_node::DAGNode>()?;
     m.add_class::<dag_node::DAGInNode>()?;
     m.add_class::<dag_node::DAGOutNode>()?;

--- a/crates/transpiler/src/passes/asap_schedule_analysis.rs
+++ b/crates/transpiler/src/passes/asap_schedule_analysis.rs
@@ -15,7 +15,7 @@ use crate::passes::alap_schedule_analysis::TimeOps;
 use hashbrown::HashMap;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use qiskit_circuit::dag_circuit::{DAGCircuit, Wire};
+use qiskit_circuit::dag_circuit::{DAGCircuit, PyDAGCircuit, Wire};
 use qiskit_circuit::dag_node::{DAGNode, DAGOpNode};
 use qiskit_circuit::operations::{OperationRef, StandardInstruction};
 use qiskit_circuit::{Clbit, Qubit};
@@ -159,7 +159,7 @@ pub fn run_asap_schedule_analysis<T: TimeOps>(
 #[pyo3(name = "asap_schedule_analysis", signature= (dag, clbit_write_latency, node_durations))]
 pub fn py_run_asap_schedule_analysis(
     py: Python,
-    dag: &DAGCircuit,
+    dag: &PyDAGCircuit,
     clbit_write_latency: u64,
     node_durations: &Bound<PyDict>,
 ) -> PyResult<Py<PyDict>> {
@@ -184,7 +184,7 @@ pub fn py_run_asap_schedule_analysis(
             op_durations.insert(node_idx, val);
         }
         let node_start_time =
-            run_asap_schedule_analysis::<u64>(dag, clbit_write_latency, op_durations)?;
+            run_asap_schedule_analysis::<u64>(&dag.dag_circuit, clbit_write_latency, op_durations)?;
         for (node_idx, t1) in node_start_time {
             let node = dag.get_node(py, node_idx)?;
             py_dict.set_item(node, t1)?;
@@ -201,8 +201,11 @@ pub fn py_run_asap_schedule_analysis(
             let val = py_duration.extract::<f64>()?;
             op_durations.insert(node_idx, val);
         }
-        let node_start_time =
-            run_asap_schedule_analysis::<f64>(dag, clbit_write_latency as f64, op_durations)?;
+        let node_start_time = run_asap_schedule_analysis::<f64>(
+            &dag.dag_circuit,
+            clbit_write_latency as f64,
+            op_durations,
+        )?;
         for (node_idx, t1) in node_start_time {
             let node = dag.get_node(py, node_idx)?;
             py_dict.set_item(node, t1)?;

--- a/crates/transpiler/src/passes/basis_translator/compose_transforms.rs
+++ b/crates/transpiler/src/passes/basis_translator/compose_transforms.rs
@@ -83,7 +83,7 @@ pub(super) fn compose_transforms<'a>(
             placeholder_params = extract_py.params;
             extract_py.operation
         };
-        let qubits: Vec<Qubit> = (0..dag.num_qubits() as u32).map(Qubit).collect();
+        let qubits: Vec<Qubit> = (0..dag.qubits().len() as u32).map(Qubit).collect();
         dag.apply_operation_back(
             gate,
             &qubits,
@@ -144,12 +144,13 @@ pub(super) fn compose_transforms<'a>(
                         )
                     })?;
                 let replace_dag: DAGCircuit =
-                    DAGCircuit::from_circuit_data(&replacement, true, None, None, None, None)
-                        .map_err(|_| {
+                    DAGCircuit::from_circuit_data(&replacement, true, None, None).map_err(
+                        |_| {
                             BasisTranslatorError::BasisDAGCircuitError(
                                 "Error converting circuit to dag".to_string(),
                             )
-                        })?;
+                        },
+                    )?;
                 dag.substitute_node_with_dag(node, &replace_dag, None, None, None)
                     .map_err(|_| {
                         BasisTranslatorError::BasisDAGCircuitError(

--- a/crates/transpiler/src/passes/filter_op_nodes.rs
+++ b/crates/transpiler/src/passes/filter_op_nodes.rs
@@ -13,7 +13,7 @@
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 
-use qiskit_circuit::dag_circuit::DAGCircuit;
+use qiskit_circuit::dag_circuit::PyDAGCircuit;
 use qiskit_circuit::packed_instruction::PackedInstruction;
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
@@ -21,7 +21,7 @@ use rustworkx_core::petgraph::stable_graph::NodeIndex;
 #[pyo3(name = "filter_op_nodes")]
 pub fn py_filter_op_nodes(
     py: Python,
-    dag: &mut DAGCircuit,
+    dag: &mut PyDAGCircuit,
     predicate: &Bound<PyAny>,
 ) -> PyResult<()> {
     let callable = |node: NodeIndex| -> PyResult<bool> {
@@ -29,13 +29,13 @@ pub fn py_filter_op_nodes(
         predicate.call1((dag_op_node,))?.extract()
     };
     let mut remove_nodes: Vec<NodeIndex> = Vec::new();
-    for node in dag.op_node_indices(true) {
+    for node in dag.dag_circuit.op_node_indices(true) {
         if !callable(node)? {
             remove_nodes.push(node);
         }
     }
     for node in remove_nodes {
-        dag.remove_op_node(node);
+        dag.dag_circuit.remove_op_node(node);
     }
     Ok(())
 }
@@ -46,14 +46,14 @@ pub fn py_filter_op_nodes(
 ///     dag (DAGCircuit): The dag circuit to filter the ops from
 ///     label (str): The label to filter nodes on
 #[pyfunction]
-pub fn filter_labeled_op(dag: &mut DAGCircuit, label: String) {
+pub fn filter_labeled_op(dag: &mut PyDAGCircuit, label: String) {
     let predicate = |node: &PackedInstruction| -> bool {
         match node.label() {
             Some(inst_label) => inst_label != label,
             None => false,
         }
     };
-    dag.filter_op_nodes(predicate);
+    dag.dag_circuit.filter_op_nodes(predicate);
 }
 
 pub fn filter_op_nodes_mod(m: &Bound<PyModule>) -> PyResult<()> {

--- a/crates/transpiler/src/passes/instruction_duration_check.rs
+++ b/crates/transpiler/src/passes/instruction_duration_check.rs
@@ -14,7 +14,7 @@ use crate::TranspilerError;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
-use qiskit_circuit::dag_circuit::DAGCircuit;
+use qiskit_circuit::dag_circuit::{DAGCircuit, PyDAGCircuit};
 use qiskit_circuit::operations::Param;
 use qiskit_circuit::operations::{DelayUnit, OperationRef, StandardInstruction};
 
@@ -30,7 +30,16 @@ use qiskit_circuit::operations::{DelayUnit, OperationRef, StandardInstruction};
 ///     True if rescheduling is required, False otherwise.
 
 #[pyfunction]
-#[pyo3(signature=(dag, acquire_align, pulse_align))]
+#[pyo3(name = "run_instruction_duration_check", signature=(dag, acquire_align, pulse_align))]
+pub fn py_run_instruction_duration_check(
+    py: Python,
+    dag: &PyDAGCircuit,
+    acquire_align: u32,
+    pulse_align: u32,
+) -> PyResult<bool> {
+    run_instruction_duration_check(py, &dag.dag_circuit, acquire_align, pulse_align)
+}
+
 pub fn run_instruction_duration_check(
     py: Python,
     dag: &DAGCircuit,
@@ -75,6 +84,6 @@ pub fn run_instruction_duration_check(
 }
 
 pub fn instruction_duration_check_mod(m: &Bound<PyModule>) -> PyResult<()> {
-    m.add_wrapped(wrap_pyfunction!(run_instruction_duration_check))?;
+    m.add_wrapped(wrap_pyfunction!(py_run_instruction_duration_check))?;
     Ok(())
 }

--- a/crates/transpiler/src/passes/optimize_clifford_t.rs
+++ b/crates/transpiler/src/passes/optimize_clifford_t.rs
@@ -14,7 +14,7 @@ use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use std::f64::consts::PI;
 
-use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType};
+use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType, PyDAGCircuit};
 use qiskit_circuit::operations::{OperationRef, Param, StandardGate};
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
@@ -312,6 +312,10 @@ fn optimize_clifford_t_1q(
 
 #[pyfunction]
 #[pyo3(name = "optimize_clifford_t")]
+pub fn py_run_optimize_clifford_t(dag: &mut PyDAGCircuit) -> PyResult<()> {
+    run_optimize_clifford_t(&mut dag.dag_circuit)
+}
+
 pub fn run_optimize_clifford_t(dag: &mut DAGCircuit) -> PyResult<()> {
     let op_counts = dag.get_op_counts();
 
@@ -353,7 +357,7 @@ pub fn run_optimize_clifford_t(dag: &mut DAGCircuit) -> PyResult<()> {
 }
 
 pub fn optimize_clifford_t_mod(m: &Bound<PyModule>) -> PyResult<()> {
-    m.add_wrapped(wrap_pyfunction!(run_optimize_clifford_t))?;
+    m.add_wrapped(wrap_pyfunction!(py_run_optimize_clifford_t))?;
     Ok(())
 }
 

--- a/crates/transpiler/src/passes/remove_diagonal_gates_before_measure.rs
+++ b/crates/transpiler/src/passes/remove_diagonal_gates_before_measure.rs
@@ -13,7 +13,7 @@
 /// Remove diagonal gates (including diagonal 2Q gates) before a measurement.
 use pyo3::prelude::*;
 
-use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType};
+use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType, PyDAGCircuit};
 use qiskit_circuit::operations::Operation;
 use qiskit_circuit::operations::StandardGate;
 
@@ -24,6 +24,10 @@ use qiskit_circuit::operations::StandardGate;
 ///     DAGCircuit: the optimized DAG.
 #[pyfunction]
 #[pyo3(name = "remove_diagonal_gates_before_measure")]
+pub fn py_run_remove_diagonal_before_measure(dag: &mut PyDAGCircuit) {
+    run_remove_diagonal_before_measure(&mut dag.dag_circuit)
+}
+
 pub fn run_remove_diagonal_before_measure(dag: &mut DAGCircuit) {
     static DIAGONAL_1Q_GATES: [StandardGate; 8] = [
         StandardGate::RZ,
@@ -93,6 +97,6 @@ pub fn run_remove_diagonal_before_measure(dag: &mut DAGCircuit) {
 }
 
 pub fn remove_diagonal_gates_before_measure_mod(m: &Bound<PyModule>) -> PyResult<()> {
-    m.add_wrapped(wrap_pyfunction!(run_remove_diagonal_before_measure))?;
+    m.add_wrapped(wrap_pyfunction!(py_run_remove_diagonal_before_measure))?;
     Ok(())
 }

--- a/crates/transpiler/src/passes/remove_identity_equiv.rs
+++ b/crates/transpiler/src/passes/remove_identity_equiv.rs
@@ -17,7 +17,7 @@ use rustworkx_core::petgraph::stable_graph::NodeIndex;
 use crate::gate_metrics::rotation_trace_and_dim;
 use crate::target::Target;
 use qiskit_circuit::PhysicalQubit;
-use qiskit_circuit::dag_circuit::DAGCircuit;
+use qiskit_circuit::dag_circuit::{DAGCircuit, PyDAGCircuit};
 use qiskit_circuit::operations::Operation;
 use qiskit_circuit::operations::OperationRef;
 use qiskit_circuit::operations::Param;
@@ -28,6 +28,14 @@ const MINIMUM_TOL: f64 = 1e-12;
 
 #[pyfunction]
 #[pyo3(name = "remove_identity_equiv", signature=(dag, approx_degree=Some(1.0), target=None))]
+pub fn py_run_remove_identity_equiv(
+    dag: &mut PyDAGCircuit,
+    approx_degree: Option<f64>,
+    target: Option<&Target>,
+) {
+    run_remove_identity_equiv(&mut dag.dag_circuit, approx_degree, target)
+}
+
 pub fn run_remove_identity_equiv(
     dag: &mut DAGCircuit,
     approx_degree: Option<f64>,
@@ -154,6 +162,6 @@ pub fn run_remove_identity_equiv(
 }
 
 pub fn remove_identity_equiv_mod(m: &Bound<PyModule>) -> PyResult<()> {
-    m.add_wrapped(wrap_pyfunction!(run_remove_identity_equiv))?;
+    m.add_wrapped(wrap_pyfunction!(py_run_remove_identity_equiv))?;
     Ok(())
 }

--- a/crates/transpiler/src/passes/sabre/dag.rs
+++ b/crates/transpiler/src/passes/sabre/dag.rs
@@ -35,7 +35,9 @@ fn control_flow_block_dags<'a>(
         .getattr("blocks")?
         .cast::<PyTuple>()?
         .iter()
-        .map(move |block| circuit_to_dag(block.extract()?, false, None, None)))
+        .map(move |block| {
+            circuit_to_dag(block.extract()?, false, None, None).map(|x| x.dag_circuit)
+        }))
 }
 
 /// The type of a node in the Sabre interactions graph.

--- a/crates/transpiler/src/passes/sabre/mod.rs
+++ b/crates/transpiler/src/passes/sabre/mod.rs
@@ -25,8 +25,8 @@ pub use layout::sabre_layout_and_routing;
 pub(crate) use route::sabre_routing;
 
 pub fn sabre(m: &Bound<PyModule>) -> PyResult<()> {
-    m.add_wrapped(wrap_pyfunction!(route::sabre_routing))?;
-    m.add_wrapped(wrap_pyfunction!(layout::sabre_layout_and_routing))?;
+    m.add_wrapped(wrap_pyfunction!(route::py_sabre_routing))?;
+    m.add_wrapped(wrap_pyfunction!(layout::py_sabre_layout_and_routing))?;
     m.add_class::<route::PyRoutingTarget>()?;
     m.add_class::<heuristic::SetScaling>()?;
     m.add_class::<heuristic::Heuristic>()?;

--- a/crates/transpiler/src/passes/unroll_3q_or_more.rs
+++ b/crates/transpiler/src/passes/unroll_3q_or_more.rs
@@ -16,7 +16,7 @@ use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
 use crate::QiskitError;
 use crate::target::Target;
-use qiskit_circuit::dag_circuit::DAGCircuit;
+use qiskit_circuit::dag_circuit::{DAGCircuit, PyDAGCircuit};
 use qiskit_circuit::operations::Operation;
 use thiserror::Error;
 
@@ -30,8 +30,8 @@ pub enum Unroll3qError {
 
 #[pyfunction]
 #[pyo3(name = "unroll_3q_or_more")]
-pub fn py_unroll_3q_or_more(dag: &mut DAGCircuit, target: Option<&Target>) -> PyResult<()> {
-    run_unroll_3q_or_more(dag, target).map_err(|err| match err {
+pub fn py_unroll_3q_or_more(dag: &mut PyDAGCircuit, target: Option<&Target>) -> PyResult<()> {
+    run_unroll_3q_or_more(&mut dag.dag_circuit, target).map_err(|err| match err {
         Unroll3qError::NoDefinition(e) => QiskitError::new_err(format!(
             "Cannot unroll all 3q or more gates. No rule to expand {}",
             e
@@ -63,8 +63,7 @@ pub fn run_unroll_3q_or_more(
                     }
                 };
                 let mut decomp_dag =
-                    match DAGCircuit::from_circuit_data(&definition, false, None, None, None, None)
-                    {
+                    match DAGCircuit::from_circuit_data(&definition, false, None, None) {
                         Ok(dag) => dag,
                         Err(e) => return Some(Err(Unroll3qError::SubstitutionError(e))),
                     };

--- a/crates/transpiler/src/passes/wrap_angles.rs
+++ b/crates/transpiler/src/passes/wrap_angles.rs
@@ -17,17 +17,17 @@ use rustworkx_core::petgraph::prelude::*;
 use crate::angle_bound_registry::{PyWrapAngleRegistry, WrapAngleRegistry};
 use crate::target::Target;
 use qiskit_circuit::PhysicalQubit;
-use qiskit_circuit::dag_circuit::DAGCircuit;
+use qiskit_circuit::dag_circuit::{DAGCircuit, PyDAGCircuit};
 use qiskit_circuit::operations::{Operation, Param};
 
 #[pyfunction]
 #[pyo3(name = "wrap_angles")]
 pub fn py_run_wrap_angles(
-    dag: &mut DAGCircuit,
+    dag: &mut PyDAGCircuit,
     target: &Target,
     bounds_registry: &PyWrapAngleRegistry,
 ) -> PyResult<()> {
-    run_wrap_angles(dag, target, bounds_registry.get_inner())
+    run_wrap_angles(&mut dag.dag_circuit, target, bounds_registry.get_inner())
 }
 
 pub fn run_wrap_angles(

--- a/crates/transpiler/src/transpiler.rs
+++ b/crates/transpiler/src/transpiler.rs
@@ -59,21 +59,21 @@ pub fn transpile(
     approximation_degree: Option<f64>,
     seed: Option<u64>,
 ) -> Result<(CircuitData, TranspileLayout)> {
-    let mut dag = DAGCircuit::from_circuit_data(circuit, false, None, None, None, None)?;
+    let mut dag = DAGCircuit::from_circuit_data(circuit, false, None, None)?;
     let mut commutation_checker = get_standard_commutation_checker();
     let mut equivalence_library = generate_standard_equivalence_library();
     let mut transpile_layout: TranspileLayout = TranspileLayout::new(
         None,
         None,
         dag.qubits().objects().to_owned(),
-        dag.num_qubits() as u32,
+        dag.qubits().len() as u32,
         dag.qregs().to_vec(),
     );
 
     let unroll_3q_or_more = |dag: &mut DAGCircuit| -> Result<()> {
         let mut out_dag = run_unitary_synthesis(
             dag,
-            (0..dag.num_qubits()).collect(),
+            (0..dag.qubits().len()).collect(),
             3,
             Some(target),
             HashSet::new(),
@@ -272,7 +272,7 @@ pub fn transpile(
     }
     // Translation Stage
     let translation = |dag: &mut DAGCircuit, equiv_lib: &mut EquivalenceLibrary| -> Result<()> {
-        let num_qubits = dag.num_qubits();
+        let num_qubits = dag.qubits().len();
         *dag = run_unitary_synthesis(
             dag,
             (0..num_qubits).collect(),
@@ -323,9 +323,9 @@ pub fn transpile(
         }
     } else if optimization_level == OptimizationLevel::Level2 {
         run_consolidate_blocks(&mut dag, false, approximation_degree, Some(target))?;
-        let num_qubits = dag.num_qubits();
+        let num_qubits = dag.qubits().len();
         dag = run_unitary_synthesis(
-            &mut dag,
+            &dag,
             (0..num_qubits).collect(),
             0,
             Some(target),
@@ -357,9 +357,9 @@ pub fn transpile(
 
         while continue_loop {
             run_consolidate_blocks(&mut dag, false, approximation_degree, Some(target))?;
-            let num_qubits = dag.num_qubits();
+            let num_qubits = dag.qubits().len();
             dag = run_unitary_synthesis(
-                &mut dag,
+                &dag,
                 (0..num_qubits).collect(),
                 0,
                 Some(target),

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -217,7 +217,7 @@ class UnitarySynthesis(TransformationPass):
             _coupling_edges = (
                 set(self._coupling_map.get_edges()) if self._coupling_map is not None else set()
             )
-            out = run_main_loop(
+            run_main_loop(
                 dag,
                 list(qubit_indices.values()),
                 self._min_qubits,
@@ -229,7 +229,7 @@ class UnitarySynthesis(TransformationPass):
                 self._natural_direction,
                 self._pulse_optimize,
             )
-            return out
+            return dag
         else:
             for method, kwargs in method_list:
                 if method.supports_basis_gates:


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit splits out the Python only component of the DAGCircuit struct in Rust. The DAGCircuit struct has two fields that explicitly require Python, `metadata` and `duration`, and there are two more fields that are only ever used in Python, `unit` and `name` despite both being strings. To make the Python component distinct and separable this makes a separate Python interface struct PyDAGCircuit which wraps the inner pure rust DAGCircuit that contains the extra data for Python. This struct also defines all the Python methods so the inner rust DAGCircuit doesn't define any interface to Python anymore and it's all isolated to the

This commit will prepare us towards implementing #14240 to make pyo3 and needing python symbols a compile time option. While it is possible to conditionally compile all these aspects everywhere there are a few advantages an explict stuct provides. The first is making all the places we expect a Python interface very explicit. This makes it easy to reason about special handling only needed for python and isolate it to separate blocks. It also reduces the code complexity for when we do insert conditional compilation features, because we only need to add the cfg attributes to a few outer places instead of handling it internally in every spot something from Python is used. Looking to the future the long term goal this split enables is moving the Python aspects of the DAGCircuit and the transpiler to the pyext crate. Having all the Python interface components be separate structs and functions means when we finish the data model migration all these interface points can just be moved to the pyext crate since they'll be self contained. We can't do that yet as control flow is still dependent on the Python interface.

### Details and comments

TODO:

- [ ] Fix test failures/panics with control flow (circuit to dag issues)