### PR TITLE
Move 2q block-consolidation logic to `qiskit-synthesis`

### DIFF
--- a/crates/quantum_info/src/lib.rs
+++ b/crates/quantum_info/src/lib.rs
@@ -11,7 +11,6 @@
 // that they have been altered from the originals.
 
 pub mod clifford;
-pub mod convert_2q_block_matrix;
 pub mod pauli_lindblad_map;
 pub mod sparse_observable;
 pub mod sparse_pauli_op;

--- a/crates/synthesis/src/lib.rs
+++ b/crates/synthesis/src/lib.rs
@@ -17,6 +17,7 @@ pub mod evolution;
 pub mod linalg;
 pub mod linear;
 pub mod linear_phase;
+pub mod matrix;
 mod multi_controlled;
 pub mod pauli_evolution;
 pub mod pauli_products;

--- a/crates/synthesis/src/matrix/mod.rs
+++ b/crates/synthesis/src/matrix/mod.rs
@@ -1,0 +1,13 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+pub mod two_qubit;

--- a/crates/synthesis/src/matrix/two_qubit.rs
+++ b/crates/synthesis/src/matrix/two_qubit.rs
@@ -10,7 +10,6 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use pyo3::Python;
 use pyo3::intern;
 use pyo3::prelude::*;
 
@@ -26,9 +25,9 @@ use qiskit_circuit::imports::QI_OPERATOR;
 use qiskit_circuit::interner::Interner;
 use qiskit_circuit::operations::{ArrayType, OperationRef};
 use qiskit_circuit::packed_instruction::PackedInstruction;
+use qiskit_quantum_info::versor_u2::{VersorSU2, VersorU2, VersorU2Error};
 
 use crate::QiskitError;
-use crate::versor_u2::{VersorSU2, VersorU2, VersorU2Error};
 
 #[inline]
 fn matrix4_from_pyreadonly(array: &PyReadonlyArray2<Complex64>) -> Matrix4<Complex64> {

--- a/crates/synthesis/src/qsd.rs
+++ b/crates/synthesis/src/qsd.rs
@@ -31,6 +31,7 @@ use crate::euler_one_qubit_decomposer::{
 use crate::linalg::{
     closest_unitary, is_hermitian_matrix, nalgebra_array_view, svd_decomposition, verify_unitary,
 };
+use crate::matrix::two_qubit;
 use crate::two_qubit_decompose::{TwoQubitBasisDecomposer, two_qubit_decompose_up_to_diagonal};
 use qiskit_circuit::bit::ShareableQubit;
 use qiskit_circuit::circuit_data::{CircuitData, CircuitDataError, PyCircuitData};
@@ -38,7 +39,6 @@ use qiskit_circuit::interner::Interned;
 use qiskit_circuit::operations::{ArrayType, OperationRef, Param, StandardGate, UnitaryGate};
 use qiskit_circuit::packed_instruction::{PackedInstruction, PackedOperation};
 use qiskit_circuit::{BlocksMode, Qubit, VarsMode};
-use qiskit_quantum_info::convert_2q_block_matrix::instructions_to_matrix;
 
 const EPS: f64 = 1e-10;
 
@@ -719,7 +719,7 @@ fn apply_a2(
     for ind in ind2q.windows(2) {
         let mat1 = match diagonal_rollover.get(&ind[0]) {
             Some(circ) => {
-                let mat: Matrix4<Complex64> = instructions_to_matrix(
+                let mat: Matrix4<Complex64> = two_qubit::instructions_to_matrix(
                     circ.data().iter(),
                     [Qubit(0), Qubit(1)],
                     circ.qargs_interner(),
@@ -730,7 +730,7 @@ fn apply_a2(
         };
         let mat2 = match diagonal_rollover.get(&ind[1]) {
             Some(circ) => nalgebra_array_view::<Complex64, U4, U4>(
-                instructions_to_matrix(
+                two_qubit::instructions_to_matrix(
                     circ.data().iter(),
                     [Qubit(0), Qubit(1)],
                     circ.qargs_interner(),

--- a/crates/synthesis/src/two_qubit_decompose/basis_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/basis_decomposer.rs
@@ -34,7 +34,7 @@ use crate::euler_one_qubit_decomposer::{
     unitary_to_gate_sequence_inner,
 };
 use crate::linalg::ndarray_to_faer;
-use qiskit_quantum_info::convert_2q_block_matrix::change_basis;
+use crate::matrix::two_qubit;
 
 use qiskit_circuit::bit::ShareableQubit;
 use qiskit_circuit::circuit_data::{CircuitData, PyCircuitData};
@@ -1058,7 +1058,7 @@ fn compute_unitary(sequence: &TwoQubitSequenceVec, global_phase: f64) -> Array2<
             let result = match q_list.as_slice() {
                 [0] => Some(kron(&identity, &op_matrix)),
                 [1] => Some(kron(&op_matrix, &identity)),
-                [1, 0] => Some(change_basis(op_matrix.view())),
+                [1, 0] => Some(two_qubit::change_basis(op_matrix.view())),
                 [] => Some(Array2::eye(4)),
                 _ => None,
             };

--- a/crates/transpiler/src/passes/consolidate_blocks.rs
+++ b/crates/transpiler/src/passes/consolidate_blocks.rs
@@ -31,10 +31,10 @@ use qiskit_circuit::interner::Interned;
 use qiskit_circuit::operations::StandardGate;
 use qiskit_circuit::operations::{ArrayType, Operation, Param, UnitaryGate};
 use qiskit_circuit::packed_instruction::PackedOperation;
-use qiskit_quantum_info::convert_2q_block_matrix::{
+use qiskit_synthesis::linalg::nalgebra_array_view;
+use qiskit_synthesis::matrix::two_qubit::{
     blocks_to_matrix, get_1q_matrix_from_inst, get_2q_matrix_from_inst, get_matrix_from_inst,
 };
-use qiskit_synthesis::linalg::nalgebra_array_view;
 use qiskit_synthesis::two_qubit_decompose::RXXEquivalent;
 use qiskit_synthesis::two_qubit_decompose::{
     TwoQubitBasisDecomposer, TwoQubitControlledUDecomposer,


### PR DESCRIPTION
This is dependent on both the circuit IRs _and_ the `quantum-info` objects.  All of these functions are primarily used in synthesis, which makes `qiskit-synthesis` a relatively natural place for them; they're not _strictly_ about immediate synthesis of a matrix into circuit objects, but they are very much along the path to that.
