### PR TITLE
Return old phase from `DAGCircuit::set_global_phase_*`

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -914,15 +914,8 @@ impl DAGCircuit {
     /// Args:
     ///     angle (float, :class:`.ParameterExpression`): The phase angle.
     #[setter(global_phase)]
-    pub fn set_global_phase_param(&mut self, angle: Param) -> PyResult<()> {
-        match angle {
-            Param::Float(angle) => self.set_global_phase_f64(angle),
-            Param::ParameterExpression(angle) => {
-                self.global_phase = Param::ParameterExpression(angle);
-            }
-            Param::Obj(_) => return Err(PyTypeError::new_err("Invalid type for global phase")),
-        }
-        Ok(())
+    pub fn set_global_phase(&mut self, angle: Param) -> PyResult<()> {
+        self.set_global_phase_param(angle).map(|_| ())
     }
 
     /// Remove all operation nodes with the given name.
@@ -6230,12 +6223,30 @@ impl DAGCircuit {
         Ok((in_node, out_node))
     }
 
-    /// Set the global phase to a float value.
+    /// Set the global phase to a float value.  Returns the old phase.
     ///
     /// Unlike the general [set_global_phase_param], this is infallible.
     #[inline]
-    pub fn set_global_phase_f64(&mut self, angle: f64) {
-        self.global_phase = Param::Float(angle.rem_euclid(::std::f64::consts::TAU));
+    pub fn set_global_phase_f64(&mut self, angle: f64) -> Param {
+        std::mem::replace(
+            &mut self.global_phase,
+            Param::Float(angle.rem_euclid(::std::f64::consts::TAU)),
+        )
+    }
+
+    /// Set the global phase to a general [Param].  Returns the old phase.
+    ///
+    /// Unlike the general [set_global_phase_param], this is infallible.
+    #[inline]
+    pub fn set_global_phase_param(&mut self, angle: Param) -> PyResult<Param> {
+        match angle {
+            Param::Float(angle) => Ok(self.set_global_phase_f64(angle)),
+            Param::ParameterExpression(angle) => Ok(std::mem::replace(
+                &mut self.global_phase,
+                Param::ParameterExpression(angle),
+            )),
+            Param::Obj(_) => Err(PyTypeError::new_err("Invalid type for global phase")),
+        }
     }
 
     /// Get the nodes on the given wire.
@@ -7298,14 +7309,13 @@ impl DAGCircuit {
 
     pub fn add_global_phase(&mut self, value: &Param) -> PyResult<()> {
         match value {
-            Param::Obj(_) => {
-                return Err(PyTypeError::new_err(
-                    "Invalid parameter type, only float and parameter expression are supported",
-                ));
-            }
-            _ => self.set_global_phase_param(add_global_phase(&self.global_phase, value))?,
+            Param::Obj(_) => Err(PyTypeError::new_err(
+                "Invalid parameter type, only float and parameter expression are supported",
+            )),
+            _ => self
+                .set_global_phase_param(add_global_phase(&self.global_phase, value))
+                .map(|_| ()),
         }
-        Ok(())
     }
 
     /// Return the op name counts in the circuit

--- a/crates/transpiler/src/passes/commutative_optimization.rs
+++ b/crates/transpiler/src/passes/commutative_optimization.rs
@@ -482,7 +482,7 @@ pub fn run_commutative_optimization(
     let num_nodes = node_indices.len();
 
     let mut node_actions: Vec<NodeAction> = vec![NodeAction::Keep; num_nodes];
-    let mut new_global_phase = dag.global_phase().clone();
+    let mut new_global_phase = new_dag.set_global_phase_f64(0.0);
 
     let mut modified: bool = false;
 

--- a/crates/transpiler/src/passes/remove_identity_equiv.rs
+++ b/crates/transpiler/src/passes/remove_identity_equiv.rs
@@ -250,8 +250,7 @@ pub fn py_remove_identity_equiv(
     //
     // This doesn't account for control-flow blocks which _also_ might have set global phases, byt
     // `run_remove_identity_equiv` as of Qiskit 2.4 doesn't recurse, so the hack should hold.
-    let old_phase = dag.global_phase().clone();
-    dag.set_global_phase_f64(0.0);
+    let old_phase = dag.set_global_phase_f64(0.0);
 
     // Explicitly release GIL because threads may call Python to get
     // the matrix for a PyGate


### PR DESCRIPTION
`ParameterExpression` can get rather heavy, and this permits temporarily swapping out the global phase without having to clone what was there before in order to store it.

This is just a minor potential interface tweak I noticed while writing #16054.


### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
