### PR TITLE
Avoid adding auto-indices numbers for single bit registers

### DIFF
--- a/crates/circuit/src/circuit_drawer.rs
+++ b/crates/circuit/src/circuit_drawer.rs
@@ -1338,6 +1338,61 @@ c: ═══════╩══
     }
 
     #[test]
+    fn test_mixed_single_and_multi_bit_registers() {
+        // Single-bit registers ("q", "c") mixed with multi-bit registers ("qr", "cr").
+        // Single-bit ones render without the index suffix ("q:", "c:").
+        // Multi-bit ones keep the index ("qr_0:", "qr_1:", "cr_0:", "cr_1:").
+        let q = QuantumRegister::new_owning("q", 1);
+        let qr = QuantumRegister::new_owning("qr", 2);
+        let c = ClassicalRegister::new_owning("c", 1);
+        let cr = ClassicalRegister::new_owning("cr", 2);
+
+        let qubits: Vec<ShareableQubit> = (0..q.len())
+            .map(|i| q.get(i).expect("index in range"))
+            .chain((0..qr.len()).map(|i| qr.get(i).expect("index in range")))
+            .collect();
+        let clbits: Vec<ShareableClbit> = (0..c.len())
+            .map(|i| c.get(i).expect("index in range"))
+            .chain((0..cr.len()).map(|i| cr.get(i).expect("index in range")))
+            .collect();
+
+        let mut circuit = CircuitData::new(Some(qubits), Some(clbits), Param::Float(0.0)).unwrap();
+        _ = circuit.add_creg(c, true);
+        _ = circuit.add_creg(cr, true);
+        _ = circuit.add_qreg(q, true);
+        _ = circuit.add_qreg(qr, true);
+
+        circuit
+            .push_standard_gate(StandardGate::H, &[], &[Qubit::new(0)])
+            .unwrap();
+        circuit
+            .push_standard_gate(StandardGate::H, &[], &[Qubit::new(1)])
+            .unwrap();
+
+        let result = draw_circuit(&circuit, false, false, Some(100)).unwrap();
+        let expected = "
+      ┌───┐
+   q: ┤ H ├
+      └───┘
+      ┌───┐
+qr_0: ┤ H ├
+      └───┘
+
+qr_1: ─────
+
+
+   c: ═════
+
+
+cr_0: ═════
+
+
+cr_1: ═════
+";
+        assert_eq!(result, expected.trim_start_matches("\n"));
+    }
+
+    #[test]
     fn test_fold() {
         let mut circuit = basic_circuit();
 

--- a/crates/circuit/src/circuit_drawer.rs
+++ b/crates/circuit/src/circuit_drawer.rs
@@ -166,7 +166,7 @@ impl WireInputElement<'_> {
                         .registers()
                         .first()
                         .expect("Register cannot be empty");
-                    if !register.is_empty() {
+                    if register.len() > 1 {
                         Some(format!("{}_{}: ", register.name(), index))
                     } else {
                         Some(format!("{}: ", register.name()))
@@ -186,7 +186,7 @@ impl WireInputElement<'_> {
                         .registers()
                         .first()
                         .expect("Register cannot be empty");
-                    if !register.is_empty() {
+                    if register.len() > 1 {
                         Some(format!("{}_{}: ", register.name(), index))
                     } else {
                         Some(format!("{}: ", register.name()))
@@ -1292,6 +1292,47 @@ c1_1: ══════════
 c2_0: ══════════
 
 c2_1: ══════════
+";
+        assert_eq!(result, expected.trim_start_matches("\n"));
+    }
+
+    #[test]
+    fn test_single_bit_registers() {
+        // Single-bit registers should render as "q: " and "c: " (no auto-index suffix "_0").
+        let qreg = QuantumRegister::new_owning("q", 1);
+        let creg = ClassicalRegister::new_owning("c", 1);
+
+        let qubits: Vec<ShareableQubit> = (0..qreg.len())
+            .map(|i| qreg.get(i).expect("index in range"))
+            .collect();
+        let clbits: Vec<ShareableClbit> = (0..creg.len())
+            .map(|i| creg.get(i).expect("index in range"))
+            .collect();
+
+        let mut circuit = CircuitData::new(Some(qubits), Some(clbits), Param::Float(0.0)).unwrap();
+        _ = circuit.add_creg(creg, true);
+        _ = circuit.add_qreg(qreg, true);
+
+        circuit
+            .push_standard_gate(StandardGate::H, &[], &[Qubit::new(0)])
+            .unwrap();
+
+        let inst = PackedInstruction {
+            op: StandardInstruction::Measure.into(),
+            qubits: circuit.add_qargs(&[Qubit::new(0)]),
+            clbits: circuit.add_cargs(&[Clbit::new(0)]),
+            params: None,
+            label: None,
+        };
+        circuit.push(inst).unwrap();
+
+        let result = draw_circuit(&circuit, false, false, Some(100)).unwrap();
+        let expected = "
+   ┌───┐┌───┐
+q: ┤ H ├┤ M ├
+   └───┘└─╥─┘
+          ║
+c: ═══════╩══
 ";
         assert_eq!(result, expected.trim_start_matches("\n"));
     }


### PR DESCRIPTION
Task 8 in [Enhancements to the Rust circuit drawer](https://github.com/Qiskit/qiskit/issues/15849#top)