### PR TITLE
Move unitary matrix circuit simulator to `qiskit-synthesis`

### DIFF
--- a/crates/pyext/src/lib.rs
+++ b/crates/pyext/src/lib.rs
@@ -74,7 +74,7 @@ fn _accelerate(m: &Bound<PyModule>) -> PyResult<()> {
     add_submodule(m, ::qiskit_quantum_info::sparse_observable::sparse_observable, "sparse_observable")?;
     add_submodule(m, ::qiskit_quantum_info::sparse_pauli_op::sparse_pauli_op, "sparse_pauli_op")?;
     add_submodule(m, ::qiskit_transpiler::passes::scheduling_mod, "scheduling")?;
-    add_submodule(m, ::qiskit_quantum_info::unitary_sim::unitary_sim, "unitary_sim")?;
+    add_submodule(m, ::qiskit_synthesis::matrix::sim::unitary_sim, "unitary_sim")?;
     add_submodule(m, ::qiskit_transpiler::passes::split_2q_unitaries_mod, "split_2q_unitaries")?;
     add_submodule(m, ::qiskit_synthesis::synthesis, "synthesis")?;
     add_submodule(m, ::qiskit_transpiler::target::target, "target")?;

--- a/crates/quantum_info/src/lib.rs
+++ b/crates/quantum_info/src/lib.rs
@@ -15,7 +15,6 @@ pub mod pauli_lindblad_map;
 pub mod sparse_observable;
 pub mod sparse_pauli_op;
 pub mod unitary_compose;
-pub mod unitary_sim;
 pub mod versor_u2;
 
 mod rayon_ext;

--- a/crates/synthesis/src/matrix/mod.rs
+++ b/crates/synthesis/src/matrix/mod.rs
@@ -10,4 +10,5 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+pub mod sim;
 pub mod two_qubit;

--- a/crates/synthesis/src/matrix/sim.rs
+++ b/crates/synthesis/src/matrix/sim.rs
@@ -16,8 +16,9 @@ use numpy::IntoPyArray;
 use pyo3::prelude::*;
 use qiskit_circuit::circuit_data::{CircuitData, PyCircuitData};
 use qiskit_circuit::operations::{Operation, OperationRef, Param, StandardInstruction};
+use qiskit_quantum_info::unitary_compose;
 
-use crate::{QiskitError, unitary_compose};
+use crate::QiskitError;
 
 // The code is based on top of unitary_compose. For circuits with 13 or more qubits, einsum
 // throws an "index out of bounds" error.

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -969,8 +969,8 @@ pub fn synth_mcx_noaux_hp24(num_controls: usize) -> PyResult<CircuitData> {
 
 #[cfg(all(test, not(miri)))]
 mod test {
+    use crate::matrix::sim::sim_unitary_circuit;
     use approx::abs_diff_eq;
-    use qiskit_quantum_info::unitary_sim::sim_unitary_circuit;
 
     use super::{increment_n_dirty_large, increment_n_dirty_small};
 


### PR DESCRIPTION
This isn't the most natural place ever for it, but it wasn't really any better in `qiskit-quantum-info`, and this doesn't produce problematic ordering in the dependency chain.

Depends on #15912, but only in the sense that _one_ of the two moves needs to set up the `qiskit_synthesis::matrix` module, and I did that one first.
