### PR TITLE
Fix `TemplateOptimization` dropping the `global_phase` on substitution

### DIFF
--- a/qiskit/converters/circuit_to_dagdependency.py
+++ b/qiskit/converters/circuit_to_dagdependency.py
@@ -29,6 +29,7 @@ def circuit_to_dagdependency(circuit, create_preds_and_succs=True):
     dagdependency = DAGDependency()
     dagdependency.name = circuit.name
     dagdependency.metadata = circuit.metadata
+    dagdependency.global_phase = circuit.global_phase  # preserve phase for template matching
 
     dagdependency.add_qubits(circuit.qubits)
     dagdependency.add_clbits(circuit.clbits)

--- a/qiskit/converters/circuit_to_dagdependency.py
+++ b/qiskit/converters/circuit_to_dagdependency.py
@@ -29,7 +29,6 @@ def circuit_to_dagdependency(circuit, create_preds_and_succs=True):
     dagdependency = DAGDependency()
     dagdependency.name = circuit.name
     dagdependency.metadata = circuit.metadata
-    dagdependency.global_phase = circuit.global_phase  # preserve phase for template matching
 
     dagdependency.add_qubits(circuit.qubits)
     dagdependency.add_clbits(circuit.clbits)
@@ -46,5 +45,8 @@ def circuit_to_dagdependency(circuit, create_preds_and_succs=True):
     if create_preds_and_succs:
         dagdependency._add_predecessors()
         dagdependency._add_successors()
+
+    # copy metadata
+    dagdependency.global_phase = circuit.global_phase
 
     return dagdependency

--- a/qiskit/converters/circuit_to_dagdependency.py
+++ b/qiskit/converters/circuit_to_dagdependency.py
@@ -46,7 +46,7 @@ def circuit_to_dagdependency(circuit, create_preds_and_succs=True):
         dagdependency._add_predecessors()
         dagdependency._add_successors()
 
-    # copy metadata
+    # copy global phase
     dagdependency.global_phase = circuit.global_phase
 
     return dagdependency

--- a/qiskit/transpiler/passes/optimization/template_matching/template_substitution.py
+++ b/qiskit/transpiler/passes/optimization/template_matching/template_substitution.py
@@ -429,12 +429,7 @@ class TemplateSubstitution:
                     inst = node.op.copy()
                     dag_dep_opt.add_op_node(inst.inverse(), qargs, cargs)
 
-                # The identity check asserts U(template) = I, so the gate content
-                # alone (ignoring the stored global_phase phi_T) implements
-                # e^{-i*phi_T} * I.  Substituting the matched gates with the
-                # template inverse therefore multiplies the circuit state by
-                # e^{-i*phi_T}, which must be recorded by decreasing the circuit's
-                # global_phase by phi_T for each match applied.
+                # Update global phase to account for the template's phase.
                 dag_dep_opt.global_phase -= group.template_dag_dep.global_phase
 
             # Add the unmatched gates.

--- a/qiskit/transpiler/passes/optimization/template_matching/template_substitution.py
+++ b/qiskit/transpiler/passes/optimization/template_matching/template_substitution.py
@@ -372,6 +372,7 @@ class TemplateSubstitution:
         dag_dep_opt = DAGDependency()
 
         dag_dep_opt.name = self.circuit_dag_dep.name
+        dag_dep_opt.global_phase = self.circuit_dag_dep.global_phase
 
         qregs = list(self.circuit_dag_dep.qregs.values())
         cregs = list(self.circuit_dag_dep.cregs.values())
@@ -427,6 +428,12 @@ class TemplateSubstitution:
                     node = group.template_dag_dep.get_node(index)
                     inst = node.op.copy()
                     dag_dep_opt.add_op_node(inst.inverse(), qargs, cargs)
+
+                # The template represents the identity up to a global phase φ_T,
+                # i.e. U(template) = e^{i*φ_T} * I.  Replacing the matched gates
+                # with template_inverse applies e^{-i*φ_T} to the circuit, so the
+                # circuit's global phase must decrease by φ_T for each match applied.
+                dag_dep_opt.global_phase -= group.template_dag_dep.global_phase
 
             # Add the unmatched gates.
             for node_id in self.unmatched_list:

--- a/qiskit/transpiler/passes/optimization/template_matching/template_substitution.py
+++ b/qiskit/transpiler/passes/optimization/template_matching/template_substitution.py
@@ -429,10 +429,12 @@ class TemplateSubstitution:
                     inst = node.op.copy()
                     dag_dep_opt.add_op_node(inst.inverse(), qargs, cargs)
 
