### PR TITLE
Add internal direct 2q synthesis interface to UnitarySynthesis

### DIFF
--- a/crates/transpiler/src/passes/unitary_synthesis/mod.rs
+++ b/crates/transpiler/src/passes/unitary_synthesis/mod.rs
@@ -488,14 +488,48 @@ fn synthesize_1q_matrix_onto(
     Ok(true)
 }
 
-fn synthesize_2q_matrix_onto(
-    out: &mut DAGCircuitBuilder,
+#[derive(Debug)]
+pub struct TwoQSynthesisResult {
+    pub sequence: TwoQubitGateSequence,
+    pub dir: Direction2q,
+    pub fidelity: Option<f64>,
+}
+
+#[inline]
+pub fn fidelity_2q_sequence(
+    pair: &(Direction2q, TwoQubitGateSequence),
+    constraint: &QpuConstraint,
+    qargs_phys: [PhysicalQubit; 2],
+) -> f64 {
+    let QpuConstraint::Target(target) = &constraint else {
+        return 1.;
+    };
+    let (dir, sequence) = pair;
+    let order = dir.as_indices();
+    let phys = [qargs_phys[order[0] as usize], qargs_phys[order[1] as usize]];
+    sequence
+        .gates()
+        .iter()
+        .map(|(op, _, qubits)| {
+            let qargs: &[_] = match *qubits.as_slice() {
+                [q] => &[phys[q as usize]],
+                [q1, q2] => &[phys[q1 as usize], phys[q2 as usize]],
+                _ => panic!("sequences should only contain 1q and 2q gates"),
+            };
+            // TODO: this does not handle the possibility of a 2q decomposer (like the
+            // XXDecomposer) using specialised instructions whose operation names do not match
+            // their target key.
+            1. - target.get_error(op.name(), qargs).unwrap_or(0.)
+        })
+        .product()
+}
+
+pub fn synthesize_2q_matrix(
     mut unitary: CowArray<Complex64, Ix2>,
     qargs_phys: [PhysicalQubit; 2],
-    qargs_virt: [Qubit; 2],
     state: &mut UnitarySynthesisState,
     constraint: QpuConstraint,
-) -> PyResult<bool> {
+) -> PyResult<Option<TwoQSynthesisResult>> {
     let decomposer_cache = &mut state.cache;
     let config = &state.config;
 
@@ -548,31 +582,7 @@ fn synthesize_2q_matrix_onto(
         // inconsistent; either it should be an error in _all_ circumstances if synthesis fails or
         // in _none_.  It's tricky to recreate the pre-Qiskit-2.4 behaviour bug-for-bug in the new
         // refactor because of how the split between decomposer construction and use works now.
-        return Ok(false);
-    };
-
-    let fidelity = |pair: &(Direction2q, TwoQubitGateSequence)| -> f64 {
-        let QpuConstraint::Target(target) = &constraint else {
-            return 1.;
-        };
-        let (dir, sequence) = pair;
-        let order = dir.as_indices();
-        let phys = [qargs_phys[order[0] as usize], qargs_phys[order[1] as usize]];
-        sequence
-            .gates()
-            .iter()
-            .map(|(op, _, qubits)| {
-                let qargs: &[_] = match *qubits.as_slice() {
-                    [q] => &[phys[q as usize]],
-                    [q1, q2] => &[phys[q1 as usize], phys[q2 as usize]],
-                    _ => panic!("sequences should only contain 1q and 2q gates"),
-                };
-                // TODO: this does not handle the possibility of a 2q decomposer (like the
-                // XXDecomposer) using specialised instructions whose operation names do not match
-                // their target key.
-                1. - target.get_error(op.name(), qargs).unwrap_or(0.)
-            })
-            .product()
+        return Ok(None);
     };
 
     // We only need to calculate the best score if there's more than one sequence.
@@ -580,8 +590,9 @@ fn synthesize_2q_matrix_onto(
     let mut best_pair = first;
     for sequence in sequences {
         let sequence = sequence?;
-        let prev_fidelity = best_fidelity.unwrap_or_else(|| fidelity(&best_pair));
-        let this_fidelity = fidelity(&sequence);
+        let prev_fidelity = best_fidelity
+            .unwrap_or_else(|| fidelity_2q_sequence(&best_pair, &constraint, qargs_phys));
+        let this_fidelity = fidelity_2q_sequence(&sequence, &constraint, qargs_phys);
         if this_fidelity > prev_fidelity {
             best_fidelity = Some(this_fidelity);
             best_pair = sequence;
@@ -589,10 +600,26 @@ fn synthesize_2q_matrix_onto(
             best_fidelity = Some(prev_fidelity);
         }
     }
+    Ok(Some(TwoQSynthesisResult {
+        sequence: best_pair.1,
+        dir: best_pair.0,
+        fidelity: best_fidelity,
+    }))
+}
 
+fn synthesize_2q_matrix_onto(
+    out: &mut DAGCircuitBuilder,
+    unitary: CowArray<Complex64, Ix2>,
+    qargs_phys: [PhysicalQubit; 2],
+    qargs_virt: [Qubit; 2],
+    state: &mut UnitarySynthesisState,
+    constraint: QpuConstraint,
+) -> PyResult<bool> {
+    let Some(result) = synthesize_2q_matrix(unitary, qargs_phys, state, constraint)? else {
+        return Ok(false);
+    };
     // ... now apply the best sequence.
-    let (dir, sequence) = best_pair;
-    let order = dir.as_indices();
+    let order = result.dir.as_indices();
     let out_qargs = [qargs_virt[order[0] as usize], qargs_virt[order[1] as usize]];
     let qubit_keys = [
         out.insert_qargs(&[out_qargs[0]]),
@@ -600,8 +627,8 @@ fn synthesize_2q_matrix_onto(
         out.insert_qargs(&[out_qargs[0], out_qargs[1]]),
         out.insert_qargs(&[out_qargs[1], out_qargs[0]]),
     ];
-    out.add_global_phase(&Param::Float(sequence.global_phase()))?;
-    for (gate, params, qubits) in sequence.gates() {
+    out.add_global_phase(&Param::Float(result.sequence.global_phase()))?;
+    for (gate, params, qubits) in result.sequence.gates() {
         let qubits = match qubits.as_slice() {
             [0] => qubit_keys[0],
             [1] => qubit_keys[1],


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds an internal dedicated function to the UnitarySynthesis function to enable other passes that are synthesizes unitaries to reuse the logic from UnitarySynthesis. We're looking at adding new passes that will do 2q synthesized to a target, specifically the two qubit peephole optimization pass being added in #13419. The new interface in this PR lets that pass (and potential future passes) reuse the logic from unitary synthesis without the rest of the infrastructure. This was originally part of #13419 but this opts to split it out since it's logically independent from the PR adding the new pass.

### Details and comments


