### PR TITLE
Fix CSPLayout to detect 3-or-more-qubit gates (fix #7155)

### DIFF
--- a/qiskit/transpiler/passes/layout/csp_layout.py
+++ b/qiskit/transpiler/passes/layout/csp_layout.py
@@ -89,6 +89,11 @@ class CSPLayout(AnalysisPass):
             cxs.add((qubits.index(gate.qargs[0]), qubits.index(gate.qargs[1])))
         edges = set(self.coupling_map.get_edges())
 
+        for gate in dag.gate_nodes():
+            if len(gate.qargs) > 2:
+                self.property_set["CSPLayout_stop_reason"] = "3-or-more-qubit gate found"
+                return
+
         if self.time_limit is None and self.call_limit is None:
             solver = RecursiveBacktrackingSolver()
         else:

--- a/test/python/transpiler/test_csp_layout.py
+++ b/test/python/transpiler/test_csp_layout.py
@@ -316,6 +316,24 @@ class TestCSPLayout(QiskitTestCase):
 
         self.assertNotEqual(layout_1, layout_2)
 
+    def test_3q_gate_on_linear_coupling(self):
+        """A CCX (3-qubit gate) on a linear coupling map should fail gracefully.
+
+        Linear coupling: 0 - 1 - 2
+        CCX requires complete connectivity among its 3 qubits, which a line cannot provide.
+        """
+        qr = QuantumRegister(3, "qr")
+        circuit = QuantumCircuit(qr)
+        circuit.cx(qr[0], qr[1])
+        circuit.ccx(qr[2], qr[0], qr[1])
+
+        dag = circuit_to_dag(circuit)
+        pass_ = CSPLayout(CouplingMap([[0, 1], [1, 2]]), strict_direction=False, seed=self.seed)
+        pass_.run(dag)
+        layout = pass_.property_set["layout"]
+        self.assertIsNone(layout)
+        self.assertEqual(pass_.property_set["CSPLayout_stop_reason"], "3-or-more-qubit gate found")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

CSPLayout was only checking 2-qubit gates (via `dag.two_qubit_ops()`) and ignoring gates with 3+ qubits like CCX. This caused the pass to incorrectly report 'solution found' for circuits with multi-qubit gates that cannot be mapped to a linear coupling map.

## Fix

Added a check for any gate with more than 2 qubits before running the CSP solver. If such a gate is found, the pass now fails gracefully with `CSPLayout_stop_reason = "3-or-more-qubit gate found"`.

## Changes

- **csp_layout.py**: Added early-exit check for 3+ qubit gates
- **test_csp_layout.py**: Added test case covering CCX on linear coupling map

## Reproduction (before fix)

```python
from qiskit import QuantumCircuit
from qiskit.transpiler import CouplingMap
from qiskit.transpiler.passes import CSPLayout

qc = QuantumCircuit(3)
qc.cx(0, 1)
qc.ccx(2, 0, 1)

pass_ = CSPLayout(CouplingMap([[0, 1], [1, 2]]))
result = pass_(qc)
print(pass_.property_set["CSPLayout_stop_reason"])
# Before: 'solution found' (WRONG - CCX needs complete connectivity)
# After:  '3-or-more-qubit gate found'
```

## Checklist

- [x] Tests pass (existing + new test for this case)
- [x] Follows Qiskit coding style
- [ ] Documentation updated (if needed)
- [ ] Changelog entry (if applicable)

Closes #7155