-                # The template represents the identity up to a global phase φ_T,
-                # i.e. U(template) = e^{i*φ_T} * I.  Replacing the matched gates
-                # with template_inverse applies e^{-i*φ_T} to the circuit, so the
-                # circuit's global phase must decrease by φ_T for each match applied.
+                # The identity check asserts U(template) = I, so the gate content
+                # alone (ignoring the stored global_phase phi_T) implements
+                # e^{-i*phi_T} * I.  Substituting the matched gates with the
+                # template inverse therefore multiplies the circuit state by
+                # e^{-i*phi_T}, which must be recorded by decreasing the circuit's
+                # global_phase by phi_T for each match applied.
                 dag_dep_opt.global_phase -= group.template_dag_dep.global_phase
 
             # Add the unmatched gates.

--- a/releasenotes/notes/fix-circuit-to-dagdependency-global-phase-14537.yaml
+++ b/releasenotes/notes/fix-circuit-to-dagdependency-global-phase-14537.yaml
@@ -2,7 +2,6 @@
 fixes:
   - |
     Fixed :func:`.circuit_to_dagdependency` failing to copy ``global_phase`` when converting
-       a template :class:`.QuantumCircuit` to a :class:`.DAGDependency`, so any phase
-       carried by the template was lost before matching began.
+    a template :class:`.QuantumCircuit` to a :class:`.DAGDependency`.
 
     Fixes `#14537 <https://github.com/Qiskit/qiskit/issues/14537>`__.

--- a/releasenotes/notes/fix-circuit-to-dagdependency-global-phase-14537.yaml
+++ b/releasenotes/notes/fix-circuit-to-dagdependency-global-phase-14537.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed :func:`.circuit_to_dagdependency` failing to copy ``global_phase`` when converting
+       a template :class:`.QuantumCircuit` to a :class:`.DAGDependency`, so any phase
+       carried by the template was lost before matching began.
+
+    Fixes `#14537 <https://github.com/Qiskit/qiskit/issues/14537>`__.

--- a/releasenotes/notes/fix-template-optimization-global-phase-14537.yaml
+++ b/releasenotes/notes/fix-template-optimization-global-phase-14537.yaml
@@ -1,9 +1,8 @@
 ---
 fixes:
   - |
-    Fixed two bugs in :class:.TemplateSubstitution: the optimized circuit's global_phase 
-    was silently reset to zero when substitutions were applied, and the template's global_phase 
-    was not subtracted from the output circuit after each substitution. 
-    Both produced a circuit not operator-equivalent to the input.
+    Fixed global phase handling in :class:`.TemplateSubstitution`, which previously
+    silently reset to input circuit's global phase to zero and didn't correct for global
+    phases of the templates.
 
     Fixes `#14537 <https://github.com/Qiskit/qiskit/issues/14537>`__.

--- a/releasenotes/notes/fix-template-optimization-global-phase-14537.yaml
+++ b/releasenotes/notes/fix-template-optimization-global-phase-14537.yaml
@@ -1,21 +1,9 @@
 ---
 fixes:
   - |
-    Fixed :class:`.TemplateOptimization` silently dropping or miscalculating the
-    ``global_phase`` of circuits and templates during substitution. There were three
-    independent bugs:
-
-    1. :func:`.circuit_to_dagdependency` did not copy ``global_phase`` when converting
-       a template :class:`.QuantumCircuit` to a :class:`.DAGDependency`, so any phase
-       carried by the template was lost before matching began.
-
-    2. :class:`.TemplateSubstitution` constructed a new :class:`.DAGDependency` for the
-       optimized circuit without copying the original circuit's ``global_phase``, causing
-       it to be silently reset to zero whenever at least one substitution was applied.
-
-    3. When a template carries a nonzero ``global_phase`` ``phi_T`` (meaning its gate
-       content alone implements ``e^{-i*phi_T} * I`` while the full operator is ``I``),
-       each substitution was not subtracting ``phi_T`` from the output circuit's
-       ``global_phase``, producing a result that was not operator-equivalent to the input.
+    Fixed two bugs in :class:.TemplateSubstitution: the optimized circuit's global_phase 
+    was silently reset to zero when substitutions were applied, and the template's global_phase 
+    was not subtracted from the output circuit after each substitution. 
+    Both produced a circuit not operator-equivalent to the input.
 
     Fixes `#14537 <https://github.com/Qiskit/qiskit/issues/14537>`__.

