### PR TITLE
Support measure-like instructions in ResetAfterMeasureSimplification

### DIFF
--- a/qiskit/transpiler/passes/optimization/reset_after_measure_simplification.py
+++ b/qiskit/transpiler/passes/optimization/reset_after_measure_simplification.py
@@ -34,7 +34,13 @@ class ResetAfterMeasureSimplification(TransformationPass):
     @control_flow.trivial_recurse
     def run(self, dag):
         """Run the pass on a dag."""
-        for node in dag.op_nodes(Measure):
+        for node in dag.topological_op_nodes():
+            is_measure_like = isinstance(node.op, Measure) or (
+                node.op.name.startswith("measure") and len(node.qargs) == 1 and len(node.cargs) == 1
+            )
+            if not is_measure_like:
+                continue
+
             succ = next(dag.quantum_successors(node))
             if isinstance(succ, DAGOpNode) and isinstance(succ.op, Reset):
                 x_body = QuantumCircuit(1)

--- a/test/python/transpiler/test_reset_after_measure_simplification.py
+++ b/test/python/transpiler/test_reset_after_measure_simplification.py
@@ -17,6 +17,7 @@ from qiskit.circuit import Clbit
 from qiskit.transpiler.passes.optimization import ResetAfterMeasureSimplification
 from qiskit.circuit import IfElseOp
 from test import QiskitTestCase
+from qiskit.circuit import Instruction
 
 
 class TestResetAfterMeasureSimplificationt(QiskitTestCase):
@@ -31,6 +32,25 @@ class TestResetAfterMeasureSimplificationt(QiskitTestCase):
 
         ans_qc = QuantumCircuit(1, 1)
         ans_qc.measure(0, 0)
+        x_body = QuantumCircuit(1)
+        x_body.x(0)
+        new_x = IfElseOp((ans_qc.clbits[0], 1), x_body)
+        ans_qc.append(new_x, [ans_qc.qubits[0]])
+
+        self.assertEqual(new_qc, ans_qc)
+
+
+    def test_measure_2_like_instruction(self):
+        """Test reset simplification for measure-like custom instructions."""
+        qc = QuantumCircuit(1, 1)
+        measure_2 = Instruction("measure_2", 1, 1, [])
+        qc.append(measure_2, [0], [0])
+        qc.reset(0)
+
+        new_qc = ResetAfterMeasureSimplification()(qc)
+
+        ans_qc = QuantumCircuit(1, 1)
+        ans_qc.append(measure_2, [0], [0])
         x_body = QuantumCircuit(1)
         x_body.x(0)
         new_x = IfElseOp((ans_qc.clbits[0], 1), x_body)


### PR DESCRIPTION
Fixes #15935

## Summary
Update ResetAfterMeasureSimplification to support measure-like instructions
such as `measure_2`, in addition to the built-in `Measure` instruction.

## Problem
When a measurement is converted into a custom measure-like instruction
before this pass runs, the pass does not recognize it and therefore does
not simplify a following reset.

## Fix
Iterate over topological op nodes and detect measure-like instructions by:
- checking for the built-in `Measure`, or
- checking for single-qubit, single-clbit instructions whose name starts with `measure`

## Tests
Added a regression test covering a custom `measure_2` instruction followed by `reset`.