### PR TITLE
Improve compose() errors for circuit width mismatches

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -79,6 +79,10 @@ use rustworkx_core::traversal::{
     bfs_successors as core_bfs_successors, descendants as core_descendants,
 };
 
+fn dag_compose_width_error(bit_kind: &str, other: usize, dest: usize) -> String {
+    format!("Cannot compose onto a DAGCircuit with fewer {bit_kind} ({other} > {dest}).")
+}
+
 use crate::imports::PARAMETER;
 use crate::instruction::Parameters;
 use crate::parameter_table::ParameterUuid;
@@ -1433,12 +1437,6 @@ impl DAGCircuit {
         if front {
             return Err(DAGCircuitError::new_err(
                 "Front composition not supported yet.",
-            ));
-        }
-
-        if other.qubits.len() > self.qubits.len() || other.clbits.len() > self.clbits.len() {
-            return Err(DAGCircuitError::new_err(
-                "Trying to compose with another DAGCircuit which has more 'in' edges.",
             ));
         }
 
@@ -7696,9 +7694,18 @@ impl DAGCircuit {
         inline_captures: bool,
     ) -> PyResult<()> {
         if other.qubits.len() > self.qubits.len() || other.clbits.len() > self.clbits.len() {
-            return Err(DAGCircuitError::new_err(
-                "Trying to compose with another DAGCircuit which has more 'in' edges.",
-            ));
+            if other.qubits.len() > self.qubits.len() {
+                return Err(DAGCircuitError::new_err(dag_compose_width_error(
+                    "qubits",
+                    other.qubits.len(),
+                    self.qubits.len(),
+                )));
+            }
+            return Err(DAGCircuitError::new_err(dag_compose_width_error(
+                "classical bits",
+                other.clbits.len(),
+                self.clbits.len(),
+            )));
         }
 
         let qubit_map = match qubits {

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -79,6 +79,7 @@ use rustworkx_core::traversal::{
     bfs_successors as core_bfs_successors, descendants as core_descendants,
 };
 
+#[inline]
 fn dag_compose_width_error(bit_kind: &str, other: usize, dest: usize) -> String {
     format!("Cannot compose onto a DAGCircuit with fewer {bit_kind} ({other} > {dest}).")
 }

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2280,9 +2280,15 @@ class QuantumCircuit:
                 dest.append(other, qargs=qubits, cargs=clbits, copy=copy)
             return None if inplace else dest
 
-        if other.num_qubits > dest.num_qubits or other.num_clbits > dest.num_clbits:
+        if other.num_qubits > dest.num_qubits:
             raise CircuitError(
-                "Trying to compose with another QuantumCircuit which has more 'in' edges."
+                f"Cannot compose a circuit with {other.num_qubits} qubit(s) "
+                f"into a circuit with {dest.num_qubits} qubit(s)."
+            )
+        if other.num_clbits > dest.num_clbits:
+            raise CircuitError(
+                f"Cannot compose a circuit with {other.num_clbits} classical bit(s) "
+                f"into a circuit with {dest.num_clbits} classical bit(s)."
             )
 
         # Maps bits in 'other' to bits in 'dest'.

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2282,13 +2282,13 @@ class QuantumCircuit:
 
         if other.num_qubits > dest.num_qubits:
             raise CircuitError(
-                f"Cannot compose a circuit with {other.num_qubits} qubit(s) "
-                f"into a circuit with {dest.num_qubits} qubit(s)."
+                "Cannot compose onto a circuit with fewer qubits "
+                f"({other.num_qubits} > {dest.num_qubits})."
             )
         if other.num_clbits > dest.num_clbits:
             raise CircuitError(
-                f"Cannot compose a circuit with {other.num_clbits} classical bit(s) "
-                f"into a circuit with {dest.num_clbits} classical bit(s)."
+                "Cannot compose onto a circuit with fewer classical bits "
+                f"({other.num_clbits} > {dest.num_clbits})."
             )
 
         # Maps bits in 'other' to bits in 'dest'.

--- a/test/python/circuit/test_compose.py
+++ b/test/python/circuit/test_compose.py
@@ -972,6 +972,31 @@ class TestCircuitCompose(QiskitTestCase):
         with self.assertRaisesRegex(CircuitError, "Duplicate clbits"):
             base.compose(attempt, [0, 1], [1, 1])
 
+    def test_rejects_rhs_with_too_many_qubits(self):
+        """Test that compose rejects a circuit with too many qubits."""
+        base = QuantumCircuit(1)
+        attempt = QuantumCircuit(2)
+
+        with self.assertRaisesRegex(
+            CircuitError,
+            r"Cannot compose a circuit with 2 qubit\(s\) into a circuit with 1 qubit\(s\)\.",
+        ):
+            base.compose(attempt)
+
+    def test_rejects_rhs_with_too_many_clbits(self):
+        """Test that compose rejects a circuit with too many classical bits."""
+        base = QuantumCircuit(1, 1)
+        attempt = QuantumCircuit(1, 2)
+
+        with self.assertRaisesRegex(
+            CircuitError,
+            (
+                r"Cannot compose a circuit with 2 classical bit\(s\) "
+                r"into a circuit with 1 classical bit\(s\)\."
+            ),
+        ):
+            base.compose(attempt)
+
     def test_cannot_mix_inputs_and_captures(self):
         """The rules about mixing `input` and `capture` vars should still apply."""
         a = expr.Var.new("a", types.Bool())

--- a/test/python/circuit/test_compose.py
+++ b/test/python/circuit/test_compose.py
@@ -979,7 +979,7 @@ class TestCircuitCompose(QiskitTestCase):
 
         with self.assertRaisesRegex(
             CircuitError,
-            r"Cannot compose a circuit with 2 qubit\(s\) into a circuit with 1 qubit\(s\)\.",
+            r"Cannot compose onto a circuit with fewer qubits \(2 > 1\)\.",
         ):
             base.compose(attempt)
 
@@ -990,10 +990,7 @@ class TestCircuitCompose(QiskitTestCase):
 
         with self.assertRaisesRegex(
             CircuitError,
-            (
-                r"Cannot compose a circuit with 2 classical bit\(s\) "
-                r"into a circuit with 1 classical bit\(s\)\."
-            ),
+            r"Cannot compose onto a circuit with fewer classical bits \(2 > 1\)\.",
         ):
             base.compose(attempt)
 

--- a/test/python/dagcircuit/test_compose.py
+++ b/test/python/dagcircuit/test_compose.py
@@ -531,6 +531,28 @@ class TestDagCompose(QiskitTestCase):
         ):
             dest.compose(source, inline_captures=True)
 
+    def test_rejects_rhs_with_too_many_qubits(self):
+        """Test that compose rejects a DAG with too many qubits."""
+        dest = circuit_to_dag(QuantumCircuit(1))
+        other = circuit_to_dag(QuantumCircuit(2))
+
+        with self.assertRaisesRegex(
+            DAGCircuitError,
+            r"Cannot compose onto a DAGCircuit with fewer qubits \(2 > 1\)\.",
+        ):
+            dest.compose(other)
+
+    def test_rejects_rhs_with_too_many_clbits(self):
+        """Test that compose rejects a DAG with too many classical bits."""
+        dest = circuit_to_dag(QuantumCircuit(1, 1))
+        other = circuit_to_dag(QuantumCircuit(1, 2))
+
+        with self.assertRaisesRegex(
+            DAGCircuitError,
+            r"Cannot compose onto a DAGCircuit with fewer classical bits \(2 > 1\)\.",
+        ):
+            dest.compose(other)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #13935.

This updates `QuantumCircuit.compose()` to raise clearer error messages when the circuit being composed is wider than the destination circuit.

Specifically:
- qubit-width mismatches now report the source and destination qubit counts
- classical-bit-width mismatches now report the source and destination classical-bit counts

## What changed

- replaced the internal-facing `"more 'in' edges"` error with user-facing `CircuitError` messages
- added regression tests covering:
  - composing a 2-qubit circuit into a 1-qubit circuit
  - composing a circuit with 2 classical bits into a circuit with 1 classical bit

## Why

The previous error message exposed internal graph terminology that is hard for new users to interpret. This change makes the failure mode more actionable and easier to understand.

## Testing

```bash
tox -epy313 -- -n test.python.circuit.test_compose
```

## AI disclosure

I used OpenAI Codex (GPT-5) for implementation assistance, and I reviewed and understood all changes before submitting this PR.