--- a/releasenotes/notes/fix-template-optimization-global-phase-14537.yaml
+++ b/releasenotes/notes/fix-template-optimization-global-phase-14537.yaml
@@ -18,4 +18,4 @@ fixes:
        each substitution was not subtracting ``phi_T`` from the output circuit's
        ``global_phase``, producing a result that was not operator-equivalent to the input.
 
-    Fixes :issue:`14537`.
+    Fixes `#14537 <https://github.com/Qiskit/qiskit/issues/14537>`__.

--- a/releasenotes/notes/fix-template-optimization-global-phase-14537.yaml
+++ b/releasenotes/notes/fix-template-optimization-global-phase-14537.yaml
@@ -1,0 +1,20 @@
+---
+fixes:
+  - |
+    Fixed :class:`.TemplateOptimization` silently dropping the ``global_phase`` of the circuit
+    being optimized when a template substitution is applied.
+
+    There were two independent bugs:
+
+    1. :func:`.circuit_to_dagdependency` did not copy ``global_phase`` when converting a template
+       :class:`.QuantumCircuit` to a :class:`.DAGDependency`, so any phase on the template was
+       lost before matching began.
+
+    2. :class:`.TemplateSubstitution` constructed a new :class:`.DAGDependency` for the optimized
+       circuit without copying the original circuit's ``global_phase``, causing it to be silently
+       reset to zero whenever at least one substitution was applied.
+
+    Circuits with a nonzero ``global_phase`` that are optimized via :class:`.TemplateOptimization`
+    now correctly retain their phase in the output.
+
+    Fixes :issue:`14537`.

--- a/releasenotes/notes/fix-template-optimization-global-phase-14537.yaml
+++ b/releasenotes/notes/fix-template-optimization-global-phase-14537.yaml
@@ -1,20 +1,21 @@
 ---
 fixes:
   - |
-    Fixed :class:`.TemplateOptimization` silently dropping the ``global_phase`` of the circuit
-    being optimized when a template substitution is applied.
+    Fixed :class:`.TemplateOptimization` silently dropping or miscalculating the
+    ``global_phase`` of circuits and templates during substitution. There were three
+    independent bugs:
 
-    There were two independent bugs:
+    1. :func:`.circuit_to_dagdependency` did not copy ``global_phase`` when converting
+       a template :class:`.QuantumCircuit` to a :class:`.DAGDependency`, so any phase
+       carried by the template was lost before matching began.
 
-    1. :func:`.circuit_to_dagdependency` did not copy ``global_phase`` when converting a template
-       :class:`.QuantumCircuit` to a :class:`.DAGDependency`, so any phase on the template was
-       lost before matching began.
+    2. :class:`.TemplateSubstitution` constructed a new :class:`.DAGDependency` for the
+       optimized circuit without copying the original circuit's ``global_phase``, causing
+       it to be silently reset to zero whenever at least one substitution was applied.
 
-    2. :class:`.TemplateSubstitution` constructed a new :class:`.DAGDependency` for the optimized
-       circuit without copying the original circuit's ``global_phase``, causing it to be silently
-       reset to zero whenever at least one substitution was applied.
-
-    Circuits with a nonzero ``global_phase`` that are optimized via :class:`.TemplateOptimization`
-    now correctly retain their phase in the output.
+    3. When a template carries a nonzero ``global_phase`` ``phi_T`` (meaning its gate
+       content alone implements ``e^{-i*phi_T} * I`` while the full operator is ``I``),
+       each substitution was not subtracting ``phi_T`` from the output circuit's
+       ``global_phase``, producing a result that was not operator-equivalent to the input.
 
     Fixes :issue:`14537`.

--- a/test/python/transpiler/test_template_matching.py
+++ b/test/python/transpiler/test_template_matching.py
@@ -820,6 +820,40 @@ class TestTemplateMatching(QiskitTestCase):
         # Operator equivalence confirms the full unitary (including phase) is preserved.
         self.assertTrue(Operator(circuit_in) == Operator(result))
 
