### PR TITLE
Fix LaTeX circuit drawer math-mode gate labels

### DIFF
--- a/qiskit/visualization/circuit/_utils.py
+++ b/qiskit/visualization/circuit/_utils.py
@@ -50,6 +50,26 @@ def _is_boolean_expression(gate_text, op):
     return isinstance(op, (PhaseOracleGate, BitFlipOracleGate)) and gate_text == op.label
 
 
+def _format_latex_label_with_mathmode(label):
+    """Format a latex label that contains explicit math-mode segments."""
+    parts = re.split(r"(?<!\\)\$", label)
+    if len(parts) % 2 == 0:
+        return None
+
+    formatted = []
+    for index, part in enumerate(parts):
+        if not part:
+            continue
+        if index % 2:
+            formatted.append(part)
+        else:
+            part = part.replace("_", "\\_")
+            part = part.replace("^", "\\string^")
+            part = part.replace("-", "\\mbox{-}")
+            formatted.append(f"\\mathrm{{{part}}}")
+    return "".join(formatted)
+
+
 def get_gate_ctrl_text(op, drawer, style=None):
     """Load the gate_text and ctrl_text strings based on names and labels"""
 
@@ -118,11 +138,15 @@ def get_gate_ctrl_text(op, drawer, style=None):
         ) and (op_type not in [PauliEvolutionGate, PauliProductMeasurement]):
             gate_text = f"$\\mathrm{{{gate_text.capitalize()}}}$"
         else:
-            gate_text = f"$\\mathrm{{{gate_text}}}$"
-            # Remove mathmode _, ^, and - formatting from user names and labels
-            gate_text = gate_text.replace("_", "\\_")
-            gate_text = gate_text.replace("^", "\\string^")
-            gate_text = gate_text.replace("-", "\\mbox{-}")
+            formatted_gate_text = _format_latex_label_with_mathmode(gate_text)
+            if formatted_gate_text is None:
+                gate_text = f"$\\mathrm{{{gate_text}}}$"
+                # Remove mathmode _, ^, and - formatting from user names and labels
+                gate_text = gate_text.replace("_", "\\_")
+                gate_text = gate_text.replace("^", "\\string^")
+                gate_text = gate_text.replace("-", "\\mbox{-}")
+            else:
+                gate_text = formatted_gate_text
         ctrl_text = f"$\\mathrm{{{ctrl_text}}}$"
 
     # Only capitalize internally-created gate or instruction names

--- a/releasenotes/notes/latex-mathmode-gate-labels-5174ebc09bfb7e5c.yaml
+++ b/releasenotes/notes/latex-mathmode-gate-labels-5174ebc09bfb7e5c.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    Fixed :meth:`.QuantumCircuit.draw` with ``output="latex"`` or
+    ``output="latex_source"`` so gate labels can include explicit LaTeX
+    math-mode segments such as ``"$U^a$"`` without producing invalid LaTeX.

--- a/test/python/visualization/test_circuit_latex.py
+++ b/test/python/visualization/test_circuit_latex.py
@@ -22,6 +22,7 @@ from qiskit.visualization import circuit_drawer
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister, transpile
 from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit.circuit.library import (
+    HGate,
     XGate,
     MCXGate,
     RZZGate,
@@ -238,6 +239,34 @@ class TestLatexSourceGenerator(QiskitVisualizationTestCase):
         circuit_drawer(circuit, filename=filename, output="latex_source", barrier_label_len=9)
 
         self.assertEqualToReference(filename)
+
+    def test_mathmode_gate_label(self):
+        """Test gate labels with explicit math mode."""
+        circuit = QuantumCircuit(1)
+        circuit.append(HGate(label="$U^a$"), [0])
+
+        source = circuit_drawer(circuit, output="latex_source")
+
+        self.assertIn(r"\gate{U^a}", source)
+        self.assertNotIn(r"\gate{\mathrm{$U", source)
+
+    def test_plain_gate_label(self):
+        """Test gate labels without explicit math mode."""
+        circuit = QuantumCircuit(1)
+        circuit.append(HGate(label="U^a"), [0])
+
+        source = circuit_drawer(circuit, output="latex_source")
+
+        self.assertIn(r"\gate{\mathrm{U\string^a}}", source)
+
+    def test_mixed_mathmode_gate_label(self):
+        """Test gate labels with text outside explicit math mode."""
+        circuit = QuantumCircuit(1)
+        circuit.append(HGate(label="prefix $U^a$ suffix"), [0])
+
+        source = circuit_drawer(circuit, output="latex_source")
+
+        self.assertIn(r"\gate{\mathrm{prefix\,}U^a\mathrm{\,suffix}}", source)
 
     def test_big_gates(self):
         """Test large gates with params"""


### PR DESCRIPTION
fixes #9208

## Summary

Fix LaTeX circuit drawer handling of gate labels that contain explicit math-mode segments such as `"$U^a$"`.

## Root cause

The LaTeX drawer wrapped user labels in `\mathrm{...}` before handling explicit math-mode fragments, so labels containing `$...$` were turned into invalid LaTeX.

## Fix

Add a small helper in the LaTeX label-formatting path that preserves balanced explicit math-mode segments and only escapes the surrounding plain-text portions. Add regression tests for pure math labels, plain-text labels, and mixed text-plus-math labels. Add the required release note.

## Tests

- `python -m unittest -v test.python.visualization.test_circuit_latex`
- `python -m unittest -v test.python.visualization.test_utils`
- `black --check qiskit/visualization/circuit/_utils.py test/python/visualization/test_circuit_latex.py`
- `ruff check qiskit/visualization/circuit/_utils.py test/python/visualization/test_circuit_latex.py`

## Notes / limitations

- I validated the behavior through `latex_source`; I did not complete full rendered `draw("latex")` image generation locally because `pdftocairo` is not installed in this environment.
- `reno -q lint` was not verifiable in this local checkout because of a Dulwich missing-object error unrelated to the note contents.
- AI tool disclosure: Codex (GPT-5).
