### PR TITLE
Invert `qiskit-quantum-info` and `qiskit-circuit` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,6 +2113,7 @@ dependencies = [
  "num-traits",
  "numpy",
  "pyo3",
+ "qiskit-quantum-info",
  "qiskit-util",
  "rayon",
  "rustworkx-core",

--- a/crates/circuit/Cargo.toml
+++ b/crates/circuit/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 qiskit-util = { workspace = true, features = ["py"] }
+qiskit-quantum-info.workspace = true
 rayon.workspace = true
 ahash.workspace = true
 rustworkx-core.workspace = true

--- a/crates/circuit/src/standard_gate/convert.rs
+++ b/crates/circuit/src/standard_gate/convert.rs
@@ -1,0 +1,145 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use super::StandardGate;
+use crate::operations::{Operation, Param};
+use qiskit_quantum_info::versor_u2::{VersorSU2, VersorU2, VersorU2Error};
+
+use nalgebra::{Quaternion, Unit};
+use std::f64::consts::{FRAC_1_SQRT_2, FRAC_PI_2, FRAC_PI_4, FRAC_PI_8};
+
+const COS_FRAC_PI_8: f64 = 0.9238795325112867;
+const SIN_FRAC_PI_8: f64 = 0.3826834323650898;
+
+/// Conversion logic of `StandardGate::versor_u2`.
+pub fn versor_u2(gate: StandardGate, params: &[Param]) -> Result<VersorU2, VersorU2Error> {
+    debug_assert_eq!(params.len(), gate.num_params() as usize);
+    match gate {
+        StandardGate::GlobalPhase => {
+            let &[Param::Float(phase)] = params else {
+                return Err(VersorU2Error::Symbolic);
+            };
+            Ok(VersorSU2::identity().with_phase(phase))
+        }
+        StandardGate::H => {
+            Ok(
+                VersorSU2::from_quaternion_unchecked(0., -FRAC_1_SQRT_2, 0., -FRAC_1_SQRT_2)
+                    .with_phase(FRAC_PI_2),
+            )
+        }
+        StandardGate::I => Ok(VersorU2::identity()),
+        StandardGate::X => {
+            Ok(VersorSU2::from_quaternion_unchecked(0., 0., 0., -1.).with_phase(FRAC_PI_2))
+        }
+        StandardGate::Y => {
+            Ok(VersorSU2::from_quaternion_unchecked(0., 0., -1., 0.).with_phase(FRAC_PI_2))
+        }
+        StandardGate::Z => {
+            Ok(VersorSU2::from_quaternion_unchecked(0., -1., 0., 0.).with_phase(FRAC_PI_2))
+        }
+        StandardGate::Phase | StandardGate::U1 => {
+            let &[Param::Float(angle)] = params else {
+                return Err(VersorU2Error::Symbolic);
+            };
+            Ok(VersorSU2::from_rz(angle).with_phase(angle * 0.5))
+        }
+        StandardGate::R => {
+            let &[Param::Float(angle), Param::Float(axis)] = params else {
+                return Err(VersorU2Error::Symbolic);
+            };
+            let (sin_angle, cos_angle) = (angle * 0.5).sin_cos();
+            let (sin_axis, cos_axis) = axis.sin_cos();
+            Ok(VersorSU2::from_quaternion_unchecked(
+                cos_angle,
+                0.,
+                -sin_axis * sin_angle,
+                -cos_axis * sin_angle,
+            )
+            .into())
+        }
+        StandardGate::RX => {
+            let &[Param::Float(angle)] = params else {
+                return Err(VersorU2Error::Symbolic);
+            };
+            Ok(VersorSU2::from_rx(angle).into())
+        }
+        StandardGate::RY => {
+            let &[Param::Float(angle)] = params else {
+                return Err(VersorU2Error::Symbolic);
+            };
+            Ok(VersorSU2::from_ry(angle).into())
+        }
+        StandardGate::RZ => {
+            let &[Param::Float(angle)] = params else {
+                return Err(VersorU2Error::Symbolic);
+            };
+            Ok(VersorSU2::from_rz(angle).into())
+        }
+        StandardGate::S => {
+            Ok(
+                VersorSU2::from_quaternion_unchecked(FRAC_1_SQRT_2, -FRAC_1_SQRT_2, 0., 0.)
+                    .with_phase(FRAC_PI_4),
+            )
+        }
+        StandardGate::Sdg => {
+            Ok(
+                VersorSU2::from_quaternion_unchecked(FRAC_1_SQRT_2, FRAC_1_SQRT_2, 0., 0.)
+                    .with_phase(-FRAC_PI_4),
+            )
+        }
+        StandardGate::SX => {
+            Ok(
+                VersorSU2::from_quaternion_unchecked(FRAC_1_SQRT_2, 0., 0., -FRAC_1_SQRT_2)
+                    .with_phase(FRAC_PI_4),
+            )
+        }
+        StandardGate::SXdg => {
+            Ok(
+                VersorSU2::from_quaternion_unchecked(FRAC_1_SQRT_2, 0., 0., FRAC_1_SQRT_2)
+                    .with_phase(-FRAC_PI_4),
+            )
+        }
+        StandardGate::T => {
+            Ok(
+                VersorSU2::from_quaternion_unchecked(COS_FRAC_PI_8, -SIN_FRAC_PI_8, 0., 0.)
+                    .with_phase(FRAC_PI_8),
+            )
+        }
+        StandardGate::Tdg => {
+            Ok(
+                VersorSU2::from_quaternion_unchecked(COS_FRAC_PI_8, SIN_FRAC_PI_8, 0., 0.)
+                    .with_phase(-FRAC_PI_8),
+            )
+        }
+        StandardGate::U | StandardGate::U3 => {
+            let &[Param::Float(theta), Param::Float(phi), Param::Float(lambda)] = params else {
+                return Err(VersorU2Error::Symbolic);
+            };
+            Ok(
+                (VersorSU2::from_rz(phi) * VersorSU2::from_ry(theta) * VersorSU2::from_rz(lambda))
+                    .with_phase((phi + lambda) * 0.5),
+            )
+        }
+        StandardGate::U2 => {
+            let &[Param::Float(phi), Param::Float(lambda)] = params else {
+                return Err(VersorU2Error::Symbolic);
+            };
+            let (sin, cos) = (lambda * 0.5).sin_cos();
+            // The RY(pi/2).RZ(lambda) part of the decomposition, without the phase term.
+            let ry_rz = VersorSU2(Unit::new_unchecked(
+                FRAC_1_SQRT_2 * Quaternion::new(cos, -sin, -cos, -sin),
+            ));
+            Ok((VersorSU2::from_rz(phi) * ry_rz).with_phase((phi + lambda) * 0.5))
+        }
+        _ => Err(VersorU2Error::MultiQubit),
+    }
+}

--- a/crates/circuit/src/standard_gate/mod.rs
+++ b/crates/circuit/src/standard_gate/mod.rs
@@ -10,9 +10,12 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+mod convert;
+
 use crate::circuit_data::{CircuitData, PyCircuitData};
 use crate::operations::{Operation, Param, add_param, clone_param, multiply_param, radd_param};
 use crate::{Qubit, gate_matrix, impl_intopyobject_for_copy_pyclass, imports};
+use qiskit_quantum_info::versor_u2::{VersorU2, VersorU2Error};
 
 use ndarray::{Array2, aview2};
 use num_complex::Complex64;
@@ -1842,6 +1845,13 @@ impl StandardGate {
             Self::C3SX => None,
             Self::RC3X => None,
         }
+    }
+
+    /// Get the versor representation of a 1q [StandardGate] without constructing a matrix.
+    ///
+    /// Returns the error state if `gate` is not 1q, or if any of the parameters are symbolic.
+    pub fn versor_u2(&self, params: &[Param]) -> Result<VersorU2, VersorU2Error> {
+        convert::versor_u2(*self, params)
     }
 }
 