+    def test_circuit_and_template_both_have_nonzero_global_phase(self):
+        """Regression test for #14537: fixes #2 and #3 compose correctly.
+
+        When both the circuit and the template carry a nonzero global_phase, the
+        output must account for both: the circuit's phase is preserved (fix #2)
+        and the template's per-match phase is subtracted (fix #3).
+        """
+        template = QuantumCircuit(1)
+        template.h(0)
+        template.s(0)
+        template.h(0)
+        template.s(0)
+        template.h(0)
+        template.s(0)
+        template.global_phase = -np.pi / 4
+
+        qr = QuantumRegister(1, "qr")
+        circuit_in = QuantumCircuit(qr)
+        circuit_in.h(qr[0])
+        circuit_in.s(qr[0])
+        circuit_in.h(qr[0])
+        circuit_in.s(qr[0])
+        circuit_in.h(qr[0])
+        circuit_in.s(qr[0])
+        circuit_in.global_phase = np.pi / 3
+
+        result = PassManager(TemplateOptimization([template])).run(circuit_in)
+
+        # All gates cancelled; total phase = circuit phase + template compensation
+        # = pi/3 + pi/4 = 7*pi/12.
+        self.assertAlmostEqual(float(result.global_phase) % (2 * np.pi), 7 * np.pi / 12)
+        self.assertEqual(result.count_ops(), {})
+        self.assertTrue(Operator(circuit_in) == Operator(result))
+
     def test_circuit_global_phase_preserved_with_multiple_template_matches(self):
         """Regression test for #14537: circuit global_phase is preserved across multiple matches.
 

--- a/test/python/transpiler/test_template_matching.py
+++ b/test/python/transpiler/test_template_matching.py
@@ -763,5 +763,52 @@ class TestTemplateMatching(QiskitTestCase):
         self.assertEqual(scc.num_cached_entries(), 0)
 
 
+    def test_circuit_global_phase_preserved_after_template_match(self):
+        """Regression test for #14537: circuit global_phase must survive template optimization.
+
+        When a template match is found and substitution occurs, the optimized circuit
+        must retain the original circuit's global_phase unchanged.
+        """
+        qr = QuantumRegister(2, "qr")
+        circuit_in = QuantumCircuit(qr)
+        circuit_in.cx(qr[0], qr[1])
+        circuit_in.cx(qr[0], qr[1])
+        circuit_in.global_phase = np.pi / 4
+
+        template = QuantumCircuit(QuantumRegister(2, "qrc"))
+        template.cx(0, 1)
+        template.cx(0, 1)
+
+        result = PassManager(TemplateOptimization([template])).run(circuit_in)
+
+        self.assertAlmostEqual(float(result.global_phase), np.pi / 4)
+
+    def test_circuit_global_phase_preserved_with_multiple_template_matches(self):
+        """Regression test for #14537: circuit global_phase is preserved across multiple matches.
+
+        When a template matches more than once in the circuit, the original circuit's
+        global_phase must appear exactly once in the output — not zeroed out and not
+        multiplied by the number of matches.
+        """
+        qr = QuantumRegister(2, "qr")
+        circuit_in = QuantumCircuit(qr)
+        # Two independent pairs of CX gates — the template will match twice.
+        circuit_in.cx(qr[0], qr[1])
+        circuit_in.cx(qr[0], qr[1])
+        circuit_in.cx(qr[0], qr[1])
+        circuit_in.cx(qr[0], qr[1])
+        circuit_in.global_phase = np.pi / 3
+
+        template = QuantumCircuit(QuantumRegister(2, "qrc"))
+        template.cx(0, 1)
+        template.cx(0, 1)
+
+        result = PassManager(TemplateOptimization([template])).run(circuit_in)
+
+        # All gates are cancelled; global_phase must be exactly pi/3.
+        self.assertAlmostEqual(float(result.global_phase), np.pi / 3)
+        self.assertEqual(result.count_ops(), {})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/transpiler/test_template_matching.py
+++ b/test/python/transpiler/test_template_matching.py
@@ -783,6 +783,44 @@ class TestTemplateMatching(QiskitTestCase):
 
         self.assertAlmostEqual(float(result.global_phase), np.pi / 4)
 
+    def test_template_nonzero_global_phase_applied_to_circuit(self):
+        """Regression test for #14537: template global_phase is subtracted per match.
+
+        When a template carries a nonzero global_phase phi_T, its gate content alone
+        implements e^{-i*phi_T} * I (the identity check asserts the full operator is I).
+        Each substitution must therefore decrease the circuit's global_phase by phi_T.
+
+        HSHSHS has gate unitary e^{i*pi/4} * I; with global_phase = -pi/4 the full
+        operator is I, so the template passes the identity check.  After the six gates
+        are cancelled the output circuit must carry global_phase = pi/4 so that
+        Operator(input) == Operator(output).
+        """
+        template = QuantumCircuit(1)
+        template.h(0)
+        template.s(0)
+        template.h(0)
+        template.s(0)
+        template.h(0)
+        template.s(0)
+        template.global_phase = -np.pi / 4
+
+        qr = QuantumRegister(1, "qr")
+        circuit_in = QuantumCircuit(qr)
+        circuit_in.h(qr[0])
+        circuit_in.s(qr[0])
+        circuit_in.h(qr[0])
+        circuit_in.s(qr[0])
+        circuit_in.h(qr[0])
+        circuit_in.s(qr[0])
+
+        result = PassManager(TemplateOptimization([template])).run(circuit_in)
+
+        # All gates cancelled; global_phase must be pi/4 to match the gate unitary.
+        self.assertAlmostEqual(float(result.global_phase) % (2 * np.pi), np.pi / 4)
+        self.assertEqual(result.count_ops(), {})
+        # Operator equivalence confirms the full unitary (including phase) is preserved.
+        self.assertTrue(Operator(circuit_in) == Operator(result))
+
     def test_circuit_global_phase_preserved_with_multiple_template_matches(self):
         """Regression test for #14537: circuit global_phase is preserved across multiple matches.
 

