### PR TITLE
Format floating-point values in the Rust circuit drawer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,6 +1314,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2234,6 +2291,8 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "itertools 0.14.0",
+ "lexical-core",
+ "lexical-write-float",
  "nalgebra 0.34.2",
  "ndarray",
  "nom",

--- a/crates/circuit/Cargo.toml
+++ b/crates/circuit/Cargo.toml
@@ -32,7 +32,9 @@ nom-unicode.workspace = true
 nom-language.workspace = true
 crossterm = "0.29.0"
 unicode-width = "0.2"
-unicode-segmentation = "1.13"
+unicode-segmentation = "1.12"
+lexical-core = "1.0.6"
+lexical-write-float = "1.0.6"
 
 [dependencies.pyo3]
 workspace = true

--- a/crates/circuit/Cargo.toml
+++ b/crates/circuit/Cargo.toml
@@ -32,7 +32,7 @@ nom-unicode.workspace = true
 nom-language.workspace = true
 crossterm = "0.29.0"
 unicode-width = "0.2"
-unicode-segmentation = "1.12"
+unicode-segmentation = "1.13"
 lexical-core = "1.0.6"
 lexical-write-float = "1.0.6"
 

--- a/crates/circuit/src/circuit_drawer.rs
+++ b/crates/circuit/src/circuit_drawer.rs
@@ -685,13 +685,13 @@ struct F64UiFormatter {
 }
 
 impl F64UiFormatter {
-    fn new(num_significant_digits: i32) -> Self {
+    fn new(num_significant_digits: usize) -> Self {
         let options = lexical_write_float::Options::builder()
-            .max_significant_digits(core::num::NonZeroUsize::new(
-                num_significant_digits as usize,
+            .max_significant_digits(core::num::NonZeroUsize::new(num_significant_digits))
+            .positive_exponent_break(core::num::NonZeroI32::new(num_significant_digits as i32))
+            .negative_exponent_break(core::num::NonZeroI32::new(
+                -(num_significant_digits as i32) + 1,
             ))
-            .positive_exponent_break(core::num::NonZeroI32::new(num_significant_digits))
-            .negative_exponent_break(core::num::NonZeroI32::new(-num_significant_digits + 1))
             .trim_floats(true)
             .build_strict();
 
@@ -2231,6 +2231,25 @@ q_1: ┤ Rz(1.2346e8) ├┤ Rx(0.12346) ├┤ Rx(1.2346e-5) ├
 
         for test in test_points {
             assert_eq!(format_float_pi(test.0), test.1.map(|s| s.to_string()));
+        }
+    }
+
+    #[test]
+    fn test_f64_ui_formatter() {
+        let test_data_5_sig_digits = [
+            (-1.23, "-1.23"),
+            (1.23456, "1.2346"),
+            (-12.34567, "-12.346"),
+            (123456.78, "123460"),
+            (-0.0001, "-0.0001"),
+            (12.34 * 1_000_000.0, "1.234e7"),
+            (-0.00001, "-1e-5"),
+            (12345678.000001, "1.2346e7"),
+        ];
+
+        let mut formatter = F64UiFormatter::new(5);
+        for test in test_data_5_sig_digits {
+            assert_eq!(test.1, formatter.format(test.0));
         }
     }
 }

--- a/crates/circuit/src/circuit_drawer.rs
+++ b/crates/circuit/src/circuit_drawer.rs
@@ -63,7 +63,10 @@ pub fn draw_circuit(
             if approx::abs_diff_eq!(*f, 0.) {
                 String::new()
             } else {
-                format!("global phase: {}\n", F64UiFormatter::new(5).format(*f))
+                format!(
+                    "global phase: {}\n",
+                    F64UiFormatter::new(5).format_with_pi(*f)
+                )
             }
         }
         Param::ParameterExpression(expr) => {
@@ -672,13 +675,19 @@ impl TextWireElement {
     }
 }
 
-/// A simple formatter for rendering nicely-truncated floating-point numbers,
-/// in a way similar to Python's g or printf's %g format specifiers.
+/// A formatter for UI rendering of floating-point numbers
+///
+/// Supports formatting similar to Python's `g` or C printf's `%g` format specifiers
+/// as well as formatting of multiples and fractions of pi.
+///
 /// Example outputs:
-/// F64UiFormatter::new(4).format(1.23456) --> 1.235
-/// F64UiFormatter::new(4).format(123.456) --> 123.5
-/// F64UiFormatter::new(5).format(12345678f64) --> 1.2346e7
-/// F64UiFormatter::new(5).format(-0.00001234) --> -1.234e-5
+/// ```text
+/// F64UiFormatter::new(4).format(1.23456)        → 1.235
+/// F64UiFormatter::new(4).format(123.456)        → 123.5
+/// F64UiFormatter::new(5).format(12345678.0)     → 1.2346e7
+/// F64UiFormatter::new(5).format(-0.00001234)    → -1.234e-5
+/// F64UiFormatter::new(5).format_with_pi(5π/6)   → 5π/6
+/// ```
 struct F64UiFormatter {
     buffer: Vec<u8>,
     options: lexical_write_float::Options,
@@ -706,6 +715,12 @@ impl F64UiFormatter {
     fn format(&mut self, num: f64) -> &str {
         let buf = num.to_lexical_with_options::<STANDARD>(&mut self.buffer, &self.options);
         std::str::from_utf8_mut(buf).expect("Byte representation should be valid")
+    }
+
+    /// Tries to format the string as a multiple or simple fraction of pi if possible,
+    /// otherwise falls back to the simpler [F64UiFormatter::format] logic
+    fn format_with_pi(&mut self, num: f64) -> String {
+        format_float_pi(num).unwrap_or_else(|| self.format(num).to_owned())
     }
 }
 
@@ -807,7 +822,9 @@ impl TextDrawer {
                         .params_view()
                         .iter()
                         .map(|param| match param {
-                            Param::Float(f) => F64UiFormatter::new(5).format(*f).to_string(),
+                            Param::Float(f) => {
+                                F64UiFormatter::new(5).format_with_pi(*f).to_string()
+                            }
                             Param::ParameterExpression(expr) => expr.to_string(),
                             _ => format!("{:?}", param),
                         })
@@ -2139,7 +2156,7 @@ q_1: ┤ Ry(🎩) ├┤1          ├┤ 💶🔉(🎩) ├┤1           ├�
             ShareableQubit::new_anonymous(),
             ShareableQubit::new_anonymous(),
         ];
-        let mut circuit = CircuitData::new(Some(qubits), None, Param::Float(12.3)).unwrap();
+        let mut circuit = CircuitData::new(Some(qubits), None, Param::Float(0.8 * PI)).unwrap();
 
         circuit
             .push_standard_gate(StandardGate::RX, &[Param::Float(1.234567)], &[Qubit(0)])
@@ -2165,15 +2182,22 @@ q_1: ┤ Ry(🎩) ├┤1          ├┤ 💶🔉(🎩) ├┤1           ├�
         circuit
             .push_standard_gate(StandardGate::RX, &[Param::Float(0.0000123456)], &[Qubit(1)])
             .unwrap();
+        circuit
+            .push_standard_gate(
+                StandardGate::RX,
+                &[Param::Float(2.0 / 3.0 * PI)],
+                &[Qubit(1)],
+            )
+            .unwrap();
 
         let result = draw_circuit(&circuit, true, true, None).unwrap();
         let expected = "
-global phase: 6.0168
+global phase: 4π/5
       ┌────────────┐ ┌────────────┐ ┌───────────────┐
-q_0: ─┤ Rx(1.2346) ├─┤ Rx(123.46) ├─┤ Ry(1.23456*ϕ) ├
-     ┌┴────────────┴┐├────────────┴┐├───────────────┤
-q_1: ┤ Rz(1.2346e8) ├┤ Rx(0.12346) ├┤ Rx(1.2346e-5) ├
-     └──────────────┘└─────────────┘└───────────────┘
+q_0: ─┤ Rx(1.2346) ├─┤ Rx(123.46) ├─┤ Ry(1.23456*ϕ) ├────────────
+     ┌┴────────────┴┐├────────────┴┐├───────────────┤┌──────────┐
+q_1: ┤ Rz(1.2346e8) ├┤ Rx(0.12346) ├┤ Rx(1.2346e-5) ├┤ Rx(2π/3) ├
+     └──────────────┘└─────────────┘└───────────────┘└──────────┘
 ";
 
         assert_eq!(result, expected.trim_start_matches("\n"));
@@ -2245,11 +2269,13 @@ q_1: ┤ Rz(1.2346e8) ├┤ Rx(0.12346) ├┤ Rx(1.2346e-5) ├
             (12.34 * 1_000_000.0, "1.234e7"),
             (-0.00001, "-1e-5"),
             (12345678.000001, "1.2346e7"),
+            (15.0 * PI / 16.0, "15π/16"),
+            (-2.0 * PI / 3.0, "-2π/3"),
         ];
 
         let mut formatter = F64UiFormatter::new(5);
         for test in test_data_5_sig_digits {
-            assert_eq!(test.1, formatter.format(test.0));
+            assert_eq!(test.1.to_owned(), formatter.format_with_pi(test.0));
         }
     }
 }

--- a/crates/circuit/src/circuit_drawer.rs
+++ b/crates/circuit/src/circuit_drawer.rs
@@ -19,6 +19,8 @@ use approx;
 use crossterm::terminal;
 use hashbrown::HashSet;
 use itertools::{Itertools, MinMaxResult};
+use lexical_core::ToLexicalWithOptions;
+use lexical_write_float::{self, format::STANDARD};
 use pyo3::prelude::*;
 use std::f64::consts::PI;
 use std::fmt::Debug;
@@ -61,10 +63,7 @@ pub fn draw_circuit(
             if approx::abs_diff_eq!(*f, 0.) {
                 String::new()
             } else {
-                format!(
-                    "global phase: {}\n",
-                    format_float_pi(*f).unwrap_or_else(|| f.to_string())
-                )
+                format!("global phase: {}\n", F64UiFormatter::new(5).format(*f))
             }
         }
         Param::ParameterExpression(expr) => {
@@ -673,6 +672,43 @@ impl TextWireElement {
     }
 }
 
+/// A simple formatter for rendering nicely-truncated floating-point numbers,
+/// in a way similar to Python's g or printf's %g format specifiers.
+/// Example outputs:
+/// F64UiFormatter::new(4).format(1.23456) --> 1.235
+/// F64UiFormatter::new(4).format(123.456) --> 123.5
+/// F64UiFormatter::new(5).format(12345678f64) --> 1.2346e7
+/// F64UiFormatter::new(5).format(-0.00001234) --> -1.234e-5
+struct F64UiFormatter {
+    buffer: Vec<u8>,
+    options: lexical_write_float::Options,
+}
+
+impl F64UiFormatter {
+    fn new(num_significant_digits: i32) -> Self {
+        let options = lexical_write_float::Options::builder()
+            .max_significant_digits(core::num::NonZeroUsize::new(
+                num_significant_digits as usize,
+            ))
+            .positive_exponent_break(core::num::NonZeroI32::new(num_significant_digits))
+            .negative_exponent_break(core::num::NonZeroI32::new(-num_significant_digits + 1))
+            .trim_floats(true)
+            .build_strict();
+
+        F64UiFormatter {
+            buffer: vec![0u8; options.buffer_size_const::<f64, STANDARD>()],
+            options,
+        }
+    }
+
+    /// Formats the input number based on the formatting options.
+    /// This Can be called multiple times, but the internal buffer is overwritten on each call.
+    fn format(&mut self, num: f64) -> &str {
+        let buf = num.to_lexical_with_options::<STANDARD>(&mut self.buffer, &self.options);
+        std::str::from_utf8_mut(buf).expect("Byte representation should be valid")
+    }
+}
+
 pub const Q_WIRE: char = '─';
 pub const C_WIRE: char = '═';
 pub const TOP_CON: char = '┴';
@@ -735,7 +771,11 @@ impl TextDrawer {
                     StandardInstruction::Delay(delay_unit) => {
                         match instruction.params_view().first().unwrap() {
                             Param::Float(duration) => {
-                                format!("Delay({}[{}])", duration, delay_unit)
+                                format!(
+                                    "Delay({}[{}])",
+                                    F64UiFormatter::new(5).format(*duration),
+                                    delay_unit
+                                )
                             }
                             Param::ParameterExpression(expr) => {
                                 format!("Delay({}[{}])", expr, delay_unit)
@@ -767,7 +807,7 @@ impl TextDrawer {
                         .params_view()
                         .iter()
                         .map(|param| match param {
-                            Param::Float(f) => format_float_pi(*f).unwrap_or_else(|| f.to_string()),
+                            Param::Float(f) => F64UiFormatter::new(5).format(*f).to_string(),
                             Param::ParameterExpression(expr) => expr.to_string(),
                             _ => format!("{:?}", param),
                         })
@@ -2089,6 +2129,53 @@ q_0: ──────────┤0  Rxx(🎩) ├────────�
 q_1: ┤ Ry(🎩) ├┤1          ├┤ 💶🔉(🎩) ├┤1           ├┤1         ├
      └────────┘└───────────┘└──────────┘└────────────┘└──────────┘
 ";
+        assert_eq!(result, expected.trim_start_matches("\n"));
+    }
+
+    #[cfg(not(miri))]
+    #[test]
+    fn test_f64_formatting() {
+        let qubits = vec![
+            ShareableQubit::new_anonymous(),
+            ShareableQubit::new_anonymous(),
+        ];
+        let mut circuit = CircuitData::new(Some(qubits), None, Param::Float(12.3)).unwrap();
+
+        circuit
+            .push_standard_gate(StandardGate::RX, &[Param::Float(1.234567)], &[Qubit(0)])
+            .unwrap();
+        circuit
+            .push_standard_gate(StandardGate::RX, &[Param::Float(123.4567)], &[Qubit(0)])
+            .unwrap();
+
+        let expr = ParameterExpression::from_symbol(Symbol::new("ϕ", None, None))
+            .mul(&ParameterExpression::from_f64(1.23456))
+            .unwrap();
+        let param = Param::ParameterExpression(Arc::new(expr));
+        circuit
+            .push_standard_gate(StandardGate::RY, &[param], &[Qubit(0)])
+            .unwrap();
+        circuit
+            .push_standard_gate(StandardGate::RZ, &[Param::Float(123456789f64)], &[Qubit(1)])
+            .unwrap();
+
+        circuit
+            .push_standard_gate(StandardGate::RX, &[Param::Float(0.1234567)], &[Qubit(1)])
+            .unwrap();
+        circuit
+            .push_standard_gate(StandardGate::RX, &[Param::Float(0.0000123456)], &[Qubit(1)])
+            .unwrap();
+
+        let result = draw_circuit(&circuit, true, true, None).unwrap();
+        let expected = "
+global phase: 6.0168
+      ┌────────────┐ ┌────────────┐ ┌───────────────┐
+q_0: ─┤ Rx(1.2346) ├─┤ Rx(123.46) ├─┤ Ry(1.23456*ϕ) ├
+     ┌┴────────────┴┐├────────────┴┐├───────────────┤
+q_1: ┤ Rz(1.2346e8) ├┤ Rx(0.12346) ├┤ Rx(1.2346e-5) ├
+     └──────────────┘└─────────────┘└───────────────┘
+";
+
         assert_eq!(result, expected.trim_start_matches("\n"));
     }
 


### PR DESCRIPTION
This commit adds formatting functionality to render floating-point values (e.g. rotation angles) in a way similar to the `g` formatting flag in Python.

This PR addresses item 3 in #15849

### Details and comments
For example, this results in an output like this: 
```text
global phase: 6.0168
      ┌────────────┐ ┌────────────┐ ┌───────────────┐
q_0: ─┤ Rx(1.2346) ├─┤ Rx(123.46) ├─┤ Ry(1.23456*ϕ) ├
     ┌┴────────────┴┐├────────────┴┐├───────────────┤
q_1: ┤ Rz(1.2346e8) ├┤ Rx(0.12346) ├┤ Rx(1.2346e-5) ├
     └──────────────┘└─────────────┘└───────────────┘
```
instead of: 
```text
global phase: 6.0168146928204145
     ┌──────────────┐ ┌──────────────┐  ┌───────────────┐
q_0: ┤ Rx(1.234567) ├─┤ Rx(123.4567) ├──┤ Ry(1.23456*ϕ) ├──
     ├──────────────┴┐├──────────────┴┐┌┴───────────────┴─┐
q_1: ┤ Rz(123456789) ├┤ Rx(0.1234567) ├┤ Rx(0.0000123456) ├
     └───────────────┘└───────────────┘└──────────────────┘
```



