### PR TITLE
Update `PauliProductRotationGate.to_matrix()` from `scipy` to `numpy`

### DIFF
--- a/qiskit/circuit/library/generalized_gates/pauli_product_rotation.py
+++ b/qiskit/circuit/library/generalized_gates/pauli_product_rotation.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import typing
 import numpy as np
-import scipy as sc
 
 from qiskit.circuit import QuantumCircuit, CircuitError, Gate
 from qiskit._accelerate.synthesis.pauli_products import synth_pauli_product_rotation
@@ -179,4 +178,5 @@ class PauliProductRotationGate(Gate):
     def to_matrix(self):
         pauli_matrix = self.pauli().to_matrix(sparse=False)
         angle = self.params[0]
-        return sc.linalg.expm(-0.5j * angle * pauli_matrix)
+        iden_matrix = np.eye(pauli_matrix.shape[0], dtype=complex)
+        return np.cos(angle / 2) * iden_matrix - 1j * np.sin(angle / 2) * pauli_matrix

--- a/qiskit/circuit/library/generalized_gates/pauli_product_rotation.py
+++ b/qiskit/circuit/library/generalized_gates/pauli_product_rotation.py
@@ -176,11 +176,19 @@ class PauliProductRotationGate(Gate):
         return Pauli((self._pauli_z, self._pauli_x, 0))
 
     def to_matrix(self):
-        """Calculate the matrix of PauliProductRotationGate(pauli, angle),
-        it equals to: exp(-0.5j * angle * pauli) or equivalently to
-        cos(angle/2) * I - 1j * sin(angle / 2) * pauli"""
+        r"""Returns a dense matrix representation of
+        :class:`~.PauliProductRotationGate`.
+
+        This implements
+
+        .. math::
+
+        e^{-i \theta / 2 P} = cos(\theta / 2) I - i sin(\theta / 2) P.
+
+        for a rotation angle :math:`\theta` and Pauli :math:`P`.
+        """
         angle = self.params[0]
-        pauli_matrix = self.pauli().to_matrix(sparse=False)
-        ppr_matrix = -1j * np.sin(angle / 2) * pauli_matrix
-        np.fill_diagonal(ppr_matrix, ppr_matrix.diagonal() + np.cos(angle / 2))
-        return ppr_matrix
+        out = self.pauli().to_matrix(sparse=False)
+        out *= -1j * np.sin(angle / 2)
+        np.fill_diagonal(out, out.diagonal() + np.cos(angle / 2))
+        return out

--- a/qiskit/circuit/library/generalized_gates/pauli_product_rotation.py
+++ b/qiskit/circuit/library/generalized_gates/pauli_product_rotation.py
@@ -176,7 +176,11 @@ class PauliProductRotationGate(Gate):
         return Pauli((self._pauli_z, self._pauli_x, 0))
 
     def to_matrix(self):
-        pauli_matrix = self.pauli().to_matrix(sparse=False)
+        """Calculate the matrix of PauliProductRotationGate(pauli, angle),
+        it eqauls to: exp(-0.5j * angle * pauli) or equivalently to
+        cos(angle/2) * I - 1j * sin(angle / 2) * pauli"""
         angle = self.params[0]
-        iden_matrix = np.eye(pauli_matrix.shape[0], dtype=complex)
-        return np.cos(angle / 2) * iden_matrix - 1j * np.sin(angle / 2) * pauli_matrix
+        pauli_matrix = self.pauli().to_matrix(sparse=False)
+        ppr_matrix = -1j * np.sin(angle / 2) * ppr_matrix
+        np.fill_diagonal(ppr_matrix, ppr_matrix.diagonal() + np.cos(angle / 2))
+        return ppr_matrix

--- a/qiskit/circuit/library/generalized_gates/pauli_product_rotation.py
+++ b/qiskit/circuit/library/generalized_gates/pauli_product_rotation.py
@@ -183,7 +183,7 @@ class PauliProductRotationGate(Gate):
 
         .. math::
 
-           e^{-i \theta / 2 P} = \cos(\theta / 2) I - i \sin(\theta / 2) P.
+           e^{-i \theta / 2 P} = \cos(\theta / 2) I - i \sin(\theta / 2) P
 
         for a rotation angle :math:`\theta` and Pauli :math:`P`.
         """

--- a/qiskit/circuit/library/generalized_gates/pauli_product_rotation.py
+++ b/qiskit/circuit/library/generalized_gates/pauli_product_rotation.py
@@ -177,7 +177,7 @@ class PauliProductRotationGate(Gate):
 
     def to_matrix(self):
         """Calculate the matrix of PauliProductRotationGate(pauli, angle),
-        it eqauls to: exp(-0.5j * angle * pauli) or equivalently to
+        it equals to: exp(-0.5j * angle * pauli) or equivalently to
         cos(angle/2) * I - 1j * sin(angle / 2) * pauli"""
         angle = self.params[0]
         pauli_matrix = self.pauli().to_matrix(sparse=False)

--- a/qiskit/circuit/library/generalized_gates/pauli_product_rotation.py
+++ b/qiskit/circuit/library/generalized_gates/pauli_product_rotation.py
@@ -181,6 +181,6 @@ class PauliProductRotationGate(Gate):
         cos(angle/2) * I - 1j * sin(angle / 2) * pauli"""
         angle = self.params[0]
         pauli_matrix = self.pauli().to_matrix(sparse=False)