--- a/test/python/transpiler/test_template_matching.py
+++ b/test/python/transpiler/test_template_matching.py
@@ -784,11 +784,13 @@ class TestTemplateMatching(QiskitTestCase):
 
         result_mult = TemplateOptimization([template])(circuit_in_mult)
 
-        self.assertAlmostEqual(float(result.global_phase), np.pi / 4)
-        self.assertEqual(result.count_ops(), {})
+        with self.subTest(msg="single template match"):
+            self.assertAlmostEqual(float(result.global_phase), np.pi / 4)
+            self.assertEqual(result.count_ops(), {})
 
-        self.assertAlmostEqual(float(result_mult.global_phase), np.pi / 3)
-        self.assertEqual(result_mult.count_ops(), {})
+        with self.subTest(msg="multiple template matches"):
+            self.assertAlmostEqual(float(result_mult.global_phase), np.pi / 3)
+            self.assertEqual(result_mult.count_ops(), {})
 
     def test_template_nonzero_global_phase_applied_to_circuit(self):
         """Test that operator equivalence is preserved on partial template match with nonzero template global_phase (#14537)."""

--- a/test/python/transpiler/test_template_matching.py
+++ b/test/python/transpiler/test_template_matching.py
@@ -793,7 +793,10 @@ class TestTemplateMatching(QiskitTestCase):
             self.assertEqual(result_mult.count_ops(), {})
 
     def test_template_nonzero_global_phase_applied_to_circuit(self):
-        """Test that operator equivalence is preserved on partial template match with nonzero template global_phase (#14537)."""
+        """Test the template's global phase is respected.
+        
+        Regression test of #14537.
+        """
 
         template = QuantumCircuit(1)
         template.h(0)

--- a/test/python/transpiler/test_template_matching.py
+++ b/test/python/transpiler/test_template_matching.py
@@ -737,7 +737,7 @@ class TestTemplateMatching(QiskitTestCase):
         qc.swap(0, 1)
         qc.h(0)
         qc_opt = pm.run(qc)
-        self.assertTrue(Operator(qc) == Operator(qc_opt))
+        self.assertEqual(Operator(qc), Operator(qc_opt))
 
     def test_clifford_templates(self):
         """Tests TemplateOptimization pass on several larger examples."""
@@ -758,16 +758,12 @@ class TestTemplateMatching(QiskitTestCase):
                 seed=seed,
             )
             qc_opt = pm.run(qc)
-            self.assertTrue(Operator(qc) == Operator(qc_opt))
+            self.assertEqual(Operator(qc), Operator(qc_opt))
         # All of these gates are in the commutation library, i.e. the cache should not be used
         self.assertEqual(scc.num_cached_entries(), 0)
 
     def test_circuit_global_phase_preserved_after_template_match(self):
-        """Regression test for #14537: circuit global_phase must survive template optimization.
-
-        When a template match is found and substitution occurs, the optimized circuit
-        must retain the original circuit's global_phase unchanged.
-        """
+        """Test that circuit global_phase survives template optimization (#14537)."""
         qr = QuantumRegister(2, "qr")
         circuit_in = QuantumCircuit(qr)
         circuit_in.cx(qr[0], qr[1])