--- a/crates/quantum_info/Cargo.toml
+++ b/crates/quantum_info/Cargo.toml
@@ -10,7 +10,6 @@ name = "qiskit_quantum_info"
 doctest = false
 
 [dependencies]
-qiskit-circuit.workspace = true
 qiskit-util = { workspace = true, features = ["py"] }
 numpy.workspace = true
 num-complex.workspace = true
@@ -50,3 +49,6 @@ features = ["hashbrown", "indexmap", "num-complex", "num-bigint", "smallvec"]
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+qiskit-circuit.workspace = true

--- a/crates/quantum_info/src/versor_u2.rs
+++ b/crates/quantum_info/src/versor_u2.rs
@@ -10,17 +10,10 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use std::f64::consts::{FRAC_1_SQRT_2, FRAC_PI_2, FRAC_PI_4, FRAC_PI_8};
-
 use nalgebra::{Matrix2, Quaternion, Unit, UnitQuaternion};
 use ndarray::ArrayView2;
 use num_complex::Complex64;
 use thiserror::Error;
-
-use qiskit_circuit::operations::{Param, StandardGate};
-
-const COS_FRAC_PI_8: f64 = 0.9238795325112867;
-const SIN_FRAC_PI_8: f64 = 0.3826834323650898;
 
 #[derive(Error, Debug)]
 pub enum VersorU2Error {
@@ -75,7 +68,7 @@ impl VersorSU2 {
     /// Internally this calculates `sin` and `cos`, so discrete-angle forms will be more efficient
     /// to be written explicitly.
     #[inline]
-    fn from_rz(angle: f64) -> Self {
+    pub fn from_rz(angle: f64) -> Self {
         let (sin, cos) = (angle * 0.5).sin_cos();
         Self(Unit::new_unchecked(Quaternion::new(cos, -sin, 0., 0.)))
     }
@@ -85,7 +78,7 @@ impl VersorSU2 {
     /// Internally this calculates `sin` and `cos`, so discrete-angle forms will be more efficient
     /// to be written explicitly.
     #[inline]
-    fn from_ry(angle: f64) -> Self {
+    pub fn from_ry(angle: f64) -> Self {
         let (sin, cos) = (angle * 0.5).sin_cos();
         Self(Unit::new_unchecked(Quaternion::new(cos, 0., -sin, 0.)))
     }
@@ -95,7 +88,7 @@ impl VersorSU2 {
     /// Internally this calculates `sin` and `cos`, so discrete-angle forms will be more efficient
     /// to be written explicitly.
     #[inline]
-    fn from_rx(angle: f64) -> Self {
+    pub fn from_rx(angle: f64) -> Self {
         let (sin, cos) = (angle * 0.5).sin_cos();
         Self(Unit::new_unchecked(Quaternion::new(cos, 0., 0., -sin)))
     }
@@ -134,132 +127,6 @@ impl VersorU2 {
         Self {
             phase: 0.,
             su2: VersorSU2::identity(),
-        }
-    }
-
-    /// Get the versor representation of a 1q [StandardGate] without constructing a matrix.
-    ///
-    /// Returns the error state if `gate` is not 1q, or if any of the parameters are symbolic.
-    pub fn from_standard(gate: StandardGate, params: &[Param]) -> Result<Self, VersorU2Error> {
-        debug_assert_eq!(params.len(), gate.get_num_params() as usize);
-        match gate {
-            StandardGate::GlobalPhase => {
-                let &[Param::Float(phase)] = params else {
-                    return Err(VersorU2Error::Symbolic);
-                };
-                Ok(VersorSU2::identity().with_phase(phase))
-            }
-            StandardGate::H => {
-                Ok(
-                    VersorSU2::from_quaternion_unchecked(0., -FRAC_1_SQRT_2, 0., -FRAC_1_SQRT_2)
-                        .with_phase(FRAC_PI_2),
-                )
-            }
-            StandardGate::I => Ok(Self::identity()),
-            StandardGate::X => {
-                Ok(VersorSU2::from_quaternion_unchecked(0., 0., 0., -1.).with_phase(FRAC_PI_2))
-            }
-            StandardGate::Y => {
-                Ok(VersorSU2::from_quaternion_unchecked(0., 0., -1., 0.).with_phase(FRAC_PI_2))
-            }
-            StandardGate::Z => {
-                Ok(VersorSU2::from_quaternion_unchecked(0., -1., 0., 0.).with_phase(FRAC_PI_2))
-            }
-            StandardGate::Phase | StandardGate::U1 => {
-                let &[Param::Float(angle)] = params else {
-                    return Err(VersorU2Error::Symbolic);
-                };
-                Ok(VersorSU2::from_rz(angle).with_phase(angle * 0.5))
-            }
-            StandardGate::R => {
-                let &[Param::Float(angle), Param::Float(axis)] = params else {
-                    return Err(VersorU2Error::Symbolic);
-                };
-                let (sin_angle, cos_angle) = (angle * 0.5).sin_cos();
-                let (sin_axis, cos_axis) = axis.sin_cos();
-                Ok(VersorSU2::from_quaternion_unchecked(
-                    cos_angle,
-                    0.,
-                    -sin_axis * sin_angle,
-                    -cos_axis * sin_angle,
-                )
-                .into())
-            }
-            StandardGate::RX => {
-                let &[Param::Float(angle)] = params else {
-                    return Err(VersorU2Error::Symbolic);
-                };
-                Ok(VersorSU2::from_rx(angle).into())
-            }
-            StandardGate::RY => {
-                let &[Param::Float(angle)] = params else {
-                    return Err(VersorU2Error::Symbolic);
-                };
-                Ok(VersorSU2::from_ry(angle).into())
-            }
-            StandardGate::RZ => {
-                let &[Param::Float(angle)] = params else {
-                    return Err(VersorU2Error::Symbolic);
-                };
-                Ok(VersorSU2::from_rz(angle).into())
-            }
-            StandardGate::S => {
-                Ok(
-                    VersorSU2::from_quaternion_unchecked(FRAC_1_SQRT_2, -FRAC_1_SQRT_2, 0., 0.)
-                        .with_phase(FRAC_PI_4),
-                )
-            }
-            StandardGate::Sdg => {
-                Ok(
-                    VersorSU2::from_quaternion_unchecked(FRAC_1_SQRT_2, FRAC_1_SQRT_2, 0., 0.)
-                        .with_phase(-FRAC_PI_4),
-                )
-            }
-            StandardGate::SX => {
-                Ok(
-                    VersorSU2::from_quaternion_unchecked(FRAC_1_SQRT_2, 0., 0., -FRAC_1_SQRT_2)
-                        .with_phase(FRAC_PI_4),
-                )
-            }
-            StandardGate::SXdg => {
-                Ok(
-                    VersorSU2::from_quaternion_unchecked(FRAC_1_SQRT_2, 0., 0., FRAC_1_SQRT_2)
-                        .with_phase(-FRAC_PI_4),
-                )
-            }
-            StandardGate::T => {
-                Ok(
-                    VersorSU2::from_quaternion_unchecked(COS_FRAC_PI_8, -SIN_FRAC_PI_8, 0., 0.)
-                        .with_phase(FRAC_PI_8),
-                )
-            }
-            StandardGate::Tdg => {
-                Ok(
-                    VersorSU2::from_quaternion_unchecked(COS_FRAC_PI_8, SIN_FRAC_PI_8, 0., 0.)
-                        .with_phase(-FRAC_PI_8),
-                )
-            }
-            StandardGate::U | StandardGate::U3 => {
-                let &[Param::Float(theta), Param::Float(phi), Param::Float(lambda)] = params else {
-                    return Err(VersorU2Error::Symbolic);
-                };
-                Ok((VersorSU2::from_rz(phi)
-                    * VersorSU2::from_ry(theta)
-                    * VersorSU2::from_rz(lambda))
-                .with_phase((phi + lambda) * 0.5))
-            }
-            StandardGate::U2 => {
-                let &[Param::Float(phi), Param::Float(lambda)] = params else {
-                    return Err(VersorU2Error::Symbolic);
-                };
-                let (sin, cos) = (lambda * 0.5).sin_cos();
-                // The RY(pi/2).RZ(lambda) part of the decomposition, without the phase term.
-                let ry_rz = VersorSU2(Unit::new_unchecked(
-                    FRAC_1_SQRT_2 * Quaternion::new(cos, -sin, -cos, -sin),
-                ));
-                Ok((VersorSU2::from_rz(phi) * ry_rz).with_phase((phi + lambda) * 0.5))
-            }
-            _ => Err(VersorU2Error::MultiQubit),
         }
     }
 
@@ -504,9 +371,7 @@ mod test {
         for gate in all_1q_gates() {
             let params = &params[0..gate.num_params() as usize];
             let direct_matrix = gate.matrix(params).unwrap();
-            let versor_matrix = VersorU2::from_standard(gate, params)
-                .unwrap()
-                .matrix_contiguous();
+            let versor_matrix = gate.versor_u2(params).unwrap().matrix_contiguous();
             if direct_matrix.abs_diff_ne(&aview2(&versor_matrix), ATOL) {
                 fails.push((gate, direct_matrix, versor_matrix));
             }
@@ -547,8 +412,8 @@ mod test {
                 .matrix(left_params)
                 .unwrap()
                 .dot(&right.matrix(right_params).unwrap());
-            let versor_matrix = (VersorU2::from_standard(left, left_params).unwrap()
-                * VersorU2::from_standard(right, right_params).unwrap())
+            let versor_matrix = (left.versor_u2(left_params).unwrap()
+                * right.versor_u2(right_params).unwrap())
             .matrix_contiguous();
             if direct_matrix.abs_diff_ne(&aview2(&versor_matrix), ATOL) {
                 fails.push((left, right, direct_matrix, versor_matrix));

--- a/crates/synthesis/src/matrix/two_qubit.rs
+++ b/crates/synthesis/src/matrix/two_qubit.rs
@@ -202,7 +202,7 @@ impl Separable1q {
 fn versor_from_1q_gate(inst: &PackedInstruction) -> PyResult<VersorU2> {
     let tol = 1e-12;
     match inst.op.view() {
-        OperationRef::StandardGate(gate) => VersorU2::from_standard(gate, inst.params_view()),
+        OperationRef::StandardGate(gate) => gate.versor_u2(inst.params_view()),
         OperationRef::Unitary(gate) => match &gate.array {
             ArrayType::NDArray(arr) => Ok(VersorU2::from_ndarray_unchecked(&arr.view())),
             ArrayType::OneQ(arr) => Ok(VersorU2::from_nalgebra_unchecked(arr)),


### PR DESCRIPTION
This moves the last remaining dependency from `qiskit-quantum-info` out of that package and into `qiskit-circuit` itself; rather than `VersorU2` consuming the `StandardGate` to construct itself, we instead have the `StandardGate` learn how to construct `VersorU2` from itself.

This allows us to invert the dependency, and put `qiskit-quantum-info` below `qiskit-circuit` in the crate hierarchy, opening up the ability to use `qiskit-quantum-info` types natively within core circuit IR types, and to re-use `quantum-info` routines around conversion of matrix-free objects to matrix form, and so on.

Close #15919