-        ppr_matrix = -1j * np.sin(angle / 2) * ppr_matrix
+        ppr_matrix = -1j * np.sin(angle / 2) * pauli_matrix
         np.fill_diagonal(ppr_matrix, ppr_matrix.diagonal() + np.cos(angle / 2))
         return ppr_matrix

--- a/qiskit/circuit/library/generalized_gates/pauli_product_rotation.py
+++ b/qiskit/circuit/library/generalized_gates/pauli_product_rotation.py
@@ -183,7 +183,7 @@ class PauliProductRotationGate(Gate):
 
         .. math::
 
-        e^{-i \theta / 2 P} = cos(\theta / 2) I - i sin(\theta / 2) P.
+           e^{-i \theta / 2 P} = \cos(\theta / 2) I - i \sin(\theta / 2) P.
 
         for a rotation angle :math:`\theta` and Pauli :math:`P`.
         """

--- a/qiskit/circuit/library/generalized_gates/pauli_product_rotation.py
+++ b/qiskit/circuit/library/generalized_gates/pauli_product_rotation.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import typing
+import math
 import numpy as np
 
 from qiskit.circuit import QuantumCircuit, CircuitError, Gate
@@ -189,6 +190,6 @@ class PauliProductRotationGate(Gate):
         """
         angle = self.params[0]
         out = self.pauli().to_matrix(sparse=False)
-        out *= -1j * np.sin(angle / 2)
-        np.fill_diagonal(out, out.diagonal() + np.cos(angle / 2))
+        out *= -1j * math.sin(angle / 2)
+        np.fill_diagonal(out, out.diagonal() + math.cos(angle / 2))
         return out

--- a/releasenotes/notes/improve-ppr-to-matrix-e6de4615c1bcf97a.yaml
+++ b/releasenotes/notes/improve-ppr-to-matrix-e6de4615c1bcf97a.yaml
@@ -1,4 +1,4 @@
 ---
 features_circuits:
-  - Improve the runtime of :meth:`~.PauliProductRotation.to_matrix`.
+  - Improve the runtime of :meth:`~.PauliProductRotationGate.to_matrix`.
     For 10‑qubit Pauli operators, this results in a ~500× speedup.

--- a/releasenotes/notes/improve-ppr-to-matrix-e6de4615c1bcf97a.yaml
+++ b/releasenotes/notes/improve-ppr-to-matrix-e6de4615c1bcf97a.yaml
@@ -1,4 +1,4 @@
 ---
 features_circuits:
   - Improve the runtime of :meth:`~.PauliProductRotation.to_matrix`.
-    For 10-qubit Paulis the runtime improves by 500x.
+    For 10‑qubit Pauli operators, this results in a ~500× speedup.

--- a/releasenotes/notes/improve-ppr-to-matrix-e6de4615c1bcf97a.yaml
+++ b/releasenotes/notes/improve-ppr-to-matrix-e6de4615c1bcf97a.yaml
@@ -1,4 +1,5 @@
 ---
 features_circuits:
-  - Improve the runtime of :meth:`~.PauliProductRotationGate.to_matrix`.
+  - Improve the runtime of the method :meth:`~.PauliProductRotationGate.to_matrix` of
+    :class:`.PauliProductRotationGate`.
     For 10‑qubit Pauli operators, this results in a ~500× speedup.

--- a/releasenotes/notes/improve-ppr-to-matrix-e6de4615c1bcf97a.yaml
+++ b/releasenotes/notes/improve-ppr-to-matrix-e6de4615c1bcf97a.yaml
@@ -1,0 +1,4 @@
+---
+features_circuits:
+  - Improve the runtime of :meth:`~.PauliProductRotation.to_matrix`.
+    For 10-qubit Paulis the runtime improves by 500x.

--- a/releasenotes/notes/improve-ppr-to-matrix-e6de4615c1bcf97a.yaml
+++ b/releasenotes/notes/improve-ppr-to-matrix-e6de4615c1bcf97a.yaml
@@ -1,5 +1,4 @@
 ---
 performance:
-  - Improve the runtime of the method :meth:`~.PauliProductRotationGate.to_matrix` of
-    :class:`.PauliProductRotationGate`.
+  - Improve the runtime of the method :meth:`.PauliProductRotationGate.to_matrix`.
     For 10‑qubit Pauli operators, this results in a ~500× speedup.

--- a/releasenotes/notes/improve-ppr-to-matrix-e6de4615c1bcf97a.yaml
+++ b/releasenotes/notes/improve-ppr-to-matrix-e6de4615c1bcf97a.yaml
@@ -1,5 +1,5 @@
 ---
-features_circuits:
+performance:
   - Improve the runtime of the method :meth:`~.PauliProductRotationGate.to_matrix` of
     :class:`.PauliProductRotationGate`.
     For 10‑qubit Pauli operators, this results in a ~500× speedup.


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->
Update `PauliProductRotationGate.to_matrix()` to use `numpy` instead of `scipy`.
This was suggested by @Cryoris in order to simplify this code.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