@@ -783,16 +779,11 @@ class TestTemplateMatching(QiskitTestCase):
         self.assertAlmostEqual(float(result.global_phase), np.pi / 4)
 
     def test_template_nonzero_global_phase_applied_to_circuit(self):
-        """Regression test for #14537: template global_phase is subtracted per match.
-
-        When a template carries a nonzero global_phase phi_T, its gate content alone
-        implements e^{-i*phi_T} * I (the identity check asserts the full operator is I).
-        Each substitution must therefore decrease the circuit's global_phase by phi_T.
+        """Test that template global_phase is applied to the circuit per match (#14537).
 
         HSHSHS has gate unitary e^{i*pi/4} * I; with global_phase = -pi/4 the full
-        operator is I, so the template passes the identity check.  After the six gates
-        are cancelled the output circuit must carry global_phase = pi/4 so that
-        Operator(input) == Operator(output).
+        operator is I.  After the six gates are cancelled, the output circuit must
+        carry global_phase = pi/4 so that Operator(input) == Operator(output).
         """
         template = QuantumCircuit(1)
         template.h(0)
@@ -818,15 +809,10 @@ class TestTemplateMatching(QiskitTestCase):
         self.assertAlmostEqual(float(result.global_phase) % (2 * np.pi), np.pi / 4)
         self.assertEqual(result.count_ops(), {})
         # Operator equivalence confirms the full unitary (including phase) is preserved.
-        self.assertTrue(Operator(circuit_in) == Operator(result))
+        self.assertEqual(Operator(circuit_in), Operator(result))
 
     def test_circuit_and_template_both_have_nonzero_global_phase(self):
-        """Regression test for #14537: fixes #2 and #3 compose correctly.
-
-        When both the circuit and the template carry a nonzero global_phase, the
-        output must account for both: the circuit's phase is preserved (fix #2)
-        and the template's per-match phase is subtracted (fix #3).
-        """
+        """Test that circuit and template global phases both contribute to the result (#14537)."""
         template = QuantumCircuit(1)
         template.h(0)
         template.s(0)
@@ -852,15 +838,10 @@ class TestTemplateMatching(QiskitTestCase):
         # = pi/3 + pi/4 = 7*pi/12.
         self.assertAlmostEqual(float(result.global_phase) % (2 * np.pi), 7 * np.pi / 12)
         self.assertEqual(result.count_ops(), {})
-        self.assertTrue(Operator(circuit_in) == Operator(result))
+        self.assertEqual(Operator(circuit_in), Operator(result))
 
     def test_circuit_global_phase_preserved_with_multiple_template_matches(self):
-        """Regression test for #14537: circuit global_phase is preserved across multiple matches.
-
-        When a template matches more than once in the circuit, the original circuit's
-        global_phase must appear exactly once in the output — not zeroed out and not
-        multiplied by the number of matches.
-        """
+        """Test that circuit global_phase is preserved when a template matches multiple times (#14537)."""
         qr = QuantumRegister(2, "qr")
         circuit_in = QuantumCircuit(qr)
         # Two independent pairs of CX gates — the template will match twice.

--- a/test/python/transpiler/test_template_matching.py
+++ b/test/python/transpiler/test_template_matching.py
@@ -762,7 +762,6 @@ class TestTemplateMatching(QiskitTestCase):
         # All of these gates are in the commutation library, i.e. the cache should not be used
         self.assertEqual(scc.num_cached_entries(), 0)
 
-
     def test_circuit_global_phase_preserved_after_template_match(self):
         """Regression test for #14537: circuit global_phase must survive template optimization.
 

--- a/test/python/transpiler/test_template_matching.py
+++ b/test/python/transpiler/test_template_matching.py
@@ -791,7 +791,7 @@ class TestTemplateMatching(QiskitTestCase):
         self.assertEqual(result_mult.count_ops(), {})
 
     def test_template_nonzero_global_phase_applied_to_circuit(self):
-        """Test that the circuit's global_phase is preserved when no template substitution occurs (#14537)."""
+        """Test that operator equivalence is preserved on partial template match with nonzero template global_phase (#14537)."""
 
         template = QuantumCircuit(1)
         template.h(0)
@@ -811,9 +811,6 @@ class TestTemplateMatching(QiskitTestCase):
 
         result = TemplateOptimization([template])(circuit_in)
 
-        self.assertAlmostEqual(result.global_phase, np.pi / 4)
-        self.assertEqual(result.count_ops(), circuit_in.count_ops()) # no gates removed
-        # Operator equivalence confirms the full unitary (including phase) is preserved.
         self.assertEqual(Operator(circuit_in), Operator(result))
 
     def test_circuit_and_template_both_have_nonzero_global_phase(self):
@@ -841,30 +838,9 @@ class TestTemplateMatching(QiskitTestCase):
 
         # All gates cancelled; total phase = circuit phase + template compensation
         # = pi/3 + pi/4 = 7*pi/12.
-        self.assertAlmostEqual(result.global_phase, np.pi / 4)
+        self.assertAlmostEqual(result.global_phase, 7 * np.pi / 12)
         self.assertEqual(result.count_ops(), {})
         self.assertEqual(Operator(circuit_in), Operator(result))
-
-    def test_circuit_global_phase_preserved_with_multiple_template_matches(self):
-        """Test that circuit global_phase is preserved when a template matches multiple times (#14537)."""
-        qr = QuantumRegister(2, "qr")
-        circuit_in = QuantumCircuit(qr)
-        # Two independent pairs of CX gates — the template will match twice.
-        circuit_in.cx(qr[0], qr[1])
-        circuit_in.cx(qr[0], qr[1])
-        circuit_in.cx(qr[0], qr[1])
-        circuit_in.cx(qr[0], qr[1])
-        circuit_in.global_phase = np.pi / 3
-
-        template = QuantumCircuit(2)
-        template.cx(0, 1)
-        template.cx(0, 1)
-
-        result = TemplateOptimization([template])(circuit_in)
-
-        # All gates are cancelled; global_phase must be exactly pi/3.
-        self.assertAlmostEqual(float(result.global_phase), np.pi / 3)
-        self.assertEqual(result.count_ops(), {})
 
 
 if __name__ == "__main__":

--- a/test/python/transpiler/test_template_matching.py
+++ b/test/python/transpiler/test_template_matching.py
@@ -762,29 +762,37 @@ class TestTemplateMatching(QiskitTestCase):
         # All of these gates are in the commutation library, i.e. the cache should not be used
         self.assertEqual(scc.num_cached_entries(), 0)
 
-    def test_circuit_global_phase_preserved_after_template_match(self):
+    def test_circuit_global_phase_preserved_after_single_and_multiple_template_match(self):
         """Test that circuit global_phase survives template optimization (#14537)."""
-        qr = QuantumRegister(2, "qr")
-        circuit_in = QuantumCircuit(qr)
-        circuit_in.cx(qr[0], qr[1])
-        circuit_in.cx(qr[0], qr[1])
-        circuit_in.global_phase = np.pi / 4
 
-        template = QuantumCircuit(QuantumRegister(2, "qrc"))
+        circuit_in = QuantumCircuit(2, global_phase=np.pi / 4)
+        circuit_in.cx(0, 1)
+        circuit_in.cx(0, 1)
+
+        circuit_in_mult = QuantumCircuit(2, global_phase=np.pi / 3)
+        # Two independent pairs of CX gates — the template will match twice.
+        circuit_in_mult.cx(0, 1)
+        circuit_in_mult.cx(0, 1)
+        circuit_in_mult.cx(0, 1)
+        circuit_in_mult.cx(0, 1)
+
+        template = QuantumCircuit(2)
         template.cx(0, 1)
         template.cx(0, 1)
 
-        result = PassManager(TemplateOptimization([template])).run(circuit_in)
+        result = TemplateOptimization([template])(circuit_in)
+
+        result_mult = TemplateOptimization([template])(circuit_in_mult)
 
         self.assertAlmostEqual(float(result.global_phase), np.pi / 4)
+        self.assertEqual(result.count_ops(), {})
+
+        self.assertAlmostEqual(float(result_mult.global_phase), np.pi / 3)
+        self.assertEqual(result_mult.count_ops(), {})
 
     def test_template_nonzero_global_phase_applied_to_circuit(self):
-        """Test that template global_phase is applied to the circuit per match (#14537).
+        """Test that the circuit's global_phase is preserved when no template substitution occurs (#14537)."""
 
-        HSHSHS has gate unitary e^{i*pi/4} * I; with global_phase = -pi/4 the full
-        operator is I.  After the six gates are cancelled, the output circuit must
-        carry global_phase = pi/4 so that Operator(input) == Operator(output).
-        """
         template = QuantumCircuit(1)
         template.h(0)
         template.s(0)
@@ -795,19 +803,16 @@ class TestTemplateMatching(QiskitTestCase):
         template.global_phase = -np.pi / 4
 
         qr = QuantumRegister(1, "qr")
-        circuit_in = QuantumCircuit(qr)
-        circuit_in.h(qr[0])
-        circuit_in.s(qr[0])
+        circuit_in = QuantumCircuit(qr, global_phase=np.pi / 4)
         circuit_in.h(qr[0])
         circuit_in.s(qr[0])
         circuit_in.h(qr[0])
         circuit_in.s(qr[0])
 
-        result = PassManager(TemplateOptimization([template])).run(circuit_in)
+        result = TemplateOptimization([template])(circuit_in)
 
-        # All gates cancelled; global_phase must be pi/4 to match the gate unitary.
-        self.assertAlmostEqual(float(result.global_phase) % (2 * np.pi), np.pi / 4)
-        self.assertEqual(result.count_ops(), {})
+        self.assertAlmostEqual(result.global_phase, np.pi / 4)
+        self.assertEqual(result.count_ops(), circuit_in.count_ops()) # no gates removed
         # Operator equivalence confirms the full unitary (including phase) is preserved.
         self.assertEqual(Operator(circuit_in), Operator(result))
 
@@ -832,11 +837,11 @@ class TestTemplateMatching(QiskitTestCase):
         circuit_in.s(qr[0])
         circuit_in.global_phase = np.pi / 3
 
-        result = PassManager(TemplateOptimization([template])).run(circuit_in)
+        result = TemplateOptimization([template])(circuit_in)
 
         # All gates cancelled; total phase = circuit phase + template compensation
         # = pi/3 + pi/4 = 7*pi/12.
-        self.assertAlmostEqual(float(result.global_phase) % (2 * np.pi), 7 * np.pi / 12)
+        self.assertAlmostEqual(result.global_phase, np.pi / 4)
         self.assertEqual(result.count_ops(), {})
         self.assertEqual(Operator(circuit_in), Operator(result))
 
@@ -851,11 +856,11 @@ class TestTemplateMatching(QiskitTestCase):
         circuit_in.cx(qr[0], qr[1])
         circuit_in.global_phase = np.pi / 3
 
-        template = QuantumCircuit(QuantumRegister(2, "qrc"))
+        template = QuantumCircuit(2)
         template.cx(0, 1)
         template.cx(0, 1)
 
-        result = PassManager(TemplateOptimization([template])).run(circuit_in)
+        result = TemplateOptimization([template])(circuit_in)
 
         # All gates are cancelled; global_phase must be exactly pi/3.
         self.assertAlmostEqual(float(result.global_phase), np.pi / 3)

--- a/test/python/transpiler/test_template_matching.py
+++ b/test/python/transpiler/test_template_matching.py
@@ -793,10 +793,7 @@ class TestTemplateMatching(QiskitTestCase):
             self.assertEqual(result_mult.count_ops(), {})
 
     def test_template_nonzero_global_phase_applied_to_circuit(self):
-        """Test the template's global phase is respected.
-        
-        Regression test of #14537.
-        """
+        """Test the template's global phase is respected (#14537)."""
 
         template = QuantumCircuit(1)
         template.h(0)


### PR DESCRIPTION
## Summary

Fixes #14537.

`TemplateOptimization` was silently dropping or miscalculating `global_phase` in three places:

1. `circuit_to_dagdependency` did not copy `global_phase` when converting a template `QuantumCircuit` to `DAGDependency`.
2. `TemplateSubstitution.run_dag_opt` constructed the optimized `DAGDependency` without inheriting the original circuit's `global_phase`.
3. When a template carries a nonzero `global_phase` φ_T (gate content implements `e^{-i*φ_T} * I` while the full operator is `I`), the per-match phase contribution was not being subtracted from the output circuit.

## Test plan

- `test_circuit_global_phase_preserved_after_template_match` — circuit phase survives a substitution
- `test_template_nonzero_global_phase_applied_to_circuit` — template phase correctly accumulated; includes `Operator` equivalence check
- `test_circuit_global_phase_preserved_with_multiple_template_matches` — circuit phase preserved across multiple matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)