### PR TITLE
Use fprintf(stderr, ...) over printf(...) in C tests

### DIFF
--- a/test/c/common.c
+++ b/test/c/common.c
@@ -46,27 +46,27 @@ void print_circuit(const QkCircuit *qc) {
     QkCircuitInstruction inst;
     for (size_t i = 0; i < num_instructions; i++) {
         qk_circuit_get_instruction(qc, i, &inst);
-        printf("%s: qubits: (", inst.name);
+        fprintf(stderr, "%s: qubits: (", inst.name);
         for (uint32_t j = 0; j < inst.num_qubits; j++) {
-            printf("%d,", inst.qubits[j]);
+            fprintf(stderr, "%d,", inst.qubits[j]);
         }
-        printf(")");
+        fprintf(stderr, ")");
         uint32_t num_clbits = inst.num_clbits;
         if (num_clbits > 0) {
-            printf(", clbits: (");
+            fprintf(stderr, ", clbits: (");
             for (uint32_t j = 0; j < num_clbits; j++) {
-                printf("%d,", inst.clbits[j]);
+                fprintf(stderr, "%d,", inst.clbits[j]);
             }
-            printf(")");
+            fprintf(stderr, ")");
         }
-        printf("\n");
+        fprintf(stderr, "\n");
         qk_circuit_instruction_clear(&inst);
     }
 }
 
 bool compare_circuits(const QkCircuit *res, const QkCircuit *expected) {
     if (qk_circuit_num_instructions(res) != qk_circuit_num_instructions(expected)) {
-        printf("Number of instructions in circuit is mismatched\n");
+        fprintf(stderr, "Number of instructions in circuit is mismatched\n");
         return false;
     }
     QkCircuitInstruction res_inst;
@@ -76,14 +76,14 @@ bool compare_circuits(const QkCircuit *res, const QkCircuit *expected) {
         qk_circuit_get_instruction(expected, i, &expected_inst);
         int result = strcmp(res_inst.name, expected_inst.name);
         if (result != 0) {
-            printf("Gate %zu have different gates %s was found and expected %s\n", i, res_inst.name,
+            fprintf(stderr, "Gate %zu have different gates %s was found and expected %s\n", i, res_inst.name,
                    expected_inst.name);
             qk_circuit_instruction_clear(&res_inst);
             qk_circuit_instruction_clear(&expected_inst);
             return false;
         }
         if (res_inst.num_qubits != expected_inst.num_qubits) {
-            printf("Gate %zu have different number of qubits %d was found and expected %d\n", i,
+            fprintf(stderr, "Gate %zu have different number of qubits %d was found and expected %d\n", i,
                    res_inst.num_qubits, expected_inst.num_qubits);
             qk_circuit_instruction_clear(&res_inst);
             qk_circuit_instruction_clear(&expected_inst);
@@ -91,11 +91,11 @@ bool compare_circuits(const QkCircuit *res, const QkCircuit *expected) {
         }
         for (uint32_t j = 0; j < res_inst.num_qubits; j++) {
             if (res_inst.qubits[j] != expected_inst.qubits[j]) {
-                printf("Qubit %d for gate %zu are different %d was found and expected %d\n", j, i,
+                fprintf(stderr, "Qubit %d for gate %zu are different %d was found and expected %d\n", j, i,
                        res_inst.qubits[j], expected_inst.qubits[j]);
-                printf("Expected circuit instructions:\n");
+                fprintf(stderr, "Expected circuit instructions:\n");
                 print_circuit(expected);
-                printf("Result circuit:\n");
+                fprintf(stderr, "Result circuit:\n");
                 print_circuit(res);
                 qk_circuit_instruction_clear(&res_inst);
                 qk_circuit_instruction_clear(&expected_inst);
@@ -103,7 +103,7 @@ bool compare_circuits(const QkCircuit *res, const QkCircuit *expected) {
             }
         }
         if (res_inst.num_clbits != expected_inst.num_clbits) {
-            printf("Gate %zu have different number of clbits %d was found and expected %d\n", i,
+            fprintf(stderr, "Gate %zu have different number of clbits %d was found and expected %d\n", i,
                    res_inst.num_clbits, expected_inst.num_clbits);
             qk_circuit_instruction_clear(&res_inst);
             qk_circuit_instruction_clear(&expected_inst);
@@ -111,7 +111,7 @@ bool compare_circuits(const QkCircuit *res, const QkCircuit *expected) {
         }
         for (uint32_t j = 0; j < res_inst.num_clbits; j++) {
             if (res_inst.clbits[j] != expected_inst.clbits[j]) {
-                printf("Clbit %d for gate %zu are different %d was found and expected %d\n", j, i,
+                fprintf(stderr, "Clbit %d for gate %zu are different %d was found and expected %d\n", j, i,
                        res_inst.clbits[j], expected_inst.clbits[j]);
                 qk_circuit_instruction_clear(&res_inst);
                 qk_circuit_instruction_clear(&expected_inst);
@@ -119,7 +119,7 @@ bool compare_circuits(const QkCircuit *res, const QkCircuit *expected) {
             }
         }
         if (res_inst.num_params != expected_inst.num_params) {
-            printf("Gate %zu have different number of params %d was found and expected %d\n", i,
+            fprintf(stderr, "Gate %zu have different number of params %d was found and expected %d\n", i,
                    res_inst.num_params, expected_inst.num_params);
             qk_circuit_instruction_clear(&res_inst);
             qk_circuit_instruction_clear(&expected_inst);
@@ -130,7 +130,7 @@ bool compare_circuits(const QkCircuit *res, const QkCircuit *expected) {
                 char *res_str = qk_param_str(res_inst.params[j]);
                 char *expected_str = qk_param_str(expected_inst.params[j]);
 
-                printf("Parameter %d for gate %zu are different %s was found and expected %s\n", j,
+                fprintf(stderr, "Parameter %d for gate %zu are different %s was found and expected %s\n", j,
                        i, res_str, expected_str);
                 qk_str_free(res_str);
                 qk_str_free(expected_str);

--- a/test/c/test_basis_translator.c
+++ b/test/c/test_basis_translator.c
@@ -37,7 +37,7 @@ static int test_circuit_in_basis(void) {
     size_t circuit_len = qk_circuit_num_instructions(circuit);
     if (circuit_len != 2) {
         result = EqualityError;
-        printf(
+        fprintf(stderr, 
             "The number of gates resulting from the translation is incorrect. Expected 2, got %zu",
             circuit_len);
         goto cleanup;
@@ -51,7 +51,7 @@ static int test_circuit_in_basis(void) {
 
         if (strcmp(inst.name, gate_names[idx]) != 0) {
             result = EqualityError;
-            printf(
+            fprintf(stderr, 
                 "The operation resulting from this translation was incorrect. Expected '%s' gate, "
                 "got '%s'",
                 gate_names[idx], inst.name);
@@ -84,7 +84,7 @@ static int test_basic_basis_translator(void) {
 
     if (result_op_counts.len != 1) {
         result = EqualityError;
-        printf(
+        fprintf(stderr, 
             "The number of gates resulting from the translation is incorrect. Expected 1, got %zu",
             result_op_counts.len);
         goto cleanup;
@@ -93,7 +93,7 @@ static int test_basic_basis_translator(void) {
     QkOpCount u_count = result_op_counts.data[0];
     if (u_count.count != 1 || strcmp(u_count.name, "u") != 0) {
         result = EqualityError;
-        printf("The operation resulting from this translation was incorrect. Expected 'u' gate, "
+        fprintf(stderr, "The operation resulting from this translation was incorrect. Expected 'u' gate, "
                "got '%s'",
                u_count.name);
     }
@@ -125,7 +125,7 @@ static int test_toffoli_basis_translator(void) {
 
     if (result_op_counts.len != 4) {
         result = EqualityError;
-        printf(
+        fprintf(stderr, 
             "The number of gates resulting from the translation is incorrect. Expected 1, got %zu",
             result_op_counts.len);
         goto cleanup;
@@ -138,7 +138,7 @@ static int test_toffoli_basis_translator(void) {
         QkOpCount gate_count = result_op_counts.data[idx];
         if (gate_count.count != freqs[idx] || strcmp(gate_count.name, gates[idx]) != 0) {
             result = EqualityError;
-            printf(
+            fprintf(stderr, 
                 "The operation resulting from this translation was incorrect. Expected '%s' gate, "
                 "got '%s'",
                 gates[idx], gate_count.name);

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -36,19 +36,19 @@ static int test_empty(void) {
     qk_circuit_free(qc);
 
     if (opcount != 0) {
-        printf("The operation count %zu is not 0", opcount);
+        fprintf(stderr, "The operation count %zu is not 0", opcount);
         return EqualityError;
     }
     if (num_qubits != 0) {
-        printf("The number of qubits %d is not 0", num_qubits);
+        fprintf(stderr, "The number of qubits %d is not 0", num_qubits);
         return EqualityError;
     }
     if (num_clbits != 0) {
-        printf("The number of clbits %d is not 0", num_clbits);
+        fprintf(stderr, "The number of clbits %d is not 0", num_clbits);
         return EqualityError;
     }
     if (num_instructions != 0) {
-        printf("The number of instructions %zu is not 0", num_instructions);
+        fprintf(stderr, "The number of instructions %zu is not 0", num_instructions);
         return EqualityError;
     }
     return Ok;
@@ -64,15 +64,15 @@ static int test_circuit_with_quantum_reg(void) {
     qk_circuit_free(qc);
     qk_quantum_register_free(qr);
     if (num_qubits != 1024) {
-        printf("The number of qubits %d is not 1024", num_qubits);
+        fprintf(stderr, "The number of qubits %d is not 1024", num_qubits);
         return EqualityError;
     }
     if (num_clbits != 0) {
-        printf("The number of clbits %d is not 0", num_clbits);
+        fprintf(stderr, "The number of clbits %d is not 0", num_clbits);
         return EqualityError;
     }
     if (num_instructions != 0) {
-        printf("The number of instructions %zu is not 0", num_instructions);
+        fprintf(stderr, "The number of instructions %zu is not 0", num_instructions);
         return EqualityError;
     }
     return Ok;
@@ -95,7 +95,7 @@ static int test_circuit_copy(void) {
     qk_circuit_free(qc);
     qk_circuit_free(copy);
     if (num_instructions == num_copy_instructions) {
-        printf("The number of instructions %zu is equal to the copied %zu", num_instructions,
+        fprintf(stderr, "The number of instructions %zu is equal to the copied %zu", num_instructions,
                num_copy_instructions);
         return EqualityError;
     }
@@ -112,15 +112,15 @@ static int test_circuit_with_classical_reg(void) {
     qk_circuit_free(qc);
     qk_classical_register_free(cr);
     if (num_qubits != 0) {
-        printf("The number of qubits %d is not 0", num_qubits);
+        fprintf(stderr, "The number of qubits %d is not 0", num_qubits);
         return EqualityError;
     }
     if (num_clbits != 2048) {
-        printf("The number of clbits %d is not 2048", num_clbits);
+        fprintf(stderr, "The number of clbits %d is not 2048", num_clbits);
         return EqualityError;
     }
     if (num_instructions != 0) {
-        printf("The number of instructions %zu is not 0", num_instructions);
+        fprintf(stderr, "The number of instructions %zu is not 0", num_instructions);
         return EqualityError;
     }
     return Ok;
@@ -139,7 +139,7 @@ static int test_circuit_copy_with_instructions(void) {
     size_t num_instructions = qk_circuit_num_instructions(qc);
     size_t num_copy_instructions = qk_circuit_num_instructions(copy);
     if (num_instructions != num_copy_instructions) {
-        printf("The number of instructions %zu does not equal the copied %zu", num_instructions,
+        fprintf(stderr, "The number of instructions %zu does not equal the copied %zu", num_instructions,
                num_copy_instructions);
         return EqualityError;
     }
@@ -164,7 +164,7 @@ static int test_circuit_copy_with_instructions(void) {
     qk_circuit_free(qc);
     qk_circuit_free(copy);
     if (num_instructions == num_copy_instructions) {
-        printf("The number of instructions %zu is equal to the copied %zu", num_instructions,
+        fprintf(stderr, "The number of instructions %zu is equal to the copied %zu", num_instructions,
                num_copy_instructions);
         return EqualityError;
     }
@@ -187,12 +187,12 @@ static int test_circuit_copy_empty_like(void) {
     qk_circuit_free(copy);
 
     if (num_instructions == 0) {
-        printf("Expected the original circuit to remain unchanged, but it is now empty\n");
+        fprintf(stderr, "Expected the original circuit to remain unchanged, but it is now empty\n");
         return EqualityError;
     }
 
     if (num_copy_instructions != 0) {
-        printf("Expected no operations in the copied-empty-like circuit, but got %zu\n",
+        fprintf(stderr, "Expected no operations in the copied-empty-like circuit, but got %zu\n",
                num_copy_instructions);
         return EqualityError;
     }
@@ -207,15 +207,15 @@ static int test_no_gate_1000_bits(void) {
     qk_circuit_free(qc);
 
     if (num_qubits != 1000) {
-        printf("The number of qubits %d is not 1000", num_qubits);
+        fprintf(stderr, "The number of qubits %d is not 1000", num_qubits);
         return EqualityError;
     }
     if (num_clbits != 1000) {
-        printf("The number of clbits %d is not 1000", num_clbits);
+        fprintf(stderr, "The number of clbits %d is not 1000", num_clbits);
         return EqualityError;
     }
     if (num_instructions != 0) {
-        printf("The number of instructions %zu is not 0", num_instructions);
+        fprintf(stderr, "The number of instructions %zu is not 0", num_instructions);
         return EqualityError;
     }
 
@@ -839,14 +839,14 @@ static int test_unitary_gate_1q(void) {
     QkOperationKind kind = qk_circuit_instruction_kind(qc, num_inst - 1);
     if (kind != QkOperationKind_Unitary) {
         result = EqualityError;
-        printf("Expected instruction kind %d but got %d\n", QkOperationKind_Unitary, kind);
+        fprintf(stderr, "Expected instruction kind %d but got %d\n", QkOperationKind_Unitary, kind);
         goto cleanup;
     }
     memset(out, 0, sizeof(QkComplex64) * 4);
     qk_circuit_inst_unitary(qc, num_inst - 1, out);
     if (memcmp(out, matrix, sizeof(QkComplex64) * 4) != 0) {
         result = EqualityError;
-        printf("Unitary matrix does not match expected\n");
+        fprintf(stderr, "Unitary matrix does not match expected\n");
         goto cleanup;
     }
 
@@ -911,7 +911,7 @@ static int test_unitary_gate_3q(void) {
     QkOperationKind kind = qk_circuit_instruction_kind(qc, num_inst - 1);
     if (kind != QkOperationKind_Unitary) {
         result = EqualityError;
-        printf("Expected instruction kind %d but got %d\n", QkOperationKind_Unitary, kind);
+        fprintf(stderr, "Expected instruction kind %d but got %d\n", QkOperationKind_Unitary, kind);
         goto cleanup;
     }
 
@@ -919,7 +919,7 @@ static int test_unitary_gate_3q(void) {
     qk_circuit_inst_unitary(qc, num_inst - 1, out);
     if (memcmp(out, matrix, sizeof(QkComplex64) * dim * dim) != 0) {
         result = EqualityError;
-        printf("Unitary matrix does not match expected\n");
+        fprintf(stderr, "Unitary matrix does not match expected\n");
         goto cleanup;
     }
 
@@ -963,14 +963,14 @@ static int test_not_unitary_gate(void) {
 
     int result = Ok;
     if (exit_code != QkExitCode_ExpectedUnitary) {
-        printf("Got exit code %i but expected %i\n", exit_code, QkExitCode_ExpectedUnitary);
+        fprintf(stderr, "Got exit code %i but expected %i\n", exit_code, QkExitCode_ExpectedUnitary);
         result = EqualityError;
         goto cleanup;
     }
 
     size_t num_inst = qk_circuit_num_instructions(qc);
     if (num_inst != 0) { // we expect no gate was added
-        printf("Found gate when none should be added\n");
+        fprintf(stderr, "Found gate when none should be added\n");
         result = EqualityError;
         goto cleanup;
     }
@@ -1025,7 +1025,7 @@ static int test_get_instruction_params(void) {
     QkCircuitInstruction inst;
     qk_circuit_get_instruction(qc, 0, &inst);
     if (inst.num_params != 0) {
-        printf("Expected 0 parameters in SX, got %u\n", inst.num_params);
+        fprintf(stderr, "Expected 0 parameters in SX, got %u\n", inst.num_params);
         result = EqualityError;
         goto cleanup_inst;
     }
@@ -1034,19 +1034,19 @@ static int test_get_instruction_params(void) {
     // RX has one parameter
     qk_circuit_get_instruction(qc, 1, &inst);
     if (inst.num_params != 1) {
-        printf("Expected 1 parameter in RX, got %u\n", inst.num_params);
+        fprintf(stderr, "Expected 1 parameter in RX, got %u\n", inst.num_params);
         result = EqualityError;
         goto cleanup_inst;
     }
 
     double rx_angle = qk_param_as_real(inst.params[0]);
     if (isnan(rx_angle)) {
-        printf("Unexpected free symbol in RX gate\n");
+        fprintf(stderr, "Unexpected free symbol in RX gate\n");
         result = EqualityError;
         goto cleanup_inst;
     }
     if (fabs(rx_angle - angle[0]) > 1e-10) {
-        printf("Unexpected parameter value in RX gate\n");
+        fprintf(stderr, "Unexpected parameter value in RX gate\n");
         result = EqualityError;
         goto cleanup_inst;
     }
@@ -1055,20 +1055,20 @@ static int test_get_instruction_params(void) {
     qk_circuit_instruction_clear(&inst);
     qk_circuit_get_instruction(qc, 2, &inst);
     if (inst.num_params != 2) {
-        printf("Expected 2 parameters in R, got %u\n", inst.num_params);
+        fprintf(stderr, "Expected 2 parameters in R, got %u\n", inst.num_params);
         result = EqualityError;
         goto cleanup_inst;
     }
 
     double r_fixed = qk_param_as_real(inst.params[1]);
     if (fabs(r_fixed - r_angle) > 1e-10) {
-        printf("Unexpected parameter value in R gate\n");
+        fprintf(stderr, "Unexpected parameter value in R gate\n");
         result = EqualityError;
         goto cleanup_inst;
     }
     const QkParam *r_free = inst.params[0];
     if (!qk_param_equal(r_free, theta)) {
-        printf("Unexpected free parameter in R gate\n");
+        fprintf(stderr, "Unexpected free parameter in R gate\n");
         result = EqualityError;
         goto cleanup_inst;
     }
@@ -1077,7 +1077,7 @@ static int test_get_instruction_params(void) {
     qk_circuit_instruction_clear(&inst);
     qk_circuit_get_instruction(qc, 3, &inst);
     if (inst.num_params != 0) {
-        printf("Expected 0 parameters in unitary gate, got %u\n", inst.num_params);
+        fprintf(stderr, "Expected 0 parameters in unitary gate, got %u\n", inst.num_params);
         result = EqualityError;
         goto cleanup_inst;
     }
@@ -1115,7 +1115,7 @@ static int test_instruction_params_ownership(void) {
     QkCircuitInstruction inst;
     qk_circuit_get_instruction(qc, 0, &inst);
     if (inst.num_params != 1) {
-        printf("Expected 1 parameter in RX, got %u\n", inst.num_params);
+        fprintf(stderr, "Expected 1 parameter in RX, got %u\n", inst.num_params);
         result = EqualityError;
 
         qk_circuit_instruction_clear(&inst);
@@ -1217,7 +1217,7 @@ static int test_parameterized_circuit(void) {
     size_t num_symbols = qk_circuit_num_param_symbols(qc);
     if (num_symbols != 2) {
         result = EqualityError;
-        printf("Expected 2 symbols, found %zu\n", num_symbols);
+        fprintf(stderr, "Expected 2 symbols, found %zu\n", num_symbols);
         goto cleanup;
     }
 
@@ -1225,7 +1225,7 @@ static int test_parameterized_circuit(void) {
     size_t num_gates = qk_circuit_num_instructions(qc);
     if (num_gates != 3) {
         result = EqualityError;
-        printf("Expected 3 instructions, found %zu\n", num_gates);
+        fprintf(stderr, "Expected 3 instructions, found %zu\n", num_gates);
         goto cleanup;
     }
 
@@ -1249,7 +1249,7 @@ static int test_circuit_to_dag(void) {
     int result = Ok;
     if (qk_dag_num_qubits(dag) != 2 || qk_dag_num_clbits(dag) != 1 ||
         qk_dag_num_op_nodes(dag) != 2) {
-        printf("Circuit to DAG conversion encountered an issue\n");
+        fprintf(stderr, "Circuit to DAG conversion encountered an issue\n");
         result = EqualityError;
     }
 
@@ -1284,20 +1284,20 @@ static int test_pbc_instructions(void) {
     size_t num_inst = qk_circuit_num_instructions(circuit);
     int result = Ok;
     if (num_inst != 2) {
-        printf("Expected 2 instructions but found %zu\n", num_inst);
+        fprintf(stderr, "Expected 2 instructions but found %zu\n", num_inst);
         result = EqualityError;
         goto cleanup;
     }
 
     QkOperationKind op_kind = qk_circuit_instruction_kind(circuit, 0);
     if (op_kind != QkOperationKind_PauliProductRotation) {
-        printf("Operation kind of instruction 0 is not QkOperationKind_PauliProductRotation.\n");
+        fprintf(stderr, "Operation kind of instruction 0 is not QkOperationKind_PauliProductRotation.\n");
         result = EqualityError;
         goto cleanup;
     }
     op_kind = qk_circuit_instruction_kind(circuit, 1);
     if (op_kind != QkOperationKind_PauliProductMeasurement) {
-        printf("Operation kind of instruction 1 is not QkOperationKind_PauliProductMeasurement.\n");
+        fprintf(stderr, "Operation kind of instruction 1 is not QkOperationKind_PauliProductMeasurement.\n");
         result = EqualityError;
         goto cleanup;
     }
@@ -1311,13 +1311,13 @@ static int test_pbc_instructions(void) {
     }
 
     if (out_rot.len != 4) {
-        printf("Pauli length is not 4, but %zu\n", out_rot.len);
+        fprintf(stderr, "Pauli length is not 4, but %zu\n", out_rot.len);
         result = EqualityError;
         goto cleanup_out_rot;
     }
     for (size_t i = 0; i < rotation.len; ++i) {
         if (out_rot.x[i] != x[i] || out_rot.z[i] != z[i]) {
-            printf("(z, x) term at %zu does not match. Expected (%d, %d), got (%d, %d)\n", i, z[i],
+            fprintf(stderr, "(z, x) term at %zu does not match. Expected (%d, %d), got (%d, %d)\n", i, z[i],
                    x[i], out_rot.z[i], out_rot.x[i]);
             result = EqualityError;
             goto cleanup_out_rot;
@@ -1326,7 +1326,7 @@ static int test_pbc_instructions(void) {
     if (!qk_param_equal(out_rot.angle, angle)) {
         char *out_str = qk_param_str(out_rot.angle);
         char *expected_str = qk_param_str(angle);
-        printf("Angle (%s) does not match the original angle (%s).\n", out_str, expected_str);
+        fprintf(stderr, "Angle (%s) does not match the original angle (%s).\n", out_str, expected_str);
         qk_str_free(out_str);
         qk_str_free(expected_str);
         result = EqualityError;
@@ -1344,20 +1344,20 @@ static int test_pbc_instructions(void) {
     }
 
     if (out_meas->len != 2) {
-        printf("Pauli length is not 2, but %zu\n", out_meas->len);
+        fprintf(stderr, "Pauli length is not 2, but %zu\n", out_meas->len);
         result = EqualityError;
         goto cleanup_out_meas;
     }
     for (size_t i = 0; i < measure.len; ++i) {
         if (out_meas->x[i] != xm[i] || out_meas->z[i] != zm[i]) {
-            printf("(z, x) term at %zu does not match. Expected (%d, %d), got (%d, %d)\n", i, zm[i],
+            fprintf(stderr, "(z, x) term at %zu does not match. Expected (%d, %d), got (%d, %d)\n", i, zm[i],
                    xm[i], out_meas->z[i], out_meas->x[i]);
             result = EqualityError;
             goto cleanup_out_meas;
         }
     }
     if (out_meas->flip_outcome != measure.flip_outcome) {
-        printf("Flip (%i) does not match the original flip (%i).\n", out_meas->flip_outcome,
+        fprintf(stderr, "Flip (%i) does not match the original flip (%i).\n", out_meas->flip_outcome,
                measure.flip_outcome);
         result = EqualityError;
     }

--- a/test/c/test_commutative_cancellation.c
+++ b/test/c/test_commutative_cancellation.c
@@ -45,13 +45,13 @@ static int test_commutative_cancellation_target(void) {
 
     result = qk_transpiler_pass_standalone_commutative_cancellation(qc, target, 1.0);
     if (result != 0) {
-        printf("Running the pass failed");
+        fprintf(stderr, "Running the pass failed");
         goto cleanup;
     }
 
     if (qk_circuit_num_instructions(qc) != 1) {
         result = EqualityError;
-        printf("The gates weren't removed by this circuit");
+        fprintf(stderr, "The gates weren't removed by this circuit");
     }
 cleanup:
     qk_circuit_free(qc);
@@ -79,13 +79,13 @@ static int test_commutative_cancellation_no_target(void) {
 
     result = qk_transpiler_pass_standalone_commutative_cancellation(qc, NULL, 1.0);
     if (result != 0) {
-        printf("Running the pass failed");
+        fprintf(stderr, "Running the pass failed");
         goto cleanup;
     }
 
     if (qk_circuit_num_instructions(qc) != 1) {
         result = EqualityError;
-        printf("The gates weren't removed by this circuit");
+        fprintf(stderr, "The gates weren't removed by this circuit");
     }
 cleanup:
     qk_circuit_free(qc);

--- a/test/c/test_consolidate_blocks.c
+++ b/test/c/test_consolidate_blocks.c
@@ -257,7 +257,7 @@ static int test_non_cx_target(void) {
     QkOpCounts counts = qk_circuit_count_ops(qc);
     if (counts.len != 1) {
         result = EqualityError;
-        printf("The pass run did not result in a circuit with one unitary gate. Expected 1 gate, "
+        fprintf(stderr, "The pass run did not result in a circuit with one unitary gate. Expected 1 gate, "
                "got %zu.",
                counts.len);
         goto cleanup;
@@ -267,7 +267,7 @@ static int test_non_cx_target(void) {
     qk_circuit_get_instruction(qc, 0, &unitary);
     if (strcmp(unitary.name, "unitary") != 0) {
         result = EqualityError;
-        printf("The pass run did not result in a circuit with one unitary gate. Expected 'unitary' "
+        fprintf(stderr, "The pass run did not result in a circuit with one unitary gate. Expected 'unitary' "
                "gate, got '%s'.",
                unitary.name);
         goto cleanup_inst;

--- a/test/c/test_dag.c
+++ b/test/c/test_dag.c
@@ -50,11 +50,11 @@ static int test_empty(void) {
     qk_dag_free(dag);
 
     if (num_qubits != 0) {
-        printf("The number of qubits %u is not 0\n", num_qubits);
+        fprintf(stderr, "The number of qubits %u is not 0\n", num_qubits);
         return EqualityError;
     }
     if (num_clbits != 0) {
-        printf("The number of clbits %u is not 0\n", num_clbits);
+        fprintf(stderr, "The number of clbits %u is not 0\n", num_clbits);
         return EqualityError;
     }
     return Ok;
@@ -69,11 +69,11 @@ static int test_dag_with_quantum_reg(void) {
     qk_dag_free(dag);
     qk_quantum_register_free(qr);
     if (num_qubits != 1024) {
-        printf("The number of qubits %u is not 1024\n", num_qubits);
+        fprintf(stderr, "The number of qubits %u is not 1024\n", num_qubits);
         return EqualityError;
     }
     if (num_clbits != 0) {
-        printf("The number of clbits %u is not 0\n", num_clbits);
+        fprintf(stderr, "The number of clbits %u is not 0\n", num_clbits);
         return EqualityError;
     }
     return Ok;
@@ -88,11 +88,11 @@ static int test_dag_with_classical_reg(void) {
     qk_dag_free(dag);
     qk_classical_register_free(cr);
     if (num_qubits != 0) {
-        printf("The number of qubits %u is not 0\n", num_qubits);
+        fprintf(stderr, "The number of qubits %u is not 0\n", num_qubits);
         return EqualityError;
     }
     if (num_clbits != 2048) {
-        printf("The number of clbits %u is not 2048\n", num_clbits);
+        fprintf(stderr, "The number of clbits %u is not 2048\n", num_clbits);
         return EqualityError;
     }
     return Ok;
@@ -117,7 +117,7 @@ static int test_dag_to_circuit(void) {
 
     if (qk_circuit_num_qubits(circuit) != 2 || qk_circuit_num_clbits(circuit) != 1 ||
         qk_circuit_num_instructions(circuit) != 2) {
-        printf("DAG to circuit conversion encountered an issue\n");
+        fprintf(stderr, "DAG to circuit conversion encountered an issue\n");
         result = EqualityError;
     }
 
@@ -133,7 +133,7 @@ static int test_dag_apply_gate(void) {
 
     size_t num_ops = qk_dag_num_op_nodes(dag);
     if (num_ops != 0) {
-        printf("The number of op nodes %zu is not 0\n", num_ops);
+        fprintf(stderr, "The number of op nodes %zu is not 0\n", num_ops);
         result = EqualityError;
         goto cleanup;
     }
@@ -143,7 +143,7 @@ static int test_dag_apply_gate(void) {
 
     num_ops = qk_dag_num_op_nodes(dag);
     if (num_ops != 1) {
-        printf("The number of op nodes %zu is not 1\n", num_ops);
+        fprintf(stderr, "The number of op nodes %zu is not 1\n", num_ops);
         result = EqualityError;
         goto cleanup;
     }
@@ -154,14 +154,14 @@ static int test_dag_apply_gate(void) {
 
     num_ops = qk_dag_num_op_nodes(dag);
     if (num_ops != 2) {
-        printf("The number of op nodes %zu is not 2\n", num_ops);
+        fprintf(stderr, "The number of op nodes %zu is not 2\n", num_ops);
         result = EqualityError;
         goto cleanup;
     }
 
     // Check the node's kind.
     if (qk_dag_op_node_kind(dag, crx_node_idx) != QkOperationKind_Gate) {
-        printf("Expected gate kind\n");
+        fprintf(stderr, "Expected gate kind\n");
         result = EqualityError;
         goto cleanup;
     }
@@ -169,7 +169,7 @@ static int test_dag_apply_gate(void) {
     // Check the gate has the right number of params.
     uint32_t num_params = qk_dag_op_node_num_params(dag, crx_node_idx);
     if (num_params != 1) {
-        printf("Expected num params 1 but got %u\n", num_params);
+        fprintf(stderr, "Expected num params 1 but got %u\n", num_params);
         result = EqualityError;
         goto cleanup;
     }
@@ -178,13 +178,13 @@ static int test_dag_apply_gate(void) {
     double actual_crx_params[1];
     QkGate actual_gate = qk_dag_op_node_gate_op(dag, crx_node_idx, actual_crx_params);
     if (actual_gate != QkGate_CRX) {
-        printf("Expected gate of type %u but got %u\n", QkGate_CRX, actual_gate);
+        fprintf(stderr, "Expected gate of type %u but got %u\n", QkGate_CRX, actual_gate);
         result = EqualityError;
         goto cleanup;
     }
 
     if (actual_crx_params[0] != crx_params[0]) {
-        printf("Expected param %f but got %f\n", crx_params[0], actual_crx_params[0]);
+        fprintf(stderr, "Expected param %f but got %f\n", crx_params[0], actual_crx_params[0]);
         result = EqualityError;
     }
 cleanup:
@@ -204,13 +204,13 @@ static int test_op_node_bits_explicit(void) {
 
     uint32_t num_qubits = qk_dag_op_node_num_qubits(dag, h_node_idx);
     if (num_qubits != 1) {
-        printf("The number of qubits %u is not 1\n", num_qubits);
+        fprintf(stderr, "The number of qubits %u is not 1\n", num_qubits);
         result = EqualityError;
         goto cleanup;
     }
 
     if (qk_dag_op_node_qubits(dag, h_node_idx)[0] != h_bits[0]) {
-        printf("Expected a single qubit of value %u but got %u\n", h_bits[0],
+        fprintf(stderr, "Expected a single qubit of value %u but got %u\n", h_bits[0],
                qk_dag_op_node_qubits(dag, h_node_idx)[0]);
         result = EqualityError;
         goto cleanup;
@@ -218,7 +218,7 @@ static int test_op_node_bits_explicit(void) {
 
     uint32_t num_clbits = qk_dag_op_node_num_clbits(dag, h_node_idx);
     if (num_clbits != 0) {
-        printf("The number of clbits %u is not 0\n", num_clbits);
+        fprintf(stderr, "The number of clbits %u is not 0\n", num_clbits);
         result = EqualityError;
         goto cleanup;
     }
@@ -228,7 +228,7 @@ static int test_op_node_bits_explicit(void) {
 
     num_qubits = qk_dag_op_node_num_qubits(dag, cx_node_idx);
     if (num_qubits != 2) {
-        printf("The number of qubits %u is not 2\n", num_qubits);
+        fprintf(stderr, "The number of qubits %u is not 2\n", num_qubits);
         result = EqualityError;
         goto cleanup;
     }
@@ -236,7 +236,7 @@ static int test_op_node_bits_explicit(void) {
     const uint32_t *actual_cx_bits = qk_dag_op_node_qubits(dag, cx_node_idx);
     for (uint32_t i = 0; i < num_qubits; i++) {
         if (actual_cx_bits[i] != cx_bits[i]) {
-            printf("Expected a qubit of value %u in position %u but got %u\n", cx_bits[0], i,
+            fprintf(stderr, "Expected a qubit of value %u in position %u but got %u\n", cx_bits[0], i,
                    qk_dag_op_node_qubits(dag, cx_node_idx)[0]);
             result = EqualityError;
             goto cleanup;
@@ -245,7 +245,7 @@ static int test_op_node_bits_explicit(void) {
 
     num_clbits = qk_dag_op_node_num_clbits(dag, cx_node_idx);
     if (num_clbits != 0) {
-        printf("The number of clbits %u is not 0\n", num_clbits);
+        fprintf(stderr, "The number of clbits %u is not 0\n", num_clbits);
         result = EqualityError;
     }
 cleanup:
@@ -276,35 +276,35 @@ static int test_dag_node_type(void) {
 
     QkDagNodeType node_type = qk_dag_node_type(dag, qubit_in_idx);
     if (node_type != QkDagNodeType_QubitIn) {
-        printf("Expected node type %d but got %d\n", QkDagNodeType_QubitIn, node_type);
+        fprintf(stderr, "Expected node type %d but got %d\n", QkDagNodeType_QubitIn, node_type);
         result = EqualityError;
         goto cleanup;
     }
 
     node_type = qk_dag_node_type(dag, qubit_out_idx);
     if (node_type != QkDagNodeType_QubitOut) {
-        printf("Expected node type %d but got %d\n", QkDagNodeType_QubitOut, node_type);
+        fprintf(stderr, "Expected node type %d but got %d\n", QkDagNodeType_QubitOut, node_type);
         result = EqualityError;
         goto cleanup;
     }
 
     node_type = qk_dag_node_type(dag, clbit_in_idx);
     if (node_type != QkDagNodeType_ClbitIn) {
-        printf("Expected node type %d but got %d\n", QkDagNodeType_ClbitIn, node_type);
+        fprintf(stderr, "Expected node type %d but got %d\n", QkDagNodeType_ClbitIn, node_type);
         result = EqualityError;
         goto cleanup;
     }
 
     node_type = qk_dag_node_type(dag, clbit_out_idx);
     if (node_type != QkDagNodeType_ClbitOut) {
-        printf("Expected node type %d but got %d\n", QkDagNodeType_ClbitOut, node_type);
+        fprintf(stderr, "Expected node type %d but got %d\n", QkDagNodeType_ClbitOut, node_type);
         result = EqualityError;
         goto cleanup;
     }
 
     node_type = qk_dag_node_type(dag, h_node_idx);
     if (node_type != QkDagNodeType_Operation) {
-        printf("Expected node type %d but got %d\n", QkDagNodeType_Operation, node_type);
+        fprintf(stderr, "Expected node type %d but got %d\n", QkDagNodeType_Operation, node_type);
         result = EqualityError;
     }
 
@@ -333,25 +333,25 @@ static int test_dag_endpoint_node_value(void) {
 
         uint32_t actual = qk_dag_wire_node_value(dag, qubit_in_idx);
         if (actual != i) {
-            printf("Expected wire endpoint qubit value to be %u but got %u\n", i, actual);
+            fprintf(stderr, "Expected wire endpoint qubit value to be %u but got %u\n", i, actual);
             result = EqualityError;
             goto cleanup;
         }
         actual = qk_dag_wire_node_value(dag, qubit_out_idx);
         if (actual != i) {
-            printf("Expected wire endpoint qubit value to be %u but got %u\n", i, actual);
+            fprintf(stderr, "Expected wire endpoint qubit value to be %u but got %u\n", i, actual);
             result = EqualityError;
             goto cleanup;
         }
         actual = qk_dag_wire_node_value(dag, clbit_in_idx);
         if (actual != i) {
-            printf("Expected wire endpoint clbit value to be %u but got %u\n", i, actual);
+            fprintf(stderr, "Expected wire endpoint clbit value to be %u but got %u\n", i, actual);
             result = EqualityError;
             goto cleanup;
         }
         actual = qk_dag_wire_node_value(dag, clbit_out_idx);
         if (actual != i) {
-            printf("Expected wire endpoint clbit value to be %u but got %u\n", i, actual);
+            fprintf(stderr, "Expected wire endpoint clbit value to be %u but got %u\n", i, actual);
             result = EqualityError;
             goto cleanup;
         }
@@ -443,7 +443,7 @@ static int test_dag_get_instruction(void) {
     for (size_t i = 0; i < sizeof(indices) / sizeof(*indices); i++) {
         qk_dag_get_instruction(dag, indices[i], &inst);
         if (!instructions_equal(&inst, &expected[i])) {
-            printf("%s: mismatched instruction: %s\n", __func__, desc[i]);
+            fprintf(stderr, "%s: mismatched instruction: %s\n", __func__, desc[i]);
             result = EqualityError;
             goto cleanup;
         }
@@ -467,7 +467,7 @@ static int test_dag_topological_op_nodes(void) {
 
     size_t num_ops = qk_dag_num_op_nodes(dag);
     if (num_ops != 3) {
-        printf("The number of op nodes %zu shouldn't be 0\n", num_ops);
+        fprintf(stderr, "The number of op nodes %zu shouldn't be 0\n", num_ops);
         result = EqualityError;
         goto early_cleanup;
     }
@@ -476,19 +476,19 @@ static int test_dag_topological_op_nodes(void) {
     qk_dag_topological_op_nodes(dag, out_order);
 
     if (out_order[0] != t_gate_idx) {
-        printf("Expected gate index %u but got %u\n", t_gate_idx, out_order[0]);
+        fprintf(stderr, "Expected gate index %u but got %u\n", t_gate_idx, out_order[0]);
         result = EqualityError;
         goto cleanup;
     }
 
     if (out_order[1] != h_gate_idx) {
-        printf("Expected gate index %u but got %u\n", h_gate_idx, out_order[1]);
+        fprintf(stderr, "Expected gate index %u but got %u\n", h_gate_idx, out_order[1]);
         result = EqualityError;
         goto cleanup;
     }
 
     if (out_order[2] != s_gate_idx) {
-        printf("Expected gate index %u but got %u\n", s_gate_idx, out_order[2]);
+        fprintf(stderr, "Expected gate index %u but got %u\n", s_gate_idx, out_order[2]);
         result = EqualityError;
     }
 
@@ -560,7 +560,7 @@ static int check_unitary(const char *func, QkDag *dag, QkComplex64 scalar, const
         }
         default: {
             res = EqualityError;
-            printf("%s: bad pauli string '%s'\n", func, pauli);
+            fprintf(stderr, "%s: bad pauli string '%s'\n", func, pauli);
             goto cleanup;
         }
         }
@@ -576,13 +576,13 @@ static int check_unitary(const char *func, QkDag *dag, QkComplex64 scalar, const
     QkOperationKind kind = qk_dag_op_node_kind(dag, node);
     if (kind != QkOperationKind_Unitary) {
         res = EqualityError;
-        printf("%s: %s kind incorrect: %d\n", func, pauli, kind);
+        fprintf(stderr, "%s: %s kind incorrect: %d\n", func, pauli, kind);
         goto cleanup;
     }
     qk_dag_op_node_unitary(dag, node, next);
     if (memcmp(cur, next, sizeof(*cur) * dim * dim)) {
         res = EqualityError;
-        printf("%s: %s matrices unequal\n", func, pauli);
+        fprintf(stderr, "%s: %s matrices unequal\n", func, pauli);
         goto cleanup;
     }
 cleanup:
@@ -647,7 +647,7 @@ static int test_substitute_node_with_dag(void) {
 
     if (qk_dag_num_op_nodes(dag) != 4) {
         res = EqualityError;
-        printf("Number of instructions is %zu but expected 4\n", qk_dag_num_op_nodes(dag));
+        fprintf(stderr, "Number of instructions is %zu but expected 4\n", qk_dag_num_op_nodes(dag));
         goto cleanup;
     }
 
@@ -681,7 +681,7 @@ static int test_dag_node_neighbors(void) {
     if (successors.num_neighbors != 1 || successors.neighbors[0] != node_ccx ||
         predecessors.num_neighbors != 1 ||
         qk_dag_node_type(dag, predecessors.neighbors[0]) != QkDagNodeType_QubitIn) {
-        printf("Incorrect neighbors information for the H node!\n");
+        fprintf(stderr, "Incorrect neighbors information for the H node!\n");
         result = EqualityError;
         goto cleanup;
     }
@@ -689,7 +689,7 @@ static int test_dag_node_neighbors(void) {
     qk_dag_neighbors_clear(&predecessors);
 
     if (successors.neighbors != NULL || successors.num_neighbors != 0) {
-        printf("qk_dag_neighbors_clear didn't work!\n");
+        fprintf(stderr, "qk_dag_neighbors_clear didn't work!\n");
         result = RuntimeError;
         goto cleanup;
     }
@@ -704,7 +704,7 @@ static int test_dag_node_neighbors(void) {
         qk_dag_node_type(dag, predecessors.neighbors[0]) != QkDagNodeType_QubitIn ||
         qk_dag_node_type(dag, predecessors.neighbors[1]) != QkDagNodeType_QubitIn ||
         predecessors.neighbors[2] != node_h) {
-        printf("Incorrect neighbors information for the CCX node!\n");
+        fprintf(stderr, "Incorrect neighbors information for the CCX node!\n");
         result = EqualityError;
         goto cleanup;
     }
@@ -719,7 +719,7 @@ static int test_dag_node_neighbors(void) {
         qk_dag_node_type(dag, successors.neighbors[1]) != QkDagNodeType_QubitOut ||
         predecessors.num_neighbors != 1 || // CCX is counted as a unique predecessor
         predecessors.neighbors[0] != node_ccx) {
-        printf("Incorrect neighbors information for the CX node!\n");
+        fprintf(stderr, "Incorrect neighbors information for the CX node!\n");
         result = EqualityError;
     }
 
@@ -746,13 +746,13 @@ static int test_dag_copy_empty_like(void) {
     size_t num_ops_in_copied_dag = qk_dag_num_op_nodes(copied_dag); // 0
 
     if (num_ops_in_dag == 0) {
-        printf("Expected the original DAG to remain unchanged, but it now empty\n");
+        fprintf(stderr, "Expected the original DAG to remain unchanged, but it now empty\n");
         result = EqualityError;
         goto cleanup;
     }
 
     if (num_ops_in_copied_dag != 0) {
-        printf("Expected no operations in the copied-empty-like DAG, but got %zu\n",
+        fprintf(stderr, "Expected no operations in the copied-empty-like DAG, but got %zu\n",
                num_ops_in_copied_dag);
         result = EqualityError;
     }
@@ -828,7 +828,7 @@ static int test_dag_compose(void) {
     QkExitCode res = qk_dag_compose(dag_left, dag_right, NULL, NULL);
     if (res != QkExitCode_Success) {
         result = EqualityError;
-        printf("Error during compose. The composible dag possibly exceeded the allowed number of "
+        fprintf(stderr, "Error during compose. The composible dag possibly exceeded the allowed number of "
                "qubits.\n");
         goto cleanup;
     }
@@ -840,7 +840,7 @@ static int test_dag_compose(void) {
 
     if (left_op_nodes + right_op_nodes != new_op_nodes) {
         result = EqualityError;
-        printf("The operations did not get composed onto the left dag correctly. Expected %zu "
+        fprintf(stderr, "The operations did not get composed onto the left dag correctly. Expected %zu "
                "operations, got %zu.\n",
                left_op_nodes + right_op_nodes, new_op_nodes);
     }
@@ -860,7 +860,7 @@ static int test_dag_compose(void) {
 
     if (new_op_nodes != expected_op_nodes) {
         result = EqualityError;
-        printf("The operations did not get composed onto the left dag correctly. Expected %zu "
+        fprintf(stderr, "The operations did not get composed onto the left dag correctly. Expected %zu "
                "operations, got %zu.\n",
                left_op_nodes + right_op_nodes, new_op_nodes);
         goto expect_cleanup;
@@ -886,13 +886,13 @@ static int test_dag_compose(void) {
         // Check gate instances
         if (exp_gate != left_gate) {
             result = EqualityError;
-            printf("Incorrect operation found, expected %d, got %d.\n", exp_gate, left_gate);
+            fprintf(stderr, "Incorrect operation found, expected %d, got %d.\n", exp_gate, left_gate);
             goto loop_cleanup;
         }
 
         if (exp_num_param != left_num_param) {
             result = EqualityError;
-            printf(
+            fprintf(stderr, 
                 "Correct operation with mismatched number of parameters, expected %zu, got %zu.\n",
                 exp_num_param, left_num_param);
             goto loop_cleanup;
@@ -901,7 +901,7 @@ static int test_dag_compose(void) {
         for (int param_idx = 0; param_idx < (int)left_num_param; param_idx++) {
             if (exp_param[param_idx] != left_param[param_idx]) {
                 result = EqualityError;
-                printf("Correct operation with mismatched parameter, expected %f, got %f.\n",
+                fprintf(stderr, "Correct operation with mismatched parameter, expected %f, got %f.\n",
                        exp_param[param_idx], left_param[param_idx]);
                 goto loop_cleanup;
             }
@@ -911,7 +911,7 @@ static int test_dag_compose(void) {
         size_t left_num_qubits = qk_dag_op_node_num_qubits(dag_left, node_idx_left);
         if (exp_num_qubits != left_num_qubits) {
             result = EqualityError;
-            printf("Correct operation with mismatched number of qubits, expected %zu, got %zu.\n",
+            fprintf(stderr, "Correct operation with mismatched number of qubits, expected %zu, got %zu.\n",
                    exp_num_qubits, left_num_qubits);
             goto loop_cleanup;
         }
@@ -920,7 +920,7 @@ static int test_dag_compose(void) {
         const uint32_t *left_qubits = qk_dag_op_node_qubits(dag_left, node_idx_left);
         if (memcmp(expected_qubits, left_qubits, exp_num_qubits * sizeof(*expected_qubits))) {
             result = EqualityError;
-            printf("Correct operation with mismatched qubits\n");
+            fprintf(stderr, "Correct operation with mismatched qubits\n");
             goto loop_cleanup;
         }
 
@@ -1011,7 +1011,7 @@ static int test_dag_compose_permuted(void) {
     QkExitCode res = qk_dag_compose(dag_left, dag_right, qubits, clbits);
     if (res != QkExitCode_Success) {
         result = EqualityError;
-        printf("Error during compose. The composible dag possibly exceeded the allowed number of "
+        fprintf(stderr, "Error during compose. The composible dag possibly exceeded the allowed number of "
                "qubits..\n");
         goto cleanup;
     }
@@ -1023,7 +1023,7 @@ static int test_dag_compose_permuted(void) {
 
     if (left_op_nodes + right_op_nodes != new_op_nodes) {
         result = EqualityError;
-        printf("The operations did not get composed onto the left dag correctly. Expected %zu "
+        fprintf(stderr, "The operations did not get composed onto the left dag correctly. Expected %zu "
                "operations, got %zu.\n",
                left_op_nodes + right_op_nodes, new_op_nodes);
     }
@@ -1045,7 +1045,7 @@ static int test_dag_compose_permuted(void) {
 
     if (new_op_nodes != expected_op_nodes) {
         result = EqualityError;
-        printf("The operations did not get composed onto the left dag correctly. Expected %zu "
+        fprintf(stderr, "The operations did not get composed onto the left dag correctly. Expected %zu "
                "operations, got %zu.\n",
                left_op_nodes + right_op_nodes, new_op_nodes);
         goto expect_cleanup;
@@ -1066,7 +1066,7 @@ static int test_dag_compose_permuted(void) {
 
         if (exp_kind != exp_left) {
             result = EqualityError;
-            printf("Incorrect operation type found. Expected: %d got %d.\n", exp_kind, exp_left);
+            fprintf(stderr, "Incorrect operation type found. Expected: %d got %d.\n", exp_kind, exp_left);
             goto loop_cleanup;
         }
         if (exp_kind == QkOperationKind_Gate) {
@@ -1080,13 +1080,13 @@ static int test_dag_compose_permuted(void) {
             // Check gate instances
             if (exp_gate != left_gate) {
                 result = EqualityError;
-                printf("Incorrect operation found, expected %d, got %d.\n", exp_gate, left_gate);
+                fprintf(stderr, "Incorrect operation found, expected %d, got %d.\n", exp_gate, left_gate);
                 goto loop_cleanup;
             }
 
             if (exp_num_param != left_num_param) {
                 result = EqualityError;
-                printf("Correct operation with mismatched number of parameters, expected %zu, got "
+                fprintf(stderr, "Correct operation with mismatched number of parameters, expected %zu, got "
                        "%zu.\n",
                        exp_num_param, left_num_param);
                 goto loop_cleanup;
@@ -1095,7 +1095,7 @@ static int test_dag_compose_permuted(void) {
             for (int param_idx = 0; param_idx < (int)left_num_param; param_idx++) {
                 if (exp_param[param_idx] != left_param[param_idx]) {
                     result = EqualityError;
-                    printf("Correct operation with mismatched parameter, expected %f, got %f.\n",
+                    fprintf(stderr, "Correct operation with mismatched parameter, expected %f, got %f.\n",
                            exp_param[param_idx], left_param[param_idx]);
                     goto loop_cleanup;
                 }
@@ -1106,7 +1106,7 @@ static int test_dag_compose_permuted(void) {
         size_t left_num_qubits = qk_dag_op_node_num_qubits(dag_left, node_idx_left);
         if (exp_num_qubits != left_num_qubits) {
             result = EqualityError;
-            printf("Correct operation with mismatched number of qubits, expected %zu, got %zu.\n",
+            fprintf(stderr, "Correct operation with mismatched number of qubits, expected %zu, got %zu.\n",
                    exp_num_qubits, left_num_qubits);
             goto loop_cleanup;
         }
@@ -1115,7 +1115,7 @@ static int test_dag_compose_permuted(void) {
         const uint32_t *left_qubits = qk_dag_op_node_qubits(dag_left, node_idx_left);
         if (memcmp(expected_qubits, left_qubits, exp_num_qubits * sizeof(*expected_qubits))) {
             result = EqualityError;
-            printf("Correct operation with mismatched qubits.\n");
+            fprintf(stderr, "Correct operation with mismatched qubits.\n");
             goto loop_cleanup;
         }
 
@@ -1123,7 +1123,7 @@ static int test_dag_compose_permuted(void) {
         size_t left_num_clbits = qk_dag_op_node_num_clbits(dag_left, node_idx_left);
         if (exp_num_clbits != left_num_clbits) {
             result = EqualityError;
-            printf("Correct operation with mismatched number of clbits, expected %zu, got %zu.\n",
+            fprintf(stderr, "Correct operation with mismatched number of clbits, expected %zu, got %zu.\n",
                    exp_num_clbits, left_num_clbits);
             goto loop_cleanup;
         }
@@ -1132,7 +1132,7 @@ static int test_dag_compose_permuted(void) {
         const uint32_t *left_clbits = qk_dag_op_node_clbits(dag_left, node_idx_left);
         if (memcmp(expected_clbits, left_clbits, exp_num_clbits * sizeof(*expected_clbits))) {
             result = EqualityError;
-            printf("Correct operation with mismatched clbits.\n");
+            fprintf(stderr, "Correct operation with mismatched clbits.\n");
             goto loop_cleanup;
         }
 
@@ -1177,7 +1177,7 @@ static int test_dag_replace_block_with_unitary(void) {
     size_t num_ops = qk_dag_num_op_nodes(dag);
     if (num_ops != 3) {
         result = EqualityError;
-        printf("Number of instructions is %zu but expected 3\n", num_ops);
+        fprintf(stderr, "Number of instructions is %zu but expected 3\n", num_ops);
         goto cleanup;
     }
 
@@ -1185,7 +1185,7 @@ static int test_dag_replace_block_with_unitary(void) {
     QkOperationKind new_node_kind = qk_dag_op_node_kind(dag, new_node_idx);
     if (new_node_kind != QkOperationKind_Unitary) {
         result = EqualityError;
-        printf(
+        fprintf(stderr, 
             "The new node with index %u has incorrect operation type: expected: %d but got %d.\n",
             new_node_idx, QkOperationKind_Unitary, new_node_kind);
     }
@@ -1219,7 +1219,7 @@ static int test_dag_replace_qubitless_block_with_unitary(void) {
     size_t num_ops = qk_dag_num_op_nodes(dag);
     if (num_ops != 3) {
         result = EqualityError;
-        printf("Number of instructions is %zu but expected 3\n", num_ops);
+        fprintf(stderr, "Number of instructions is %zu but expected 3\n", num_ops);
         goto cleanup;
     }
 
@@ -1227,7 +1227,7 @@ static int test_dag_replace_qubitless_block_with_unitary(void) {
     QkOperationKind new_node_kind = qk_dag_op_node_kind(dag, new_node_idx);
     if (new_node_kind != QkOperationKind_Unitary) {
         result = EqualityError;
-        printf(
+        fprintf(stderr, 
             "The new node with index %u has incorrect operation type: expected: %d but got %d.\n",
             new_node_idx, QkOperationKind_Unitary, new_node_kind);
     }
@@ -1261,7 +1261,7 @@ static int test_dag_replace_illegal_block_with_unitary(void) {
     // replacing the provided node block would introduce a cycle.
     if (new_node_idx != UINT32_MAX) {
         result = EqualityError;
-        printf("The new node has index %u but expected %u\n", new_node_idx, UINT32_MAX);
+        fprintf(stderr, "The new node has index %u but expected %u\n", new_node_idx, UINT32_MAX);
         goto cleanup;
     }
 
@@ -1269,7 +1269,7 @@ static int test_dag_replace_illegal_block_with_unitary(void) {
     size_t num_ops = qk_dag_num_op_nodes(dag);
     if (num_ops != 3) {
         result = EqualityError;
-        printf("Number of instructions is %zu but expected 3\n", num_ops);
+        fprintf(stderr, "Number of instructions is %zu but expected 3\n", num_ops);
         goto cleanup;
     }
 
@@ -1302,7 +1302,7 @@ static int test_dag_substitute_node_with_unitary(void) {
     size_t num_ops_z = qk_dag_num_op_nodes(dag);
     if (num_ops_z != 4) {
         result = EqualityError;
-        printf("Number of instructions is %zu but expected 4\n", num_ops_z);
+        fprintf(stderr, "Number of instructions is %zu but expected 4\n", num_ops_z);
         goto cleanup;
     }
 
@@ -1310,7 +1310,7 @@ static int test_dag_substitute_node_with_unitary(void) {
     QkOperationKind new_node_kind_z = qk_dag_op_node_kind(dag, idx_z);
     if (new_node_kind_z != QkOperationKind_Unitary) {
         result = EqualityError;
-        printf("The node with index %u has incorrect operation type: expected: %d but got %d.\n",
+        fprintf(stderr, "The node with index %u has incorrect operation type: expected: %d but got %d.\n",
                idx_z, QkOperationKind_Unitary, new_node_kind_z);
     }
 

--- a/test/c/test_elide_permutations.c
+++ b/test/c/test_elide_permutations.c
@@ -35,7 +35,7 @@ static int test_standalone_elide_permutations_no_result(void) {
     int result = Ok;
     QkTranspileLayout *pass_result = qk_transpiler_pass_standalone_elide_permutations(qc);
     if (pass_result != NULL) {
-        printf("A gate was elided when one shouldn't have been\n");
+        fprintf(stderr, "A gate was elided when one shouldn't have been\n");
         qk_transpile_layout_free(pass_result);
         result = EqualityError;
     }
@@ -61,7 +61,7 @@ static int test_standalone_elide_permutations_swap_result(void) {
     int result = Ok;
     QkTranspileLayout *pass_result = qk_transpiler_pass_standalone_elide_permutations(qc);
     if (pass_result == NULL) {
-        printf("A gate wasn't elided when one should have been\n");
+        fprintf(stderr, "A gate wasn't elided when one should have been\n");
         result = EqualityError;
         goto cleanup;
     }
@@ -70,21 +70,21 @@ static int test_standalone_elide_permutations_swap_result(void) {
     uint32_t expected_permutation[5] = {0, 3, 2, 1, 4};
     for (int i = 0; i < 5; i++) {
         if (permutation[i] != expected_permutation[i]) {
-            printf("Permutation doesn't match expected\n");
+            fprintf(stderr, "Permutation doesn't match expected\n");
             result = EqualityError;
             goto result_cleanup;
         }
     }
     QkOpCounts op_counts = qk_circuit_count_ops(qc);
     if (op_counts.len != 1) {
-        printf("More than 1 type of gates in circuit\n");
+        fprintf(stderr, "More than 1 type of gates in circuit\n");
         result = EqualityError;
         goto ops_cleanup;
     }
     for (size_t i = 0; i < op_counts.len; i++) {
         int swap_gate = strcmp(op_counts.data[i].name, "swap");
         if (swap_gate == 0) {
-            printf("Swap gate in circuit which should have been elided\n");
+            fprintf(stderr, "Swap gate in circuit which should have been elided\n");
             result = EqualityError;
             goto ops_cleanup;
         }
@@ -118,7 +118,7 @@ static int test_elide_permutations_no_result(void) {
     int result = Ok;
     QkTranspileLayout *pass_result = qk_transpiler_pass_elide_permutations(dag);
     if (pass_result != NULL) {
-        printf("A gate was elided when one shouldn't have been\n");
+        fprintf(stderr, "A gate was elided when one shouldn't have been\n");
         qk_transpile_layout_free(pass_result);
         result = EqualityError;
     }
@@ -147,7 +147,7 @@ static int test_elide_permutations_swap_result(void) {
     int result = Ok;
     QkTranspileLayout *pass_result = qk_transpiler_pass_elide_permutations(dag);
     if (pass_result == NULL) {
-        printf("A gate wasn't elided when one should have been\n");
+        fprintf(stderr, "A gate wasn't elided when one should have been\n");
         result = EqualityError;
         goto cleanup;
     }
@@ -156,7 +156,7 @@ static int test_elide_permutations_swap_result(void) {
     uint32_t expected_permutation[5] = {0, 3, 2, 1, 4};
     for (int i = 0; i < 5; i++) {
         if (permutation[i] != expected_permutation[i]) {
-            printf("Permutation doesn't match expected\n");
+            fprintf(stderr, "Permutation doesn't match expected\n");
             result = EqualityError;
             goto result_cleanup;
         }
@@ -168,11 +168,11 @@ static int test_elide_permutations_swap_result(void) {
     for (size_t i = 1; i < num_ops; i++) {
         QkGate gate = qk_dag_op_node_gate_op(dag, ops[i], NULL);
         if (gate != first_gate) {
-            printf("More than 1 type of gates in DAG\n");
+            fprintf(stderr, "More than 1 type of gates in DAG\n");
             result = EqualityError;
             goto ops_cleanup;
         } else if (gate == QkGate_Swap) {
-            printf("Swap gate in DAG which should have been elided\n");
+            fprintf(stderr, "Swap gate in DAG which should have been elided\n");
             result = EqualityError;
             goto ops_cleanup;
         }

--- a/test/c/test_gate_direction.c
+++ b/test/c/test_gate_direction.c
@@ -28,7 +28,7 @@ static QkTarget *create_target() {
         qk_target_add_instruction(target, cx_entry) != Ok ||
         qk_target_entry_add_property(rzx_entry, qargs, 2, 0.0, 0.0) != Ok ||
         qk_target_add_instruction(target, rzx_entry) != Ok) {
-        printf("Unexpected error encountered in create_target.");
+        fprintf(stderr, "Unexpected error encountered in create_target.");
         qk_target_free(target);
         return NULL;
     }
@@ -50,7 +50,7 @@ static int test_standalone_check_gate_direction(void) {
 
     if ((result = qk_circuit_gate(circuit, QkGate_CX, qargs, NULL)) != Ok ||
         (result = qk_circuit_gate(circuit, QkGate_CX, &qargs[1], NULL)) != Ok) {
-        printf("Unexpected error encountered while adding CX gates in test_check_gate_direction.");
+        fprintf(stderr, "Unexpected error encountered while adding CX gates in test_check_gate_direction.");
         goto cleanup;
     }
 
@@ -59,7 +59,7 @@ static int test_standalone_check_gate_direction(void) {
         result = EqualityError;
     else {
         if ((result = qk_circuit_gate(circuit, QkGate_CX, &qargs[2], NULL)) != Ok) {
-            printf("Unexpected error encountered while adding a CX gate in "
+            fprintf(stderr, "Unexpected error encountered while adding a CX gate in "
                    "test_check_gate_direction.");
             goto cleanup;
         }
@@ -94,7 +94,7 @@ static int test_standalone_gate_direction_simple(void) {
             Ok || // would be replaced by 5 gates
         (result = qk_circuit_gate(circuit, QkGate_RZX, &qargs[3], params)) !=
             Ok) { // would be replaced by 5 gates
-        printf("Unexpected error encountered while adding gates in test_gate_direction.");
+        fprintf(stderr, "Unexpected error encountered while adding gates in test_gate_direction.");
         goto cleanup;
     }
 

--- a/test/c/test_iqp.c
+++ b/test/c/test_iqp.c
@@ -49,13 +49,13 @@ static int test_iqp_from_interactions(void) {
 
     QkCircuit *iqp = qk_circuit_library_iqp(num_qubits, interactions, true);
     if (iqp == NULL) {
-        printf("iqp_from_interactions returned NULL\n");
+        fprintf(stderr, "iqp_from_interactions returned NULL\n");
         return EqualityError;
     }
 
     size_t num_instructions = qk_circuit_num_instructions(iqp);
     if (num_instructions != 5) {
-        printf("Unexpected number of instructions: %zu (expected 5)\n", num_instructions);
+        fprintf(stderr, "Unexpected number of instructions: %zu (expected 5)\n", num_instructions);
         result = EqualityError;
         goto cleanup;
     }
@@ -67,7 +67,7 @@ static int test_iqp_from_interactions(void) {
 
         // All gates in this IQP construction should be 1 or 2 qubits.
         if (inst.num_qubits != 1 && inst.num_qubits != 2) {
-            printf("Unexpected num_qubits = %u at instruction %zu\n", inst.num_qubits, i);
+            fprintf(stderr, "Unexpected num_qubits = %u at instruction %zu\n", inst.num_qubits, i);
             result = EqualityError;
             qk_circuit_instruction_clear(&inst);
             goto cleanup;
@@ -82,7 +82,7 @@ static int test_iqp_from_interactions(void) {
 
     // With the chosen interactions matrix, we expect exactly one 2-qubit gate.
     if (num_two_qubit != 1) {
-        printf("Unexpected number of 2-qubit gates: %zu (expected 1)\n", num_two_qubit);
+        fprintf(stderr, "Unexpected number of 2-qubit gates: %zu (expected 1)\n", num_two_qubit);
         result = EqualityError;
     }
 
@@ -110,7 +110,7 @@ static int test_iqp_non_symmetric(void) {
 
     QkCircuit *iqp = qk_circuit_library_iqp(num_qubits, interactions, true);
     if (iqp != NULL) {
-        printf("Expected NULL circuit for non-symmetric matrix, got non-NULL\n");
+        fprintf(stderr, "Expected NULL circuit for non-symmetric matrix, got non-NULL\n");
         qk_circuit_free(iqp);
         result = EqualityError;
     }
@@ -127,13 +127,13 @@ static int test_random_iqp(void) {
     // Fixed seed for deterministic behavior
     QkCircuit *iqp = qk_circuit_library_random_iqp(num_qubits, 1234);
     if (iqp == NULL) {
-        printf("random_iqp returned NULL\n");
+        fprintf(stderr, "random_iqp returned NULL\n");
         return EqualityError;
     }
 
     size_t num_instructions = qk_circuit_num_instructions(iqp);
     if (num_instructions == 0) {
-        printf("Random IQP circuit has zero instructions\n");
+        fprintf(stderr, "Random IQP circuit has zero instructions\n");
         result = EqualityError;
         goto cleanup;
     }
@@ -143,7 +143,7 @@ static int test_random_iqp(void) {
     for (size_t i = 0; i < num_instructions; i++) {
         qk_circuit_get_instruction(iqp, i, &inst);
         if (inst.num_qubits != 1 && inst.num_qubits != 2) {
-            printf("Random IQP has instruction with num_qubits = %u at index %zu\n",
+            fprintf(stderr, "Random IQP has instruction with num_qubits = %u at index %zu\n",
                    inst.num_qubits, i);
             result = EqualityError;
             qk_circuit_instruction_clear(&inst);

--- a/test/c/test_neighbors.c
+++ b/test/c/test_neighbors.c
@@ -29,30 +29,30 @@ static int test_all_to_all(void) {
     }
     QkNeighbors neighbors;
     if (!qk_neighbors_from_target(target, &neighbors)) {
-        printf("%s: incorrect return from `qk_neighbors_from_target`\n", __func__);
+        fprintf(stderr, "%s: incorrect return from `qk_neighbors_from_target`\n", __func__);
         res = EqualityError;
         goto cleanup;
     }
     if (!qk_neighbors_is_all_to_all(&neighbors)) {
-        printf("%s: incorrect return from `qk_neighbors_is_all_to_all`\n", __func__);
+        fprintf(stderr, "%s: incorrect return from `qk_neighbors_is_all_to_all`\n", __func__);
         res = EqualityError;
         goto cleanup;
     }
     if (neighbors.neighbors || neighbors.partition) {
-        printf("%s: pointers should be null but are (%p, %p)\n", __func__,
+        fprintf(stderr, "%s: pointers should be null but are (%p, %p)\n", __func__,
                (void *)neighbors.neighbors, (void *)neighbors.partition);
         res = EqualityError;
         goto cleanup;
     }
     if (neighbors.num_qubits != num_qubits) {
-        printf("%s: incorrect num_qubits: %u\n", __func__, neighbors.num_qubits);
+        fprintf(stderr, "%s: incorrect num_qubits: %u\n", __func__, neighbors.num_qubits);
         res = EqualityError;
         goto cleanup;
     }
     // This isn't necessary to call since there's no allocations, but let's call it for coverage.
     qk_neighbors_clear(&neighbors);
     if (neighbors.neighbors || neighbors.partition) {
-        printf("%s: `qk_neighbors_free` wrote non-null pointers (%p, %p)\n", __func__,
+        fprintf(stderr, "%s: `qk_neighbors_free` wrote non-null pointers (%p, %p)\n", __func__,
                (void *)neighbors.neighbors, (void *)neighbors.partition);
         res = EqualityError;
         goto cleanup;
@@ -81,23 +81,23 @@ static int test_multiq(void) {
 
     QkNeighbors neighbors;
     if (qk_neighbors_from_target(target, &neighbors)) {
-        printf("%s: incorrect return from `qk_neighbors_from_target`\n", __func__);
+        fprintf(stderr, "%s: incorrect return from `qk_neighbors_from_target`\n", __func__);
         res = EqualityError;
         goto cleanup_target;
     }
     if (!neighbors.neighbors || !neighbors.partition) {
-        printf("%s: pointers should be non-null but are (%p, %p)\n", __func__,
+        fprintf(stderr, "%s: pointers should be non-null but are (%p, %p)\n", __func__,
                (void *)neighbors.neighbors, (void *)neighbors.partition);
         res = NullptrError;
         goto cleanup_target;
     }
     if (qk_neighbors_is_all_to_all(&neighbors)) {
-        printf("%s: incorrect return from `qk_neighbors_is_all_to_all`\n", __func__);
+        fprintf(stderr, "%s: incorrect return from `qk_neighbors_is_all_to_all`\n", __func__);
         res = EqualityError;
         goto cleanup_neighbors;
     }
     if (neighbors.num_qubits != num_qubits) {
-        printf("%s: incorrect num_qubits: %u\n", __func__, neighbors.num_qubits);
+        fprintf(stderr, "%s: incorrect num_qubits: %u\n", __func__, neighbors.num_qubits);
         res = EqualityError;
         goto cleanup_neighbors;
     }
@@ -105,14 +105,14 @@ static int test_multiq(void) {
     size_t expected_partition[] = {0, 1, 3, 5, 7, 8};
     if (memcmp(expected_partition, neighbors.partition, sizeof(expected_partition)) ||
         memcmp(expected_neighbors, neighbors.neighbors, sizeof(expected_neighbors))) {
-        printf("%s: incorrect data in neighbors\n", __func__);
+        fprintf(stderr, "%s: incorrect data in neighbors\n", __func__);
         res = EqualityError;
         goto cleanup_neighbors;
     }
 cleanup_neighbors:
     qk_neighbors_clear(&neighbors);
     if (neighbors.neighbors || neighbors.partition) {
-        printf("%s: `qk_neighbors_free` wrote non-null pointers (%p, %p)\n", __func__,
+        fprintf(stderr, "%s: `qk_neighbors_free` wrote non-null pointers (%p, %p)\n", __func__,
                (void *)neighbors.neighbors, (void *)neighbors.partition);
         res = EqualityError;
         goto cleanup_target;

--- a/test/c/test_optimize_1q_sequences.c
+++ b/test/c/test_optimize_1q_sequences.c
@@ -184,10 +184,10 @@ static int run_optimize_h_gates(optimize_h_gates_fn optimize_fn) {
 
     size_t num_gates[5] = {1, 2, 2, 1, 1};
     char *names[5] = {"u1_u2_u3", "rz_rx", "rz_sx", "rz_ry_u", "rz_ry_u_noerror"};
-    printf("Optimize h gates tests.\n");
+    fprintf(stderr, "Optimize h gates tests.\n");
     for (int idx = 0; idx < 5; idx++) {
         int result = optimize_fn(targets[idx], gates[idx], freq[idx], num_gates[idx]);
-        printf("--- Run with %-21s: %s \n", names[idx], (bool)result ? "Fail" : "Ok");
+        fprintf(stderr, "--- Run with %-21s: %s \n", names[idx], (bool)result ? "Fail" : "Ok");
         num_failed += result;
     }
     return num_failed;
@@ -232,10 +232,10 @@ static int run_optimize_identity_target(optimize_identity_target_fn optimize_fn)
         "rz_sx",
         "rz_ry_u",
     };
-    printf("Optimize identities with target tests.\n");
+    fprintf(stderr, "Optimize identities with target tests.\n");
     for (int idx = 0; idx < 4; idx++) {
         int result = optimize_fn(targets[idx]);
-        printf("--- Run with %-21s: %s \n", names[idx], (bool)result ? "Fail" : "Ok");
+        fprintf(stderr, "--- Run with %-21s: %s \n", names[idx], (bool)result ? "Fail" : "Ok");
         num_failed += result;
     }
     return num_failed;

--- a/test/c/test_param.c
+++ b/test/c/test_param.c
@@ -28,7 +28,7 @@ static int test_param_new(void) {
     qk_param_free(p);
 
     if (strcmp(str, "a") != 0) {
-        printf("The parameter is not a\n");
+        fprintf(stderr, "The parameter is not a\n");
         qk_str_free(str);
         return EqualityError;
     }
@@ -74,18 +74,18 @@ static int test_param_to_real(void) {
     qk_param_free(val);
 
     if (!isnan(x_out) || isnan(cmplx_out) || isnan(val_out)) {
-        printf("Unexpected success/failure in qk_param_as_real.\n");
+        fprintf(stderr, "Unexpected success/failure in qk_param_as_real.\n");
         return EqualityError;
     }
 
     if (fabs(val_out - 10.0) > 1e-10) {
-        printf("Unexpected extracted value in qk_param_as_real.\n");
+        fprintf(stderr, "Unexpected extracted value in qk_param_as_real.\n");
         return EqualityError;
     }
 
     // qk_param_as_real extracts the real part of a complex value
     if (fabs(cmplx_out - 1.0) > 1e-10) {
-        printf("Unexpected extracted value in qk_param_as_real.\n");
+        fprintf(stderr, "Unexpected extracted value in qk_param_as_real.\n");
         return EqualityError;
     }
 
@@ -110,7 +110,7 @@ static int test_param_binary_ops(void) {
 
     str = qk_param_str(ret);
     if (strcmp(str, "a + b") != 0) {
-        printf("qk_param_add is not a + b\n");
+        fprintf(stderr, "qk_param_add is not a + b\n");
         result = EqualityError;
         goto cleanup_str;
     }
@@ -124,7 +124,7 @@ static int test_param_binary_ops(void) {
 
     str = qk_param_str(ret);
     if (strcmp(str, "a - b") != 0) {
-        printf("qk_param_sub is not a - b\n");
+        fprintf(stderr, "qk_param_sub is not a - b\n");
         result = EqualityError;
         goto cleanup_str;
     }
@@ -138,7 +138,7 @@ static int test_param_binary_ops(void) {
 
     str = qk_param_str(ret);
     if (strcmp(str, "a*b") != 0) {
-        printf("qk_param_mul is not a*b\n");
+        fprintf(stderr, "qk_param_mul is not a*b\n");
         result = EqualityError;
         goto cleanup_str;
     }
@@ -152,7 +152,7 @@ static int test_param_binary_ops(void) {
 
     str = qk_param_str(ret);
     if (strcmp(str, "a/b") != 0) {
-        printf("qk_param_div is not a/b\n");
+        fprintf(stderr, "qk_param_div is not a/b\n");
         result = EqualityError;
         goto cleanup_str;
     }
@@ -166,7 +166,7 @@ static int test_param_binary_ops(void) {
 
     str = qk_param_str(ret);
     if (strcmp(str, "a**b") != 0) {
-        printf("qk_param_pow is not a**b\n");
+        fprintf(stderr, "qk_param_pow is not a**b\n");
         result = EqualityError;
         goto cleanup_str;
     }
@@ -205,7 +205,7 @@ static int test_param_unary_ops(void) {
     }
     str = qk_param_str(ret);
     if (strcmp(str, "sin(a + b)") != 0) {
-        printf("qk_param_sin is not sin(a + b)\n");
+        fprintf(stderr, "qk_param_sin is not sin(a + b)\n");
         result = EqualityError;
         goto cleanup_str;
     }
@@ -218,7 +218,7 @@ static int test_param_unary_ops(void) {
     }
     str = qk_param_str(ret);
     if (strcmp(str, "cos(a + b)") != 0) {
-        printf("qk_param_cos is not cos(a + b)\n");
+        fprintf(stderr, "qk_param_cos is not cos(a + b)\n");
         result = EqualityError;
         goto cleanup_str;
     }
@@ -231,7 +231,7 @@ static int test_param_unary_ops(void) {
     }
     str = qk_param_str(ret);
     if (strcmp(str, "tan(a + b)") != 0) {
-        printf("qk_param_tan is not tan(a + b)\n");
+        fprintf(stderr, "qk_param_tan is not tan(a + b)\n");
         result = EqualityError;
         goto cleanup_str;
     }
@@ -244,7 +244,7 @@ static int test_param_unary_ops(void) {
     }
     str = qk_param_str(ret);
     if (strcmp(str, "asin(a + b)") != 0) {
-        printf("qk_param_asin is not asin(a + b)\n");
+        fprintf(stderr, "qk_param_asin is not asin(a + b)\n");
         result = EqualityError;
         goto cleanup_str;
     }
@@ -257,7 +257,7 @@ static int test_param_unary_ops(void) {
     }
     str = qk_param_str(ret);
     if (strcmp(str, "acos(a + b)") != 0) {
-        printf("qk_param_acos is not acos(a + b)\n");
+        fprintf(stderr, "qk_param_acos is not acos(a + b)\n");
         result = EqualityError;
         goto cleanup_str;
     }
@@ -270,7 +270,7 @@ static int test_param_unary_ops(void) {
     }
     str = qk_param_str(ret);
     if (strcmp(str, "atan(a + b)") != 0) {
-        printf("qk_param_atan is not atan(a + b)\n");
+        fprintf(stderr, "qk_param_atan is not atan(a + b)\n");
         result = EqualityError;
         goto cleanup_str;
     }
@@ -283,7 +283,7 @@ static int test_param_unary_ops(void) {
     }
     str = qk_param_str(ret);
     if (strcmp(str, "log(a + b)") != 0) {
-        printf("qk_param_log is not log(a + b)\n");
+        fprintf(stderr, "qk_param_log is not log(a + b)\n");
         result = EqualityError;
         goto cleanup_str;
     }
@@ -296,7 +296,7 @@ static int test_param_unary_ops(void) {
     }
     str = qk_param_str(ret);
     if (strcmp(str, "exp(a + b)") != 0) {
-        printf("qk_param_exp is not exp(a + b)\n");
+        fprintf(stderr, "qk_param_exp is not exp(a + b)\n");
         result = EqualityError;
         goto cleanup_str;
     }
@@ -309,7 +309,7 @@ static int test_param_unary_ops(void) {
     }
     str = qk_param_str(ret);
     if (strcmp(str, "abs(a + b)") != 0) {
-        printf("qk_param_abs is not abs(a + b)\n");
+        fprintf(stderr, "qk_param_abs is not abs(a + b)\n");
         result = EqualityError;
         goto cleanup_str;
     }
@@ -322,7 +322,7 @@ static int test_param_unary_ops(void) {
     }
     str = qk_param_str(ret);
     if (strcmp(str, "sign(a + b)") != 0) {
-        printf("qk_param_sign is not sign(a + b)\n");
+        fprintf(stderr, "qk_param_sign is not sign(a + b)\n");
         result = EqualityError;
         goto cleanup_str;
     }
@@ -335,7 +335,7 @@ static int test_param_unary_ops(void) {
     }
     str = qk_param_str(ret);
     if (strcmp(str, "-a - b") != 0) {
-        printf("qk_param_neg is not -a - b\n");
+        fprintf(stderr, "qk_param_neg is not -a - b\n");
         result = EqualityError;
         goto cleanup_str;
     }
@@ -348,7 +348,7 @@ static int test_param_unary_ops(void) {
     }
     str = qk_param_str(ret);
     if (strcmp(str, "conj(a) + conj(b)") != 0) {
-        printf("qk_param_conj is not conj(a) + conj(b)\n");
+        fprintf(stderr, "qk_param_conj is not conj(a) + conj(b)\n");
         result = EqualityError;
         goto cleanup_str;
     }
@@ -382,7 +382,7 @@ static int test_param_with_value(void) {
 
     str = qk_param_str(ret);
     if (strcmp(str, "2.5 + a") != 0) {
-        printf("qk_param_add is not 2.5 + a\n");
+        fprintf(stderr, "qk_param_add is not 2.5 + a\n");
         result = EqualityError;
     }
     qk_str_free(str);
@@ -429,31 +429,31 @@ static int test_param_equal(void) {
     }
 
     if (!qk_param_equal(x, x)) {
-        printf("Symbol not equal to itself\n");
+        fprintf(stderr, "Symbol not equal to itself\n");
         result = EqualityError;
         goto cleanup;
     }
 
     if (qk_param_equal(x, x_imposter)) {
-        printf("Symbol equal a new instance with the same name\n");
+        fprintf(stderr, "Symbol equal a new instance with the same name\n");
         result = EqualityError;
         goto cleanup;
     }
 
     if (qk_param_equal(x, mul)) {
-        printf("Symbol equals but they differ by a coefficient\n");
+        fprintf(stderr, "Symbol equals but they differ by a coefficient\n");
         result = EqualityError;
         goto cleanup;
     }
 
     if (!qk_param_equal(sum1, sum1_clone)) {
-        printf("Expression not equal to the same expression.\n");
+        fprintf(stderr, "Expression not equal to the same expression.\n");
         result = EqualityError;
         goto cleanup;
     }
 
     if (qk_param_equal(sum1, sum2)) {
-        printf("Expression equal to a different sum.\n");
+        fprintf(stderr, "Expression equal to a different sum.\n");
         result = EqualityError;
         goto cleanup;
     }
@@ -489,7 +489,7 @@ static int test_param_copy(void) {
 
     QkParam *copy = qk_param_copy(sum);
     if (!qk_param_equal(sum, copy)) {
-        printf("Copy not equal to original\n");
+        fprintf(stderr, "Copy not equal to original\n");
         result = EqualityError;
     }
     qk_param_free(copy);

--- a/test/c/test_pbc.c
+++ b/test/c/test_pbc.c
@@ -85,19 +85,19 @@ static int test_counts_convert_to_pauli_rotations(void) {
     for (size_t i = 0; i < op_counts.len; i++) {
         if (strcmp(op_counts.data[i].name, "pauli_product_rotation") == 0) {
             if (op_counts.data[i].count != expected_ppr) {
-                printf("Expected %zu PPR but found %zu\n", expected_ppr, op_counts.data[i].count);
+                fprintf(stderr, "Expected %zu PPR but found %zu\n", expected_ppr, op_counts.data[i].count);
                 result = EqualityError;
                 break;
             }
         } else if (strcmp(op_counts.data[i].name, "pauli_product_measurement") == 0) {
             if (op_counts.data[i].count != 2) {
-                printf("Expected %zu PPM but found %zu\n", expected_ppm, op_counts.data[i].count);
+                fprintf(stderr, "Expected %zu PPM but found %zu\n", expected_ppm, op_counts.data[i].count);
                 result = EqualityError;
                 break;
             }
         } else {
             // unexpected gate name!
-            printf("Unexpected gate: %s\n", op_counts.data[i].name);
+            fprintf(stderr, "Unexpected gate: %s\n", op_counts.data[i].name);
             result = EqualityError;
             break;
         }
@@ -139,7 +139,7 @@ int check_paulis(enum Pauli *expected_paulis, bool *x, bool *z, size_t len) {
             expected_z = true;
         }
         if (x[i] != expected_x || z[i] != expected_z) {
-            printf("Expected (%i, %i) but got (%i, %i)\n", expected_x, expected_z, x[i], z[i]);
+            fprintf(stderr, "Expected (%i, %i) but got (%i, %i)\n", expected_x, expected_z, x[i], z[i]);
             result = EqualityError;
             break;
         }
@@ -163,14 +163,14 @@ int check_pauli_rotation(QkCircuit *circuit, size_t index, enum Pauli *paulis, u
     // (1) check the angle matches
     double angle = qk_param_as_real(ppr.angle);
     if (fabs(angle - expected_angle) > 1e-12) {
-        printf("Expected angle %f but got %f\n", expected_angle, angle);
+        fprintf(stderr, "Expected angle %f but got %f\n", expected_angle, angle);
         result = EqualityError;
         goto cleanup;
     }
 
     // (2) check the Paulis match
     if (ppr.len != len) {
-        printf("Expected %zu Paulis but got %zu\n", len, ppr.len);
+        fprintf(stderr, "Expected %zu Paulis but got %zu\n", len, ppr.len);
         result = EqualityError;
         goto cleanup;
     }
@@ -214,7 +214,7 @@ int check_pauli_measurement(QkCircuit *circuit, size_t index, enum Pauli *paulis
 
     // (2) check the Paulis match
     if (ppm.len != len) {
-        printf("Expected %zu Paulis but got %zu\n", len, ppm.len);
+        fprintf(stderr, "Expected %zu Paulis but got %zu\n", len, ppm.len);
         result = EqualityError;
         goto cleanup;
     }
@@ -354,7 +354,7 @@ static int test_litinski_noop(void) {
 
     int result = Ok;
     if (qk_circuit_num_instructions(circuit) != 1) {
-        printf("Expected 1 instructions, but found %zu", qk_circuit_num_instructions(circuit));
+        fprintf(stderr, "Expected 1 instructions, but found %zu", qk_circuit_num_instructions(circuit));
         result = EqualityError;
         goto cleanup;
     }
@@ -362,7 +362,7 @@ static int test_litinski_noop(void) {
     QkCircuitInstruction inst;
     qk_circuit_get_instruction(circuit, 0, &inst);
     if (strcmp(inst.name, "h") != 0) {
-        printf("Instruction at index 0 should be 'h' but is '%s'", inst.name);
+        fprintf(stderr, "Instruction at index 0 should be 'h' but is '%s'", inst.name);
         result = EqualityError;
     }
     qk_circuit_instruction_clear(&inst);

--- a/test/c/test_quantum_volume.c
+++ b/test/c/test_quantum_volume.c
@@ -29,7 +29,7 @@ static int test_qv(void) {
     QkCircuit *qv = qk_circuit_library_quantum_volume(num_qubits, num_qubits, 42);
     size_t num_instructions = qk_circuit_num_instructions(qv);
     if (num_instructions != 10) {
-        printf("Unexpected number of instructions: %zu\n", num_instructions);
+        fprintf(stderr, "Unexpected number of instructions: %zu\n", num_instructions);
         result = EqualityError;
         goto cleanup;
     }

--- a/test/c/test_remove_diagonal_gates_before_measure.c
+++ b/test/c/test_remove_diagonal_gates_before_measure.c
@@ -29,7 +29,7 @@ int test_standalone_remove_z_gate(void) {
     qk_circuit_measure(qc, 0, 0);
 
     if (2 != qk_circuit_num_instructions(qc)) {
-        printf("Circuit build failure");
+        fprintf(stderr, "Circuit build failure");
         result = RuntimeError;
         goto cleanup;
     }
@@ -37,7 +37,7 @@ int test_standalone_remove_z_gate(void) {
     qk_transpiler_pass_standalone_remove_diagonal_gates_before_measure(qc);
 
     if (1 != qk_circuit_num_instructions(qc)) {
-        printf("Circuit should only have a single instruction");
+        fprintf(stderr, "Circuit should only have a single instruction");
         result = EqualityError;
         goto cleanup;
     }
@@ -46,7 +46,7 @@ int test_standalone_remove_z_gate(void) {
     qk_circuit_get_instruction(qc, 0, &inst);
 
     if (0 != strcmp("measure", inst.name)) {
-        printf("Circuit should contain a single 'measure' instruction. Instead, it has one: '%s'.",
+        fprintf(stderr, "Circuit should contain a single 'measure' instruction. Instead, it has one: '%s'.",
                inst.name);
         result = EqualityError;
         goto cleanup_inst;
@@ -73,7 +73,7 @@ int test_remove_z_gate(void) {
     qk_dag_apply_measure(dag, 0, 0, false);
 
     if (2 != qk_dag_num_op_nodes(dag)) {
-        printf("DAG build failure");
+        fprintf(stderr, "DAG build failure");
         result = RuntimeError;
         goto cleanup;
     }
@@ -82,7 +82,7 @@ int test_remove_z_gate(void) {
 
     size_t num_ops = qk_dag_num_op_nodes(dag);
     if (1 != num_ops) {
-        printf("DAG should only have a single instruction");
+        fprintf(stderr, "DAG should only have a single instruction");
         result = EqualityError;
         goto cleanup;
     }
@@ -94,7 +94,7 @@ int test_remove_z_gate(void) {
     qk_dag_get_instruction(dag, op_nodes[0], &inst);
 
     if (0 != strcmp("measure", inst.name)) {
-        printf("DAG should contain a single 'measure' instruction. Instead, it has one: '%s'.",
+        fprintf(stderr, "DAG should contain a single 'measure' instruction. Instead, it has one: '%s'.",
                inst.name);
         result = EqualityError;
     }

--- a/test/c/test_remove_identity_equiv.c
+++ b/test/c/test_remove_identity_equiv.c
@@ -41,7 +41,7 @@ static int test_standalone_remove_identity_equiv_removes_gates(void) {
     qk_transpiler_pass_standalone_remove_identity_equivalent(qc, target, 1.0);
     if (qk_circuit_num_instructions(qc) != 1) {
         result = EqualityError;
-        printf("The gates weren't removed by this circuit");
+        fprintf(stderr, "The gates weren't removed by this circuit");
     }
 
     qk_circuit_free(qc);
@@ -67,7 +67,7 @@ static int test_remove_identity_equiv_removes_gates(void) {
     qk_transpiler_pass_remove_identity_equivalent(dag, target, 1.0);
     if (qk_dag_num_op_nodes(dag) != 1) {
         result = EqualityError;
-        printf("The gates weren't removed by this circuit");
+        fprintf(stderr, "The gates weren't removed by this circuit");
     }
 
     qk_dag_free(dag);

--- a/test/c/test_sabre_layout.c
+++ b/test/c/test_sabre_layout.c
@@ -51,7 +51,7 @@ static int test_sabre_layout_applies_layout(void) {
 
     QkOpCounts op_counts = qk_circuit_count_ops(qc);
     if (op_counts.len != 2) {
-        printf("More than 2 types of gates in circuit, circuit's instructions are:\n");
+        fprintf(stderr, "More than 2 types of gates in circuit, circuit's instructions are:\n");
         print_circuit(qc);
         result = EqualityError;
         goto cleanup;
@@ -61,13 +61,13 @@ static int test_sabre_layout_applies_layout(void) {
         int swap_gate = strcmp(name, "swap");
         int cx_gate = strcmp(name, "cx");
         if (cx_gate != 0 && swap_gate != 0) {
-            printf("Gate type of %s found in the circuit which isn't expected\n", name);
+            fprintf(stderr, "Gate type of %s found in the circuit which isn't expected\n", name);
             result = EqualityError;
             goto cleanup;
         }
         size_t count = op_counts.data[i].count;
         if (swap_gate == 0 && count != 2) {
-            printf("Unexpected number of swaps %zu found in the circuit.\n", count);
+            fprintf(stderr, "Unexpected number of swaps %zu found in the circuit.\n", count);
             result = EqualityError;
             goto cleanup;
         }
@@ -77,7 +77,7 @@ static int test_sabre_layout_applies_layout(void) {
     qk_transpile_layout_initial_layout(layout_result, false, result_initial_layout);
     for (uint32_t i = 0; i < 5; i++) {
         if (result_initial_layout[i] != expected_initial_layout[i]) {
-            printf("Initial layout maps qubit %d to %d, expected %d instead\n", i,
+            fprintf(stderr, "Initial layout maps qubit %d to %d, expected %d instead\n", i,
                    result_initial_layout[i], expected_initial_layout[i]);
             result = EqualityError;
             goto cleanup;
@@ -89,7 +89,7 @@ static int test_sabre_layout_applies_layout(void) {
     qk_transpile_layout_output_permutation(layout_result, result_permutation);
     for (uint32_t i = 0; i < 5; i++) {
         if (result_permutation[i] != expected_permutation[i]) {
-            printf("Output permutation maps qubit %d to %d, expected %d instead\n", i,
+            fprintf(stderr, "Output permutation maps qubit %d to %d, expected %d instead\n", i,
                    result_permutation[i], expected_permutation[i]);
             result = EqualityError;
             goto cleanup;
@@ -175,7 +175,7 @@ static int test_sabre_layout_no_swap(void) {
     qk_transpile_layout_initial_layout(layout_result, false, result_initial_layout);
     for (uint32_t i = 0; i < 5; i++) {
         if (result_initial_layout[i] != expected_initial_layout[i]) {
-            printf("Initial layout maps qubit %d to %d, expected %d instead\n", i,
+            fprintf(stderr, "Initial layout maps qubit %d to %d, expected %d instead\n", i,
                    result_initial_layout[i], expected_initial_layout[i]);
             result = EqualityError;
             goto cleanup;
@@ -186,7 +186,7 @@ static int test_sabre_layout_no_swap(void) {
     qk_transpile_layout_output_permutation(layout_result, result_permutation);
     for (uint32_t i = 0; i < 5; i++) {
         if (result_permutation[i] != expected_permutation[i]) {
-            printf("Output permutation maps qubit %d to %d, expected %d instead\n", i,
+            fprintf(stderr, "Output permutation maps qubit %d to %d, expected %d instead\n", i,
                    result_permutation[i], expected_permutation[i]);
             result = EqualityError;
             goto cleanup;

--- a/test/c/test_split_2q_unitaries.c
+++ b/test/c/test_split_2q_unitaries.c
@@ -31,20 +31,20 @@ static int test_standalone_split_2q_unitaries_no_unitaries(void) {
     int result = Ok;
     if (split_result != NULL) {
         result = EqualityError;
-        printf("Permutation returned for a circuit that shouldn't split\n");
+        fprintf(stderr, "Permutation returned for a circuit that shouldn't split\n");
         qk_transpile_layout_free(split_result);
         goto cleanup;
     }
     QkOpCounts counts = qk_circuit_count_ops(qc);
     if (counts.len != 1) {
-        printf("More than 1 type of gate in the circuit\n");
+        fprintf(stderr, "More than 1 type of gate in the circuit\n");
         result = EqualityError;
         goto ops_cleanup;
     }
     for (size_t i = 0; i < counts.len; i++) {
         int gate = strcmp(counts.data[i].name, "cx");
         if (gate != 0) {
-            printf("gates changed when there should be no circuit changes\n");
+            fprintf(stderr, "gates changed when there should be no circuit changes\n");
             result = EqualityError;
             goto cleanup;
         }
@@ -71,26 +71,26 @@ static int test_standalone_split_2q_unitaries_x_y_unitary(void) {
     int result = Ok;
     if (split_result != NULL) {
         result = EqualityError;
-        printf("Permutation returned for a circuit that shouldn't isn't a swap equivalent\n");
+        fprintf(stderr, "Permutation returned for a circuit that shouldn't isn't a swap equivalent\n");
         qk_transpile_layout_free(split_result);
         goto cleanup;
     }
     QkOpCounts counts = qk_circuit_count_ops(qc);
     if (counts.len != 1) {
-        printf("More than 1 type of gate in the circuit\n");
+        fprintf(stderr, "More than 1 type of gate in the circuit\n");
         result = EqualityError;
         goto ops_cleanup;
     }
     for (size_t i = 0; i < counts.len; i++) {
         int gate = strcmp(counts.data[i].name, "unitary");
         if (gate != 0) {
-            printf("Gates outside expected set in output circuit\n");
+            fprintf(stderr, "Gates outside expected set in output circuit\n");
             result = EqualityError;
             goto ops_cleanup;
         }
         size_t count = counts.data[i].count;
         if (count != 2) {
-            printf("Unexpected gate counts found\n");
+            fprintf(stderr, "Unexpected gate counts found\n");
             result = EqualityError;
             goto ops_cleanup;
         }
@@ -99,7 +99,7 @@ static int test_standalone_split_2q_unitaries_x_y_unitary(void) {
     for (size_t i = 0; i < qk_circuit_num_instructions(qc); i++) {
         qk_circuit_get_instruction(qc, i, &inst);
         if (inst.num_qubits != 1) {
-            printf("Gate %zu operates on more than 1 qubit: %u\n", i, inst.num_qubits);
+            fprintf(stderr, "Gate %zu operates on more than 1 qubit: %u\n", i, inst.num_qubits);
             result = EqualityError;
             goto ops_cleanup;
         }
@@ -128,7 +128,7 @@ static int test_standalone_split_2q_unitaries_swap_x_y_unitary(void) {
     int result = Ok;
     if (split_result == NULL) {
         result = EqualityError;
-        printf("Permutation not returned for a circuit that should have one\n");
+        fprintf(stderr, "Permutation not returned for a circuit that should have one\n");
         goto cleanup;
     }
     uint32_t permutation[2];
@@ -136,7 +136,7 @@ static int test_standalone_split_2q_unitaries_swap_x_y_unitary(void) {
     uint32_t expected[2] = {1, 0};
     for (int i = 0; i < 2; i++) {
         if (permutation[i] != expected[i]) {
-            printf("Permutation at position %d not as expected, found %u expected %u\n", i,
+            fprintf(stderr, "Permutation at position %d not as expected, found %u expected %u\n", i,
                    permutation[i], expected[i]);
             goto cleanup;
         }
@@ -144,20 +144,20 @@ static int test_standalone_split_2q_unitaries_swap_x_y_unitary(void) {
 
     QkOpCounts counts = qk_circuit_count_ops(qc);
     if (counts.len != 1) {
-        printf("More than 1 type of gate in the circuit\n");
+        fprintf(stderr, "More than 1 type of gate in the circuit\n");
         result = EqualityError;
         goto ops_cleanup;
     }
     for (size_t i = 0; i < counts.len; i++) {
         int gate = strcmp(counts.data[i].name, "unitary");
         if (gate != 0) {
-            printf("Gates outside expected set in output circuit\n");
+            fprintf(stderr, "Gates outside expected set in output circuit\n");
             result = EqualityError;
             goto ops_cleanup;
         }
         size_t count = counts.data[i].count;
         if (count != 2) {
-            printf("Unexpected gate counts found\n");
+            fprintf(stderr, "Unexpected gate counts found\n");
             result = EqualityError;
             goto ops_cleanup;
         }
@@ -166,7 +166,7 @@ static int test_standalone_split_2q_unitaries_swap_x_y_unitary(void) {
     for (size_t i = 0; i < qk_circuit_num_instructions(qc); i++) {
         qk_circuit_get_instruction(qc, i, &inst);
         if (inst.num_qubits != 1) {
-            printf("Gate %zu operates on more than 1 qubit: %u\n", i, inst.num_qubits);
+            fprintf(stderr, "Gate %zu operates on more than 1 qubit: %u\n", i, inst.num_qubits);
             result = EqualityError;
             goto ops_cleanup;
         }
@@ -195,7 +195,7 @@ static int test_split_2q_unitaries_no_unitaries(void) {
     int result = Ok;
     if (split_result != NULL) {
         result = EqualityError;
-        printf("Permutation returned for a circuit that shouldn't split\n");
+        fprintf(stderr, "Permutation returned for a circuit that shouldn't split\n");
         qk_transpile_layout_free(split_result);
         goto cleanup;
     }
@@ -206,7 +206,7 @@ static int test_split_2q_unitaries_no_unitaries(void) {
     for (size_t i = 1; i < num_ops; i++) {
         QkGate gate = qk_dag_op_node_gate_op(dag, ops[i], NULL);
         if (gate != first_gate) {
-            printf("More than 1 type of gate in DAG\n");
+            fprintf(stderr, "More than 1 type of gate in DAG\n");
             result = EqualityError;
             goto ops_cleanup;
         }
@@ -214,7 +214,7 @@ static int test_split_2q_unitaries_no_unitaries(void) {
     for (size_t i = 0; i < num_ops; i++) {
         QkGate gate = qk_dag_op_node_gate_op(dag, ops[i], NULL);
         if (gate != QkGate_CX) {
-            printf("gates changed when there should be no DAG changes\n");
+            fprintf(stderr, "gates changed when there should be no DAG changes\n");
             result = EqualityError;
             goto ops_cleanup;
         }
@@ -243,7 +243,7 @@ static int test_split_2q_unitaries_x_y_unitary(void) {
     int result = Ok;
     if (split_result != NULL) {
         result = EqualityError;
-        printf("Permutation returned for a circuit that isn't swap-equivalent\n");
+        fprintf(stderr, "Permutation returned for a circuit that isn't swap-equivalent\n");
         qk_transpile_layout_free(split_result);
         goto cleanup;
     }
@@ -251,7 +251,7 @@ static int test_split_2q_unitaries_x_y_unitary(void) {
     uint32_t *ops = malloc(num_ops * sizeof(*ops));
     qk_dag_topological_op_nodes(dag, ops);
     if (num_ops != 2) {
-        printf("Unexpected gate counts found\n");
+        fprintf(stderr, "Unexpected gate counts found\n");
         result = EqualityError;
         goto ops_cleanup;
     }
@@ -259,18 +259,18 @@ static int test_split_2q_unitaries_x_y_unitary(void) {
     for (size_t i = 0; i < num_ops; i++) {
         QkOperationKind kind = qk_dag_op_node_kind(dag, ops[i]);
         if (kind != first_kind) {
-            printf("More than 1 type of gate in DAG\n");
+            fprintf(stderr, "More than 1 type of gate in DAG\n");
             result = EqualityError;
             goto ops_cleanup;
         }
         if (kind != QkOperationKind_Unitary) {
-            printf("Gates outside expected set in output DAG\n");
+            fprintf(stderr, "Gates outside expected set in output DAG\n");
             result = EqualityError;
             goto ops_cleanup;
         }
         uint32_t nq = qk_dag_op_node_num_qubits(dag, ops[i]);
         if (nq != 1) {
-            printf("Gate %zu operates on more than 1 qubit: %u\n", i, nq);
+            fprintf(stderr, "Gate %zu operates on more than 1 qubit: %u\n", i, nq);
             result = EqualityError;
             goto ops_cleanup;
         }
@@ -300,7 +300,7 @@ static int test_split_2q_unitaries_swap_x_y_unitary(void) {
     int result = Ok;
     if (split_result == NULL) {
         result = EqualityError;
-        printf("Permutation not returned for a circuit that should have one\n");
+        fprintf(stderr, "Permutation not returned for a circuit that should have one\n");
         goto cleanup;
     }
     uint32_t permutation[2];
@@ -308,7 +308,7 @@ static int test_split_2q_unitaries_swap_x_y_unitary(void) {
     uint32_t expected[2] = {1, 0};
     for (int i = 0; i < 2; i++) {
         if (permutation[i] != expected[i]) {
-            printf("Permutation at position %d not as expected, found %u expected %u\n", i,
+            fprintf(stderr, "Permutation at position %d not as expected, found %u expected %u\n", i,
                    permutation[i], expected[i]);
             goto cleanup;
         }
@@ -318,7 +318,7 @@ static int test_split_2q_unitaries_swap_x_y_unitary(void) {
     uint32_t *ops = malloc(num_ops * sizeof(*ops));
     qk_dag_topological_op_nodes(dag, ops);
     if (num_ops != 2) {
-        printf("Unexpected gate counts found\n");
+        fprintf(stderr, "Unexpected gate counts found\n");
         result = EqualityError;
         goto ops_cleanup;
     }
@@ -326,18 +326,18 @@ static int test_split_2q_unitaries_swap_x_y_unitary(void) {
     for (size_t i = 0; i < num_ops; i++) {
         QkOperationKind kind = qk_dag_op_node_kind(dag, ops[i]);
         if (kind != first_kind) {
-            printf("More than 1 type of gate in DAG\n");
+            fprintf(stderr, "More than 1 type of gate in DAG\n");
             result = EqualityError;
             goto ops_cleanup;
         }
         if (kind != QkOperationKind_Unitary) {
-            printf("Gates outside expected set in output DAG\n");
+            fprintf(stderr, "Gates outside expected set in output DAG\n");
             result = EqualityError;
             goto ops_cleanup;
         }
         uint32_t nq = qk_dag_op_node_num_qubits(dag, ops[i]);
         if (nq != 1) {
-            printf("Gate %zu operates on more than 1 qubit: %u\n", i, nq);
+            fprintf(stderr, "Gate %zu operates on more than 1 qubit: %u\n", i, nq);
             result = EqualityError;
             goto ops_cleanup;
         }

--- a/test/c/test_suzuki_trotter.c
+++ b/test/c/test_suzuki_trotter.c
@@ -182,7 +182,7 @@ static int test_tri_ising_hamiltonian(void) {
     const size_t num_types = 7;
     if (counts.len != num_types) {
         result = EqualityError;
-        printf("Expected %zu operations, but found %zu\n", num_types, counts.len);
+        fprintf(stderr, "Expected %zu operations, but found %zu\n", num_types, counts.len);
         // goto cleanup;
     }
 
@@ -196,44 +196,44 @@ static int test_tri_ising_hamiltonian(void) {
             strcmp(count.name, "sxdg") == 0) {
             if (count.count != num_zzz_terms) {
                 result = EqualityError;
-                printf("Expected %zu %s gates, but found %zu\n", num_zzz_terms, count.name,
+                fprintf(stderr, "Expected %zu %s gates, but found %zu\n", num_zzz_terms, count.name,
                        count.count);
                 goto cleanup;
             }
         } else if (strcmp(count.name, "h") == 0) {
             if (count.count != 2 * num_zzz_terms) {
                 result = EqualityError;
-                printf("Expected %zu h gates, but found %zu\n", 2 * num_zzz_terms, count.count);
+                fprintf(stderr, "Expected %zu h gates, but found %zu\n", 2 * num_zzz_terms, count.count);
                 goto cleanup;
             }
         } else if (strcmp(count.name, "cx") == 0) {
             if (count.count != 4 * num_zzz_terms) {
                 result = EqualityError;
-                printf("Expected %zu cx gates, but found %zu\n", 4 * num_zzz_terms, count.count);
+                fprintf(stderr, "Expected %zu cx gates, but found %zu\n", 4 * num_zzz_terms, count.count);
                 goto cleanup;
             }
         } else if (strcmp(count.name, "rzz") == 0) {
             if (count.count != num_zz_terms) {
                 result = EqualityError;
-                printf("Expected %zu rzz gates, but found %zu\n", num_zz_terms, count.count);
+                fprintf(stderr, "Expected %zu rzz gates, but found %zu\n", num_zz_terms, count.count);
                 goto cleanup;
             }
         } else if (strcmp(count.name, "rzz") == 0) {
             if (count.count != num_zz_terms) {
                 result = EqualityError;
-                printf("Expected %zu rzz gates, but found %zu\n", num_zz_terms, count.count);
+                fprintf(stderr, "Expected %zu rzz gates, but found %zu\n", num_zz_terms, count.count);
                 goto cleanup;
             }
         } else if (strcmp(count.name, "rx") == 0) {
             if (count.count != num_x_terms) {
                 result = EqualityError;
-                printf("Expected %zu rx gates, but found %zu\n", num_x_terms, count.count);
+                fprintf(stderr, "Expected %zu rx gates, but found %zu\n", num_x_terms, count.count);
                 goto cleanup;
             }
         } else {
             // Invalid name in the dictionary.
             result = EqualityError;
-            printf("Invalid operation: %s\n", count.name);
+            fprintf(stderr, "Invalid operation: %s\n", count.name);
             goto cleanup;
         }
     }

--- a/test/c/test_target.c
+++ b/test/c/test_target.c
@@ -105,17 +105,17 @@ bool compare_qargs(uint32_t *lhs, uint32_t *rhs, size_t length) {
 
 void print_qargs(uint32_t *qargs, size_t length) {
     if (qargs == NULL) {
-        printf("Global");
+        fprintf(stderr, "Global");
     } else {
-        printf("[");
+        fprintf(stderr, "[");
         for (uint32_t q_idx = 0; q_idx < length; q_idx++) {
             if (q_idx < length - 1) {
-                printf("%u, ", qargs[q_idx]);
+                fprintf(stderr, "%u, ", qargs[q_idx]);
             } else {
-                printf("%u", qargs[q_idx]);
+                fprintf(stderr, "%u", qargs[q_idx]);
             }
         }
-        printf("]");
+        fprintf(stderr, "]");
     }
 }
 
@@ -128,42 +128,42 @@ static int test_empty_target(void) {
     uint32_t num_qubits = qk_target_num_qubits(target);
 
     if (num_qubits != 0) {
-        printf("The number of qubits %u is not 0.", num_qubits);
+        fprintf(stderr, "The number of qubits %u is not 0.", num_qubits);
         result = EqualityError;
         goto cleanup;
     }
 
     double retrieved_dt = qk_target_dt(target);
     if (!isnan(retrieved_dt)) {
-        printf("The dt value of this target %f is not %f.", retrieved_dt, NAN);
+        fprintf(stderr, "The dt value of this target %f is not %f.", retrieved_dt, NAN);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t retrieved_granularity = qk_target_granularity(target);
     if (retrieved_granularity != 1) {
-        printf("The granularity %u is not 1.", retrieved_granularity);
+        fprintf(stderr, "The granularity %u is not 1.", retrieved_granularity);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t retrieved_min_length = qk_target_min_length(target);
     if (retrieved_min_length != 1) {
-        printf("The min_length %u is not 1.", retrieved_min_length);
+        fprintf(stderr, "The min_length %u is not 1.", retrieved_min_length);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t pulse_alignment = qk_target_pulse_alignment(target);
     if (pulse_alignment != 1) {
-        printf("The pulse_alignment values %u is not 1.", pulse_alignment);
+        fprintf(stderr, "The pulse_alignment values %u is not 1.", pulse_alignment);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t acquire_alignment = qk_target_acquire_alignment(target);
     if (acquire_alignment != 1) {
-        printf("The acquire_alignment values %u is not 1.", acquire_alignment);
+        fprintf(stderr, "The acquire_alignment values %u is not 1.", acquire_alignment);
         result = EqualityError;
         goto cleanup;
     }
@@ -194,42 +194,42 @@ static int test_target_construct(void) {
 
     uint32_t retrieved_num_qubits = qk_target_num_qubits(target);
     if (retrieved_num_qubits != 2) {
-        printf("The number of qubits %u is not 0.", num_qubits);
+        fprintf(stderr, "The number of qubits %u is not 0.", num_qubits);
         result = EqualityError;
         goto cleanup;
     }
 
     double retrieved_dt = qk_target_dt(target);
     if (retrieved_dt != dt) {
-        printf("The dt value of this target %f is not %f.", retrieved_dt, dt);
+        fprintf(stderr, "The dt value of this target %f is not %f.", retrieved_dt, dt);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t retrieved_granularity = qk_target_granularity(target);
     if (retrieved_granularity != 2) {
-        printf("The granularity %u is not 2.", retrieved_granularity);
+        fprintf(stderr, "The granularity %u is not 2.", retrieved_granularity);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t retrieved_min_length = qk_target_min_length(target);
     if (retrieved_min_length != 3) {
-        printf("The min_length %u is not 3.", retrieved_min_length);
+        fprintf(stderr, "The min_length %u is not 3.", retrieved_min_length);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t pulse_alignment = qk_target_pulse_alignment(target);
     if (pulse_alignment != 4) {
-        printf("The pulse_alignment values %u is not 4.", pulse_alignment);
+        fprintf(stderr, "The pulse_alignment values %u is not 4.", pulse_alignment);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t acquire_alignment = qk_target_acquire_alignment(target);
     if (acquire_alignment != 1) {
-        printf("The acquire_alignment values %u is not 1.", acquire_alignment);
+        fprintf(stderr, "The acquire_alignment values %u is not 1.", acquire_alignment);
         result = EqualityError;
         goto cleanup;
     }
@@ -249,7 +249,7 @@ static int test_target_construction_ibm_like_target(void) {
     uint32_t cx_qargs[2] = {0, 1};
     QkExitCode result_prop = qk_target_entry_add_property(cx_entry, cx_qargs, 2, 2.2e-4, 6.2e-9);
     if (result_prop != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding entry.");
+        fprintf(stderr, "Unexpected error occurred when adding entry.");
         qk_target_entry_free(cx_entry);
         result = EqualityError;
         goto cleanup;
@@ -257,7 +257,7 @@ static int test_target_construction_ibm_like_target(void) {
     cx_qargs[0] = 2;
     result_prop = qk_target_entry_add_property(cx_entry, cx_qargs, 2, 3.2e-4, 4.2e-9);
     if (result_prop != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding entry.");
+        fprintf(stderr, "Unexpected error occurred when adding entry.");
         qk_target_entry_free(cx_entry);
         result = EqualityError;
         goto cleanup;
@@ -265,7 +265,7 @@ static int test_target_construction_ibm_like_target(void) {
     cx_qargs[1] = 3;
     result_prop = qk_target_entry_add_property(cx_entry, cx_qargs, 2, 1.2e-4, 4.2e-8);
     if (result_prop != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding entry.");
+        fprintf(stderr, "Unexpected error occurred when adding entry.");
         qk_target_entry_free(cx_entry);
         result = EqualityError;
         goto cleanup;
@@ -273,14 +273,14 @@ static int test_target_construction_ibm_like_target(void) {
     cx_qargs[0] = 4;
     result_prop = qk_target_entry_add_property(cx_entry, cx_qargs, 2, 1.2e-3, 2.2e-8);
     if (result_prop != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding entry.");
+        fprintf(stderr, "Unexpected error occurred when adding entry.");
         qk_target_entry_free(cx_entry);
         result = EqualityError;
         goto cleanup;
     }
     QkExitCode result_cx = qk_target_add_instruction(target, cx_entry);
     if (result_cx != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a CX gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a CX gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -290,7 +290,7 @@ static int test_target_construction_ibm_like_target(void) {
         uint32_t qargs[1] = {i};
         result_prop = qk_target_entry_add_property(rz_entry, qargs, 1, 0, 0);
         if (result_prop != QkExitCode_Success) {
-            printf("Unexpected error occurred when adding entry.");
+            fprintf(stderr, "Unexpected error occurred when adding entry.");
             result = EqualityError;
             qk_target_entry_free(rz_entry);
             goto cleanup;
@@ -298,7 +298,7 @@ static int test_target_construction_ibm_like_target(void) {
     }
     QkExitCode result_rz = qk_target_add_instruction(target, rz_entry);
     if (result_rz != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a parameterized RZ gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a parameterized RZ gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -308,7 +308,7 @@ static int test_target_construction_ibm_like_target(void) {
         uint32_t qargs[1] = {i};
         result_prop = qk_target_entry_add_property(sx_entry, qargs, 1, 1.928e-10, 7.9829e-11);
         if (result_prop != QkExitCode_Success) {
-            printf("Unexpected error occurred when adding entry.");
+            fprintf(stderr, "Unexpected error occurred when adding entry.");
             result = EqualityError;
             qk_target_entry_free(sx_entry);
             goto cleanup;
@@ -316,7 +316,7 @@ static int test_target_construction_ibm_like_target(void) {
     }
     QkExitCode result_sx = qk_target_add_instruction(target, sx_entry);
     if (result_sx != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a parameterized RZ gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a parameterized RZ gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -326,7 +326,7 @@ static int test_target_construction_ibm_like_target(void) {
         uint32_t qargs[1] = {i};
         result_prop = qk_target_entry_add_property(x_entry, qargs, 1, 1.928e-10, 7.9829e-11);
         if (result_prop != QkExitCode_Success) {
-            printf("Unexpected error occurred when adding entry.");
+            fprintf(stderr, "Unexpected error occurred when adding entry.");
             result = EqualityError;
             qk_target_entry_free(x_entry);
             goto cleanup;
@@ -334,7 +334,7 @@ static int test_target_construction_ibm_like_target(void) {
     }
     QkExitCode result_x = qk_target_add_instruction(target, x_entry);
     if (result_x != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a parameterized RZ gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a parameterized RZ gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -344,7 +344,7 @@ static int test_target_construction_ibm_like_target(void) {
         uint32_t qargs[1] = {i};
         result_prop = qk_target_entry_add_property(measure_entry, qargs, 1, 1.928e-10, 7.9829e-11);
         if (result_prop != QkExitCode_Success) {
-            printf("Unexpected error occurred when adding entry.");
+            fprintf(stderr, "Unexpected error occurred when adding entry.");
             result = EqualityError;
             qk_target_entry_free(measure_entry);
             goto cleanup;
@@ -352,7 +352,7 @@ static int test_target_construction_ibm_like_target(void) {
     }
     QkExitCode result_measure = qk_target_add_instruction(target, measure_entry);
     if (result_measure != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a parameterized RZ gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a parameterized RZ gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -372,7 +372,7 @@ static int test_target_entry_construction(void) {
     // Test length
     const size_t length = qk_target_entry_num_properties(property_map);
     if (length != 0) {
-        printf("The initial length of the provided property map was not zero: %zu", length);
+        fprintf(stderr, "The initial length of the provided property map was not zero: %zu", length);
         result = EqualityError;
         goto cleanup;
     }
@@ -382,13 +382,13 @@ static int test_target_entry_construction(void) {
 
     QkExitCode result_prop = qk_target_entry_add_property(property_map, qargs, 2, 0.00018, 0.00002);
     if (result_prop != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding entry.");
+        fprintf(stderr, "Unexpected error occurred when adding entry.");
     }
 
     // Test length
     const size_t new_length = qk_target_entry_num_properties(property_map);
     if (new_length != 1) {
-        printf("The initial length of the provided property map was not 1: %zu", length);
+        fprintf(stderr, "The initial length of the provided property map was not 1: %zu", length);
         result = EqualityError;
         goto cleanup;
     }
@@ -400,13 +400,13 @@ static int test_target_entry_construction(void) {
     QkExitCode error_result =
         qk_target_entry_add_property(property_map, invalid_qargs, 3, 0.00018, 0.00002);
     if (error_result != QkExitCode_TargetQargMismatch) {
-        printf("The operation did not fail as expected for invalid qargs.");
+        fprintf(stderr, "The operation did not fail as expected for invalid qargs.");
     }
 
     // Set name for the entry
     QkExitCode set_name_error = qk_target_entry_set_name(property_map, "cx_gate");
     if (set_name_error != QkExitCode_Success) {
-        printf("Unexpected error occurred when setting the name of the entry.\n");
+        fprintf(stderr, "Unexpected error occurred when setting the name of the entry.\n");
         result = EqualityError;
         goto cleanup;
     }
@@ -429,7 +429,7 @@ static int test_target_add_instruction(void) {
     // This operation is global, no property map is provided
     QkExitCode result_x = qk_target_add_instruction(target, qk_target_entry_new(QkGate_X));
     if (result_x != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a global X gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a global X gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -437,7 +437,7 @@ static int test_target_add_instruction(void) {
     // Re-add same gate, check if it fails
     QkExitCode result_x_readded = qk_target_add_instruction(target, qk_target_entry_new(QkGate_X));
     if (result_x_readded != QkExitCode_TargetInstAlreadyExists) {
-        printf("The addition of a repeated gate did not fail as expected.");
+        fprintf(stderr, "The addition of a repeated gate did not fail as expected.");
         result = EqualityError;
         goto cleanup;
     }
@@ -445,14 +445,14 @@ static int test_target_add_instruction(void) {
     // Number of qubits of the target should not change.
     uint32_t current_num_qubits = qk_target_num_qubits(target);
     if (current_num_qubits != 1) {
-        printf("The number of qubits this target is compatible with is not 1: %u",
+        fprintf(stderr, "The number of qubits this target is compatible with is not 1: %u",
                current_num_qubits);
         result = EqualityError;
         goto cleanup;
     }
     size_t current_size = qk_target_num_instructions(target);
     if (current_size != 1) {
-        printf("The size of this target is not correct: Expected 1, got %zu", current_size);
+        fprintf(stderr, "The size of this target is not correct: Expected 1, got %zu", current_size);
         result = EqualityError;
         goto cleanup;
     }
@@ -468,14 +468,14 @@ static int test_target_add_instruction(void) {
     QkExitCode result_cx_props =
         qk_target_entry_add_property(cx_entry, qargs, 2, inst_duration, inst_error);
     if (result_cx_props != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding property to a CX gate entry.");
+        fprintf(stderr, "Unexpected error occurred when adding property to a CX gate entry.");
         result = EqualityError;
         goto cleanup;
     }
 
     QkExitCode result_cx = qk_target_add_instruction(target, cx_entry);
     if (result_cx != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a CX gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a CX gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -483,14 +483,14 @@ static int test_target_add_instruction(void) {
     // Number of qubits of the target should change to 2.
     current_num_qubits = qk_target_num_qubits(target);
     if (current_num_qubits != 2) {
-        printf("The number of qubits this target is compatible with is not 2: %u",
+        fprintf(stderr, "The number of qubits this target is compatible with is not 2: %u",
                current_num_qubits);
         result = EqualityError;
         goto cleanup;
     }
     current_size = qk_target_num_instructions(target);
     if (current_size != 2) {
-        printf("The size of this target is not correct: Expected 2, got %zu", current_size);
+        fprintf(stderr, "The size of this target is not correct: Expected 2, got %zu", current_size);
         result = EqualityError;
         goto cleanup;
     }
@@ -506,14 +506,14 @@ static int test_target_add_instruction(void) {
     QkExitCode result_crx_props =
         qk_target_entry_add_property(crx_entry, crx_qargs, 2, crx_inst_duration, crx_inst_error);
     if (result_crx_props != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding property to a CX gate entry.");
+        fprintf(stderr, "Unexpected error occurred when adding property to a CX gate entry.");
         result = EqualityError;
         goto cleanup;
     }
 
     QkExitCode result_crx = qk_target_add_instruction(target, crx_entry);
     if (result_crx != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a CX gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a CX gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -521,14 +521,14 @@ static int test_target_add_instruction(void) {
     // Number of qubits of the target should change to 3.
     current_num_qubits = qk_target_num_qubits(target);
     if (current_num_qubits != 3) {
-        printf("The number of qubits this target is compatible with is not 3: %d",
+        fprintf(stderr, "The number of qubits this target is compatible with is not 3: %d",
                current_num_qubits);
         result = EqualityError;
         goto cleanup;
     }
     current_size = qk_target_num_instructions(target);
     if (current_size != 3) {
-        printf("The size of this target is not correct: Expected 3, got %zu", current_size);
+        fprintf(stderr, "The size of this target is not correct: Expected 3, got %zu", current_size);
         result = EqualityError;
         goto cleanup;
     }
@@ -541,7 +541,7 @@ static int test_target_add_instruction(void) {
     }
     size_t num_meas = qk_target_entry_num_properties(meas);
     if (num_meas != 3) {
-        printf("Expected 3 measurement entries but got: %zu", num_meas);
+        fprintf(stderr, "Expected 3 measurement entries but got: %zu", num_meas);
         result = EqualityError;
         qk_target_entry_free(meas);
         goto cleanup;
@@ -549,14 +549,14 @@ static int test_target_add_instruction(void) {
 
     QkExitCode result_meas_props = qk_target_add_instruction(target, meas);
     if (result_meas_props != 0) {
-        printf("Failed adding measurement instruction.");
+        fprintf(stderr, "Failed adding measurement instruction.");
         result = EqualityError;
         goto cleanup;
     }
     // Number of qubits of the target should remain 3.
     current_num_qubits = qk_target_num_qubits(target);
     if (current_num_qubits != 3) {
-        printf("The number of qubits this target is compatible with is not 3: %d",
+        fprintf(stderr, "The number of qubits this target is compatible with is not 3: %d",
                current_num_qubits);
         result = EqualityError;
         goto cleanup;
@@ -564,7 +564,7 @@ static int test_target_add_instruction(void) {
 
     current_size = qk_target_num_instructions(target);
     if (current_size != 4) {
-        printf("The size of this target is not correct: Expected 4, got %zu", current_size);
+        fprintf(stderr, "The size of this target is not correct: Expected 4, got %zu", current_size);
         result = EqualityError;
         goto cleanup;
     }
@@ -577,7 +577,7 @@ static int test_target_add_instruction(void) {
     }
     size_t num_reset = qk_target_entry_num_properties(reset);
     if (num_reset != 3) {
-        printf("Expected 3 reset entries but got: %zu", num_reset);
+        fprintf(stderr, "Expected 3 reset entries but got: %zu", num_reset);
         result = EqualityError;
         qk_target_entry_free(reset);
         goto cleanup;
@@ -586,7 +586,7 @@ static int test_target_add_instruction(void) {
     qk_target_add_instruction(target, reset);
     current_size = qk_target_num_instructions(target);
     if (current_size != 5) {
-        printf("The size of this target is not correct: Expected 5, got %zu", current_size);
+        fprintf(stderr, "The size of this target is not correct: Expected 5, got %zu", current_size);
         result = EqualityError;
         goto cleanup;
     }
@@ -622,7 +622,7 @@ static int test_target_update_instruction(void) {
     QkExitCode result_1 = qk_target_update_property(target, QkGate_CX, qargs, 2,
                                                     cx_new_inst_duration, cx_new_inst_error);
     if (result_1 != QkExitCode_Success) {
-        printf("An unexpected error occurred while modifying the property.");
+        fprintf(stderr, "An unexpected error occurred while modifying the property.");
         result = RuntimeError;
         goto cleanup;
     }
@@ -631,7 +631,7 @@ static int test_target_update_instruction(void) {
     QkExitCode result_2 = qk_target_update_property(target, QkGate_CH, qargs, 2,
                                                     cx_new_inst_duration, cx_new_inst_error);
     if (result_2 != QkExitCode_TargetInvalidInstKey) {
-        printf("The function did not fail as expected when querying the wrong instruction.");
+        fprintf(stderr, "The function did not fail as expected when querying the wrong instruction.");
         result = RuntimeError;
         goto cleanup;
     }
@@ -641,7 +641,7 @@ static int test_target_update_instruction(void) {
     QkExitCode result_3 = qk_target_update_property(target, QkGate_CX, new_qargs, 2,
                                                     cx_new_inst_duration, cx_new_inst_error);
     if (result_3 != QkExitCode_TargetInvalidQargsKey) {
-        printf("The function did not fail as expected when querying with wrong qargs.");
+        fprintf(stderr, "The function did not fail as expected when querying with wrong qargs.");
         result = RuntimeError;
         goto cleanup;
     }
@@ -672,7 +672,7 @@ static int test_target_iteration(void) {
 
         char *name = qk_target_op_name(target, op_idx);
         if (strcmp(name, names[(int)op_idx]) != 0) {
-            printf("Unexpected operation name at index %zu, expected: %s, got %s.\n", op_idx,
+            fprintf(stderr, "Unexpected operation name at index %zu, expected: %s, got %s.\n", op_idx,
                    names[(int)op_idx], name);
             result = EqualityError;
             goto cleanup;
@@ -686,19 +686,19 @@ static int test_target_iteration(void) {
             // cx
             if (op_idx == 4) {
                 if (!compare_qargs(qargs, cx_qargs[props_idx], qargs_len)) {
-                    printf(
+                    fprintf(stderr, 
                         "Unexpected qargs found for operation %s at qarg index: %zu. Expected: '",
                         name, props_idx);
                     print_qargs(cx_qargs[props_idx], qargs_len);
-                    printf("', found '");
+                    fprintf(stderr, "', found '");
                     print_qargs(qargs, qargs_len);
-                    printf("'\n");
+                    fprintf(stderr, "'\n");
                     result = EqualityError;
                     goto cleanup;
                 }
 
                 if (props.duration != cx_props[props_idx][0]) {
-                    printf("Unexpected duration value found for operation %s at qarg index: %zu. "
+                    fprintf(stderr, "Unexpected duration value found for operation %s at qarg index: %zu. "
                            "Expected: %f, got: %f.\n",
                            name, props_idx, props.duration, cx_props[props_idx][0]);
                     result = EqualityError;
@@ -706,7 +706,7 @@ static int test_target_iteration(void) {
                 }
 
                 if (props.error != cx_props[props_idx][1]) {
-                    printf("Unexpected error value found for operation %s at qarg index: %zu. "
+                    fprintf(stderr, "Unexpected error value found for operation %s at qarg index: %zu. "
                            "Expected: %f, got: %f.\n",
                            name, props_idx, props.error, cx_props[props_idx][1]);
                     result = EqualityError;
@@ -716,13 +716,13 @@ static int test_target_iteration(void) {
             // Global y
             else if (op_idx == 5) {
                 if (!compare_qargs(qargs, NULL, 0)) {
-                    printf(
+                    fprintf(stderr, 
                         "Unexpected qargs found for operation %s at qarg index: %zu. Expected: '",
                         name, props_idx);
                     print_qargs(NULL, 0);
-                    printf("', found '");
+                    fprintf(stderr, "', found '");
                     print_qargs(qargs, qargs_len);
-                    printf("'\n");
+                    fprintf(stderr, "'\n");
                     result = EqualityError;
                     goto cleanup;
                 }
@@ -730,13 +730,13 @@ static int test_target_iteration(void) {
             // Global phase
             else if (op_idx == 6) {
                 if (!compare_qargs(qargs, (uint32_t[]){}, 0)) {
-                    printf(
+                    fprintf(stderr, 
                         "Unexpected qargs found for operation %s at qarg index: %zu. Expected: '",
                         name, props_idx);
                     print_qargs((uint32_t[]){}, 0);
-                    printf("', found '");
+                    fprintf(stderr, "', found '");
                     print_qargs(qargs, qargs_len);
-                    printf("'\n");
+                    fprintf(stderr, "'\n");
                     result = EqualityError;
                     goto cleanup;
                 }
@@ -744,20 +744,20 @@ static int test_target_iteration(void) {
             // id, rz, sx, x, measure, reset
             else {
                 if (!compare_qargs(qargs, &single_qarg[props_idx], qargs_len)) {
-                    printf(
+                    fprintf(stderr, 
                         "Unexpected qargs found for operation %s at qarg index: %zu. Expected: '",
                         name, props_idx);
                     print_qargs(&single_qarg[props_idx], qargs_len);
-                    printf("', found '");
+                    fprintf(stderr, "', found '");
                     print_qargs(qargs, qargs_len);
-                    printf("'\n");
+                    fprintf(stderr, "'\n");
                     result = EqualityError;
                     goto cleanup;
                 }
 
                 if (op_idx > 6) {
                     if (props.duration != 1e-6) {
-                        printf("Unexpected duration value found for operation %s at qarg index: "
+                        fprintf(stderr, "Unexpected duration value found for operation %s at qarg index: "
                                "%zu. Expected: %f, got: %f.\n",
                                name, props_idx, props.duration, 1e-6);
                         result = EqualityError;
@@ -765,7 +765,7 @@ static int test_target_iteration(void) {
                     }
 
                     if (props.error != 1e-4) {
-                        printf("Unexpected error value found for operation %s at qarg index: %zu. "
+                        fprintf(stderr, "Unexpected error value found for operation %s at qarg index: %zu. "
                                "Expected: %f, got: %f.\n",
                                name, props_idx, props.error, 1e-4);
                         result = EqualityError;
@@ -791,7 +791,7 @@ static int test_target_indexing(void) {
     // Retrieve the index for CX
     size_t cx_idx = qk_target_op_index(target, "cx");
     if (cx_idx != 4) {
-        printf("Invalid index for cx entry: expected %d, got %zu.\n", 4, cx_idx);
+        fprintf(stderr, "Invalid index for cx entry: expected %d, got %zu.\n", 4, cx_idx);
         result = EqualityError;
         goto cleanup;
     }
@@ -799,7 +799,7 @@ static int test_target_indexing(void) {
     // Retrieve the index for cz (should fail).
     size_t cz_idx = qk_target_op_index(target, "cz");
     if (cz_idx != (size_t)-1) {
-        printf("Found index for non-existing cz entry: got %zu.\n", cz_idx);
+        fprintf(stderr, "Found index for non-existing cz entry: got %zu.\n", cz_idx);
         result = EqualityError;
         goto cleanup;
     }
@@ -807,7 +807,7 @@ static int test_target_indexing(void) {
     // Check if qargs [0,1] exist in cx
     uint32_t cx_qargs_query[2] = {0, 1};
     if (qk_target_op_qargs_index(target, cx_idx, cx_qargs_query) != 6) {
-        printf("Couldn't find valid qarg entry [0, 1] for cx.\n");
+        fprintf(stderr, "Couldn't find valid qarg entry [0, 1] for cx.\n");
         result = EqualityError;
         goto cleanup;
     }
@@ -815,7 +815,7 @@ static int test_target_indexing(void) {
     // Check if qargs [2,3] exist in cx (should fail)
     uint32_t cx_qargs_bad_query[2] = {2, 3};
     if (qk_target_op_qargs_index(target, cx_idx, cx_qargs_bad_query) != (size_t)-1) {
-        printf("Found valid qarg entry non-existing qargs [2, 3] for cx.\n");
+        fprintf(stderr, "Found valid qarg entry non-existing qargs [2, 3] for cx.\n");
         result = EqualityError;
         goto cleanup;
     }
@@ -823,7 +823,7 @@ static int test_target_indexing(void) {
     // Since index exists, this should return properly
     size_t cx_qargs_idx = qk_target_op_qargs_index(target, cx_idx, cx_qargs_query);
     if (cx_qargs_idx != 6) {
-        printf("Invalid index for cx qargs [0,1]: expected %d, got %zu.\n", 6, cx_idx);
+        fprintf(stderr, "Invalid index for cx qargs [0,1]: expected %d, got %zu.\n", 6, cx_idx);
         result = EqualityError;
         goto cleanup;
     }
@@ -831,7 +831,7 @@ static int test_target_indexing(void) {
     // Same test on the invalid query
     size_t cx_qargs_bad_idx = qk_target_op_qargs_index(target, cx_idx, cx_qargs_bad_query);
     if (cx_qargs_bad_idx != (size_t)-1) {
-        printf("Found index for non-existing qargs [2,3].\n");
+        fprintf(stderr, "Found index for non-existing qargs [2,3].\n");
         result = EqualityError;
         goto cleanup;
     }
@@ -843,7 +843,7 @@ static int test_target_indexing(void) {
 
     qk_target_op_qargs(target, cx_idx, 1, &cx_qargs, &cx_qargs_len);
     if (!compare_qargs(cx_qargs, (uint32_t[2]){4, 3}, cx_qargs_len)) {
-        printf("Retrieved incorrect qargs, expected [4, 3], got [%u, %u]\n", cx_qargs[0],
+        fprintf(stderr, "Retrieved incorrect qargs, expected [4, 3], got [%u, %u]\n", cx_qargs[0],
                cx_qargs[1]);
         result = EqualityError;
         goto cleanup;
@@ -852,13 +852,13 @@ static int test_target_indexing(void) {
     qk_target_op_props(target, cx_idx, 1, &cx_props);
 
     if (cx_props.duration != 3.0577e-11) {
-        printf("Retrieved incorrect duration property, expected 3.0577e-11, got %lf.\n",
+        fprintf(stderr, "Retrieved incorrect duration property, expected 3.0577e-11, got %lf.\n",
                cx_props.duration);
         result = EqualityError;
         goto cleanup;
     }
     if (cx_props.error != 0.00713) {
-        printf("Retrieved incorrect error property, expected 0.00713, got %lf.\n", cx_props.error);
+        fprintf(stderr, "Retrieved incorrect error property, expected 0.00713, got %lf.\n", cx_props.error);
         result = EqualityError;
         goto cleanup;
     }
@@ -866,7 +866,7 @@ static int test_target_indexing(void) {
     // Try retrieving global index for y gate
     size_t y_idx = qk_target_op_index(target, "y");
     if (y_idx != 5) {
-        printf("Invalid index for y entry: expected %d, got %zu.\n", 5, y_idx);
+        fprintf(stderr, "Invalid index for y entry: expected %d, got %zu.\n", 5, y_idx);
         result = EqualityError;
         goto cleanup;
     }
@@ -876,7 +876,7 @@ static int test_target_indexing(void) {
     qk_target_op_qargs(target, y_idx, 0, &y_qargs, &y_qargs_len);
 
     if (y_qargs != NULL) {
-        printf("Obtained non-null global qargs at index 0 for 'y'.\n");
+        fprintf(stderr, "Obtained non-null global qargs at index 0 for 'y'.\n");
         result = EqualityError;
         goto cleanup;
     }
@@ -884,7 +884,7 @@ static int test_target_indexing(void) {
     // Try retrieving [] index for global_phase gate
     size_t gp_idx = qk_target_op_index(target, "global_phase");
     if (gp_idx != 6) {
-        printf("Invalid index for y entry: expected %d, got %zu.\n", 6, gp_idx);
+        fprintf(stderr, "Invalid index for y entry: expected %d, got %zu.\n", 6, gp_idx);
         result = EqualityError;
         goto cleanup;
     }
@@ -894,7 +894,7 @@ static int test_target_indexing(void) {
     qk_target_op_qargs(target, gp_idx, 0, &gp_qargs, &gp_qargs_len);
 
     if (gp_qargs == NULL || gp_qargs_len != 0) {
-        printf("Obtained null or invalid qargs at index 0 for 'global_phase'.\n");
+        fprintf(stderr, "Obtained null or invalid qargs at index 0 for 'global_phase'.\n");
         result = EqualityError;
         goto cleanup;
     }
@@ -924,7 +924,7 @@ int test_target_instruction_supported(void) {
             if (qk_target_instruction_supported(sample_target, gate_names[gate], qargs,
                                                 gate != 3 ? NULL : rz_params) !=
                 (should_be_true || gate == 1)) {
-                printf("This target did not correctly demonstrate compatibility with %s and qargs "
+                fprintf(stderr, "This target did not correctly demonstrate compatibility with %s and qargs "
                        "[%d]",
                        gate_names[gate], qubit);
                 result = EqualityError;
@@ -938,7 +938,7 @@ int test_target_instruction_supported(void) {
                                             (QkParam *[]){
                                                 param,
                                             })) {
-            printf("This target did not correctly demonstrate compatibility with 'rz' and qargs "
+            fprintf(stderr, "This target did not correctly demonstrate compatibility with 'rz' and qargs "
                    "[%d]",
                    qubit);
             result = EqualityError;
@@ -949,7 +949,7 @@ int test_target_instruction_supported(void) {
         // Test standard instructions reset and measure
         if (!(qk_target_instruction_supported(sample_target, "measure", qargs, NULL) ==
               (qubit < 2))) {
-            printf(
+            fprintf(stderr, 
                 "This target did not correctly demonstrate compatibility with 'measure' and qargs "
                 "[%d]",
                 qubit);
@@ -964,7 +964,7 @@ int test_target_instruction_supported(void) {
     };
     for (int i = 0; i < 8; i++) {
         if (!qk_target_instruction_supported(sample_target, "cx", qarg_samples[i], NULL)) {
-            printf("This target did incorrectly demonstrate compatibility with 'cx' and qargs [%d, "
+            fprintf(stderr, "This target did incorrectly demonstrate compatibility with 'cx' and qargs [%d, "
                    "%d]",
                    qarg_samples[i][0], qarg_samples[i][1]);
             result = EqualityError;
@@ -975,7 +975,7 @@ int test_target_instruction_supported(void) {
     uint32_t cx_qargs[2] = {3, 2};
     // Instruction should not show compatibility with (3, 2)
     if (qk_target_instruction_supported(sample_target, "cx", cx_qargs, NULL)) {
-        printf("This target did incorrectly demonstrate compatibility with 'cx' and qargs [3, 2]");
+        fprintf(stderr, "This target did incorrectly demonstrate compatibility with 'cx' and qargs [3, 2]");
         result = EqualityError;
         goto cleanup;
     }
@@ -1001,7 +1001,7 @@ static int test_target_operation(void) {
         qk_target_op_get(target, inst_idx, &op);
 
         if (strcmp(op.name, names[inst_idx]) != 0) {
-            printf("The operation names did not match. Expected %s, got %s\n", names[inst_idx],
+            fprintf(stderr, "The operation names did not match. Expected %s, got %s\n", names[inst_idx],
                    op.name);
             result = EqualityError;
             break;
@@ -1010,14 +1010,14 @@ static int test_target_operation(void) {
         char *op_types[6] = {"Gate", "Barrier", "Delay", "Measure", "Reset", "Unitary"};
         if (inst_idx < 7) {
             if (op.op_type != QkOperationKind_Gate) {
-                printf("The operation's type did not match, expected Gate, got %s\n",
+                fprintf(stderr, "The operation's type did not match, expected Gate, got %s\n",
                        op_types[(size_t)op.op_type]);
                 result = EqualityError;
                 break;
             }
             QkGate gate = qk_target_op_gate(target, inst_idx);
             if (gate != std_gates[inst_idx]) {
-                printf("The gate type did not match. Expected %i, got %i\n", std_gates[inst_idx],
+                fprintf(stderr, "The gate type did not match. Expected %i, got %i\n", std_gates[inst_idx],
                        gate);
                 result = EqualityError;
                 break;
@@ -1025,7 +1025,7 @@ static int test_target_operation(void) {
             if (inst_idx == 1) {
                 double param_val = qk_param_as_real(op.params[0]);
                 if (param_val != 3.14) {
-                    printf(
+                    fprintf(stderr, 
                         "The param value for instruction '%s' did not match. Expected %f, got %f\n",
                         op.name, 3.14, param_val);
                     result = EqualityError;
@@ -1033,7 +1033,7 @@ static int test_target_operation(void) {
                 }
             } else {
                 if (op.params == NULL && op.num_params != 0) {
-                    printf("The param values for instruction '%s' did not match. Got length %u for "
+                    fprintf(stderr, "The param values for instruction '%s' did not match. Got length %u for "
                            "NULL params.\n",
                            op.name, op.num_params);
                     result = EqualityError;
@@ -1042,14 +1042,14 @@ static int test_target_operation(void) {
             }
         } else if (inst_idx == 7) {
             if (op.op_type != QkOperationKind_Measure) {
-                printf("The operation's type did not match, expected Measure, got %s\n",
+                fprintf(stderr, "The operation's type did not match, expected Measure, got %s\n",
                        op_types[(size_t)op.op_type]);
                 result = EqualityError;
                 break;
             }
         } else {
             if (op.op_type != QkOperationKind_Reset) {
-                printf("The operation's type did not match, expected Reset, got %s\n",
+                fprintf(stderr, "The operation's type did not match, expected Reset, got %s\n",
                        op_types[(size_t)op.op_type]);
                 result = EqualityError;
                 break;

--- a/test/c/test_transpiler.c
+++ b/test/c/test_transpiler.c
@@ -88,7 +88,7 @@ static int test_transpile_bv(void) {
     options.seed = 42;
     int result_code = qk_transpile(qc, target, &options, &transpile_result, &error);
     if (result_code != 0) {
-        printf("Transpilation failed with: %s\n", error);
+        fprintf(stderr, "Transpilation failed with: %s\n", error);
         result = EqualityError;
         qk_str_free(error);
         goto circuit_cleanup;
@@ -96,7 +96,7 @@ static int test_transpile_bv(void) {
 
     QkOpCounts op_counts = qk_circuit_count_ops(transpile_result.circuit);
     if (op_counts.len != 4) {
-        printf("More than 4 types of gates in circuit, circuit's instructions are:\n");
+        fprintf(stderr, "More than 4 types of gates in circuit, circuit's instructions are:\n");
         print_circuit(transpile_result.circuit);
         result = EqualityError;
         goto transpile_cleanup;
@@ -107,7 +107,7 @@ static int test_transpile_bv(void) {
         int x_gate = strcmp(op_counts.data[i].name, "x");
         int rz_gate = strcmp(op_counts.data[i].name, "rz");
         if (sx_gate != 0 && ecr_gate != 0 && x_gate != 0 && rz_gate != 0) {
-            printf("Gate type of %s found in the circuit which isn't expected\n",
+            fprintf(stderr, "Gate type of %s found in the circuit which isn't expected\n",
                    op_counts.data[i].name);
             result = EqualityError;
             goto transpile_cleanup;
@@ -118,7 +118,7 @@ static int test_transpile_bv(void) {
         qk_circuit_get_instruction(transpile_result.circuit, i, &inst);
         if (strcmp(inst.name, "ecr") == 0) {
             if (inst.num_qubits != 2) {
-                printf("Unexpected number of qubits for ecr: %d\n", inst.num_qubits);
+                fprintf(stderr, "Unexpected number of qubits for ecr: %d\n", inst.num_qubits);
                 result = EqualityError;
                 qk_circuit_instruction_clear(&inst);
                 goto transpile_cleanup;
@@ -131,7 +131,7 @@ static int test_transpile_bv(void) {
                 }
             }
             if (valid == false) {
-                printf("ECR Gate outside target on qubits: {%u, %u}\n", inst.qubits[0],
+                fprintf(stderr, "ECR Gate outside target on qubits: {%u, %u}\n", inst.qubits[0],
                        inst.qubits[1]);
                 result = EqualityError;
                 qk_circuit_instruction_clear(&inst);
@@ -177,7 +177,7 @@ static int test_transpile_idle_qubits(void) {
         int result_code =
             qk_transpile(circuit, target, &transpile_options, &transpile_result, &error);
         if (result_code != 0) {
-            printf("Transpilation failed %s\n", error);
+            fprintf(stderr, "Transpilation failed %s\n", error);
             result = EqualityError;
             qk_str_free(error);
             goto cleanup;
@@ -186,19 +186,19 @@ static int test_transpile_idle_qubits(void) {
         qk_circuit_free(transpile_result.circuit);
         qk_transpile_layout_free(transpile_result.layout);
         if (opt_level == 0 && num_instructions != 12) {
-            printf("opt_level: %d num_instructions: %zu is not the expected value 12\n", opt_level,
+            fprintf(stderr, "opt_level: %d num_instructions: %zu is not the expected value 12\n", opt_level,
                    num_instructions);
             result = EqualityError;
             goto cleanup;
         }
         if (opt_level == 1 && num_instructions != 8) {
-            printf("opt_level: %d num_instructions: %zu is not the expected value 8\n", opt_level,
+            fprintf(stderr, "opt_level: %d num_instructions: %zu is not the expected value 8\n", opt_level,
                    num_instructions);
             result = EqualityError;
             goto cleanup;
         }
         if ((opt_level == 2 || opt_level == 3) && num_instructions != 7) {
-            printf("opt_level: %d num_instructions: %zu is not the expected value 7\n", opt_level,
+            fprintf(stderr, "opt_level: %d num_instructions: %zu is not the expected value 7\n", opt_level,
                    num_instructions);
             result = EqualityError;
             goto cleanup;
@@ -236,7 +236,7 @@ static int test_transpile_options_null(void) {
     size_t num_inst = qk_circuit_num_instructions(transpile_result.circuit);
     if (num_inst != 9) {
         result = EqualityError;
-        printf("Expected 9 instruction, but got %zu\n", num_inst);
+        fprintf(stderr, "Expected 9 instruction, but got %zu\n", num_inst);
     }
 
 cleanup:
@@ -267,13 +267,13 @@ int test_init_stage_empty(void) {
     int compile_result = qk_transpile_stage_init(dag, target, NULL, state, NULL);
     if (compile_result != 0) {
         result = EqualityError;
-        printf("Running the init stage failed\n");
+        fprintf(stderr, "Running the init stage failed\n");
         goto cleanup;
     }
     uint32_t num_dag_qubits = qk_dag_num_qubits(dag);
     if (num_dag_qubits != 1024) {
         result = EqualityError;
-        printf("Number of dag qubits %u does not match expected result 1024", num_dag_qubits);
+        fprintf(stderr, "Number of dag qubits %u does not match expected result 1024", num_dag_qubits);
     }
 cleanup:
     qk_target_free(target);
@@ -302,19 +302,19 @@ int test_layout_stage_empty(void) {
     int compile_result = qk_transpile_stage_layout(dag, target, NULL, state, NULL);
     if (compile_result != 0) {
         result = EqualityError;
-        printf("Running the layout stage failed\n");
+        fprintf(stderr, "Running the layout stage failed\n");
         goto cleanup;
     }
     uint32_t num_dag_qubits = qk_dag_num_qubits(dag);
     if (num_dag_qubits != 2048) {
         result = EqualityError;
-        printf("Number of dag qubits %u does not match expected result 2048", num_dag_qubits);
+        fprintf(stderr, "Number of dag qubits %u does not match expected result 2048", num_dag_qubits);
     }
     QkTranspileLayout *layout = qk_transpile_state_layout(*state);
     uint32_t num_layout_qubits = qk_transpile_layout_num_output_qubits(layout);
     if (num_layout_qubits != 2048) {
         result = EqualityError;
-        printf("Number of layout qubits %u does not match expected result 2048\n",
+        fprintf(stderr, "Number of layout qubits %u does not match expected result 2048\n",
                num_layout_qubits);
     }
 cleanup:
@@ -345,26 +345,26 @@ int test_routing_stage_empty(void) {
     int compile_result = qk_transpile_stage_layout(dag, target, NULL, state, NULL);
     if (compile_result != 0) {
         result = EqualityError;
-        printf("Running the layout stage failed\n");
+        fprintf(stderr, "Running the layout stage failed\n");
         goto cleanup;
     }
     // The layout should already be written to the state object, so we can dereference.
     compile_result = qk_transpile_stage_routing(dag, target, NULL, *state, NULL);
     if (compile_result != 0) {
         result = EqualityError;
-        printf("Running the routing stage failed\n");
+        fprintf(stderr, "Running the routing stage failed\n");
         goto cleanup;
     }
     uint32_t num_dag_qubits = qk_dag_num_qubits(dag);
     if (num_dag_qubits != 2048) {
         result = EqualityError;
-        printf("Number of dag qubits %u does not match expected result 2048", num_dag_qubits);
+        fprintf(stderr, "Number of dag qubits %u does not match expected result 2048", num_dag_qubits);
     }
     QkTranspileLayout *layout = qk_transpile_state_layout(*state);
     uint32_t num_layout_qubits = qk_transpile_layout_num_output_qubits(layout);
     if (num_layout_qubits != 2048) {
         result = EqualityError;
-        printf("Number of layout qubits %u does not match expected result 2048\n",
+        fprintf(stderr, "Number of layout qubits %u does not match expected result 2048\n",
                num_layout_qubits);
     }
 cleanup:
@@ -392,13 +392,13 @@ int test_translation_stage_empty(void) {
     int compile_result = qk_transpile_stage_translation(dag, target, NULL, NULL);
     if (compile_result != 0) {
         result = EqualityError;
-        printf("Running the layout stage failed\n");
+        fprintf(stderr, "Running the layout stage failed\n");
         goto cleanup;
     }
     uint32_t num_dag_qubits = qk_dag_num_qubits(dag);
     if (num_dag_qubits != 2048) {
         result = EqualityError;
-        printf("Number of dag qubits %u does not match expected result 2048", num_dag_qubits);
+        fprintf(stderr, "Number of dag qubits %u does not match expected result 2048", num_dag_qubits);
     }
 cleanup:
     qk_target_free(target);
@@ -433,13 +433,13 @@ int test_optimization_stage_empty(void) {
     int compile_result = qk_transpile_stage_optimization(dag, target, NULL, NULL, *state);
     if (compile_result != 0) {
         result = EqualityError;
-        printf("Running the optimization stage failed\n");
+        fprintf(stderr, "Running the optimization stage failed\n");
         goto cleanup;
     }
     uint32_t num_dag_qubits = qk_dag_num_qubits(dag);
     if (num_dag_qubits != 2048) {
         result = EqualityError;
-        printf("Number of dag qubits %u does not match expected result 2048", num_dag_qubits);
+        fprintf(stderr, "Number of dag qubits %u does not match expected result 2048", num_dag_qubits);
     }
 cleanup:
     free(layout_mapping);

--- a/test/c/test_unitary_synthesis.c
+++ b/test/c/test_unitary_synthesis.c
@@ -23,18 +23,18 @@ static int build_unitary_target(QkTarget *target, uint32_t num_qubits) {
     // Create a target with cx connectivity in a line.
     QkExitCode result_x = qk_target_add_instruction(target, qk_target_entry_new(QkGate_X));
     if (result_x != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a global X gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a global X gate.");
         return RuntimeError;
     }
     QkExitCode result_sx = qk_target_add_instruction(target, qk_target_entry_new(QkGate_SX));
     if (result_sx != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a global SX gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a global SX gate.");
         return RuntimeError;
     }
 
     QkExitCode result_rz = qk_target_add_instruction(target, qk_target_entry_new(QkGate_RZ));
     if (result_rz != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a global RZ gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a global RZ gate.");
         return RuntimeError;
     }
 
@@ -47,13 +47,13 @@ static int build_unitary_target(QkTarget *target, uint32_t num_qubits) {
         QkExitCode result_cx_props =
             qk_target_entry_add_property(cx_entry, qargs, 2, inst_duration, inst_error);
         if (result_cx_props != QkExitCode_Success) {
-            printf("Unexpected error occurred when adding property to a CX gate entry.");
+            fprintf(stderr, "Unexpected error occurred when adding property to a CX gate entry.");
             return RuntimeError;
         }
     }
     QkExitCode result_cx = qk_target_add_instruction(target, cx_entry);
     if (result_cx != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a CX gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a CX gate.");
         return RuntimeError;
     }
     return Ok;
@@ -81,7 +81,7 @@ static int test_unitary_synthesis_identity_matrix(void) {
     qk_transpiler_pass_standalone_unitary_synthesis(qc, target, 0, 1.0);
     size_t num_instructions = qk_circuit_num_instructions(qc);
     if (num_instructions != 0) {
-        printf("Identity unitary not removed from the circuit as expected");
+        fprintf(stderr, "Identity unitary not removed from the circuit as expected");
         result = EqualityError;
     }
     qk_circuit_free(qc);
@@ -115,7 +115,7 @@ static int test_unitary_synthesis_multiqubit_identity_matrix(void) {
     qk_transpiler_pass_standalone_unitary_synthesis(qc, target, 0, 1.0);
     size_t num_instructions = qk_circuit_num_instructions(qc);
     if (num_instructions != 0) {
-        printf("Identity unitary not removed from the circuit as expected");
+        fprintf(stderr, "Identity unitary not removed from the circuit as expected");
         result = EqualityError;
     }
     qk_circuit_free(qc);

--- a/test/c/test_version_info.c
+++ b/test/c/test_version_info.c
@@ -24,13 +24,13 @@ static char *build_version_string(void) {
     char *suffix = calloc(suffix_len, sizeof(char));
     switch (QISKIT_RELEASE_LEVEL) {
     case QISKIT_RELEASE_LEVEL_DEV:
-        snprintf(suffix, suffix_len, "-dev");
+        snfprintf(stderr, suffix, suffix_len, "-dev");
         break;
     case QISKIT_RELEASE_LEVEL_BETA:
-        snprintf(suffix, suffix_len, "-beta%u", QISKIT_RELEASE_SERIAL);
+        snfprintf(stderr, suffix, suffix_len, "-beta%u", QISKIT_RELEASE_SERIAL);
         break;
     case QISKIT_RELEASE_LEVEL_RC:
-        snprintf(suffix, suffix_len, "-rc%u", QISKIT_RELEASE_SERIAL);
+        snfprintf(stderr, suffix, suffix_len, "-rc%u", QISKIT_RELEASE_SERIAL);
         break;
     default:
         // no suffix
@@ -39,7 +39,7 @@ static char *build_version_string(void) {
 
     const size_t version_len = 32;
     char *version = calloc(version_len, sizeof(char));
-    snprintf(version, version_len, "%u.%u.%u%s", QISKIT_VERSION_MAJOR, QISKIT_VERSION_MINOR,
+    snfprintf(stderr, version, version_len, "%u.%u.%u%s", QISKIT_VERSION_MAJOR, QISKIT_VERSION_MINOR,
              QISKIT_VERSION_PATCH, suffix);
     free(suffix);
     return version;
@@ -54,7 +54,7 @@ static int test_version(void) {
     if (strcmp(ref, QISKIT_VERSION) == 0)
         result = Ok;
     else {
-        printf("Qiskit version (%s) didn't match the expectation (%s)", QISKIT_VERSION, ref);
+        fprintf(stderr, "Qiskit version (%s) didn't match the expectation (%s)", QISKIT_VERSION, ref);
         result = EqualityError;
     }
 

--- a/test/c/test_vf2_layout.c
+++ b/test/c/test_vf2_layout.c
@@ -23,7 +23,7 @@ static int build_target(QkTarget *target, uint32_t num_qubits) {
     // Create a target with cx connectivity in a line.
     QkExitCode result_x = qk_target_add_instruction(target, qk_target_entry_new(QkGate_X));
     if (result_x != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a global X gate.\n");
+        fprintf(stderr, "Unexpected error occurred when adding a global X gate.\n");
         return RuntimeError;
     }
     QkTargetEntry *cx_entry = qk_target_entry_new(QkGate_CX);
@@ -35,13 +35,13 @@ static int build_target(QkTarget *target, uint32_t num_qubits) {
         QkExitCode result_cx_props =
             qk_target_entry_add_property(cx_entry, qargs, 2, inst_duration, inst_error);
         if (result_cx_props != QkExitCode_Success) {
-            printf("Unexpected error occurred when adding property to a CX gate entry.\n");
+            fprintf(stderr, "Unexpected error occurred when adding property to a CX gate entry.\n");
             return RuntimeError;
         }
     }
     QkExitCode result_cx = qk_target_add_instruction(target, cx_entry);
     if (result_cx != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a CX gate.\n");
+        fprintf(stderr, "Unexpected error occurred when adding a CX gate.\n");
         return RuntimeError;
     }
     return Ok;
@@ -71,7 +71,7 @@ static int test_vf2_average_line(void) {
     QkVF2LayoutResult *layout_result =
         qk_transpiler_pass_standalone_vf2_layout_average(qc, target, layout_config, false);
     if (!qk_vf2_layout_result_has_match(layout_result)) {
-        printf("%s: No layout was found\n", __func__);
+        fprintf(stderr, "%s: No layout was found\n", __func__);
         result = EqualityError;
         goto layout_cleanup;
     }
@@ -83,7 +83,7 @@ static int test_vf2_average_line(void) {
     for (uint32_t i = 0; i < num_qubits; i++) {
         uint32_t phys = qk_vf2_layout_result_map_virtual_qubit(layout_result, i);
         if (phys != expected[i]) {
-            printf("%s: Unexpected layout result virtual qubit %d mapped to %d\n", __func__, phys,
+            fprintf(stderr, "%s: Unexpected layout result virtual qubit %d mapped to %d\n", __func__, phys,
                    expected[i]);
             result = EqualityError;
             goto layout_cleanup;
@@ -123,7 +123,7 @@ static int test_vf2_no_layout_found(void) {
     QkVF2LayoutResult *layout_result =
         qk_transpiler_pass_standalone_vf2_layout_average(qc, target, NULL, false);
     if (qk_vf2_layout_result_has_match(layout_result)) {
-        printf("%s: Unexpected layout found when one shouldn't be possible", __func__);
+        fprintf(stderr, "%s: Unexpected layout found when one shouldn't be possible", __func__);
         result = EqualityError;
         goto layout_cleanup;
     }
@@ -160,12 +160,12 @@ static int test_vf2_exact_no_layout_1q_semantics(void) {
     QkVF2LayoutResult *layout_result =
         qk_transpiler_pass_standalone_vf2_layout_exact(qc, target, NULL);
     if (qk_vf2_layout_result_has_match(layout_result)) {
-        printf("%s: unexpected match\n", __func__);
+        fprintf(stderr, "%s: unexpected match\n", __func__);
         result = EqualityError;
         goto cleanup;
     }
     if (qk_vf2_layout_result_has_improvement(layout_result)) {
-        printf("%s: claimed improvement without a match\n", __func__);
+        fprintf(stderr, "%s: claimed improvement without a match\n", __func__);
         result = EqualityError;
         goto cleanup;
     }
@@ -178,7 +178,7 @@ cleanup:
     return result;
 
 target_failure:
-    printf("%s: failed to build_target\n", __func__);
+    fprintf(stderr, "%s: failed to build_target\n", __func__);
     return result;
 }
 
@@ -209,11 +209,11 @@ static int test_vf2_exact_no_layout_2q_semantics(void) {
     QkVF2LayoutResult *layout_result =
         qk_transpiler_pass_standalone_vf2_layout_exact(qc, target, NULL);
     if (qk_vf2_layout_result_has_match(layout_result)) {
-        printf("%s: unexpected match\n", __func__);
+        fprintf(stderr, "%s: unexpected match\n", __func__);
         goto cleanup;
     }
     if (qk_vf2_layout_result_has_improvement(layout_result)) {
-        printf("%s: claimed improvement without a match\n", __func__);
+        fprintf(stderr, "%s: claimed improvement without a match\n", __func__);
         goto cleanup;
     }
     result = Ok;
@@ -225,7 +225,7 @@ cleanup:
     return result;
 
 target_failure:
-    printf("%s: failed to build_target\n", __func__);
+    fprintf(stderr, "%s: failed to build_target\n", __func__);
     return result;
 }
 
@@ -256,11 +256,11 @@ static int test_vf2_exact_no_layout_2q_structure(void) {
     QkVF2LayoutResult *layout_result =
         qk_transpiler_pass_standalone_vf2_layout_exact(qc, target, NULL);
     if (qk_vf2_layout_result_has_match(layout_result)) {
-        printf("%s: unexpected match\n", __func__);
+        fprintf(stderr, "%s: unexpected match\n", __func__);
         goto cleanup;
     }
     if (qk_vf2_layout_result_has_improvement(layout_result)) {
-        printf("%s: claimed improvement without a match\n", __func__);
+        fprintf(stderr, "%s: claimed improvement without a match\n", __func__);
         goto cleanup;
     }
     result = Ok;
@@ -273,7 +273,7 @@ cleanup:
 
 target_failure:
     result = RuntimeError;
-    printf("%s: failed to build_target\n", __func__);
+    fprintf(stderr, "%s: failed to build_target\n", __func__);
     qk_target_free(target);
     return result;
 }
@@ -311,17 +311,17 @@ static int test_vf2_exact_no_improvement(void) {
     QkVF2LayoutResult *layout_result =
         qk_transpiler_pass_standalone_vf2_layout_exact(qc, target, NULL);
     if (!qk_vf2_layout_result_has_match(layout_result)) {
-        printf("%s: failed to find a layout\n", __func__);
+        fprintf(stderr, "%s: failed to find a layout\n", __func__);
         goto cleanup;
     }
     if (qk_vf2_layout_result_has_improvement(layout_result)) {
-        printf("%s: claimed improvement but original was optimal\n", __func__);
+        fprintf(stderr, "%s: claimed improvement but original was optimal\n", __func__);
         goto cleanup;
     }
     for (uint32_t i = 0; i < num_qubits; i++) {
         uint32_t mapped = qk_vf2_layout_result_map_virtual_qubit(layout_result, i);
         if (mapped != i) {
-            printf("%s: no-improvement result falsely mapped %u to %u\n", __func__, mapped, i);
+            fprintf(stderr, "%s: no-improvement result falsely mapped %u to %u\n", __func__, mapped, i);
             goto cleanup;
         }
     }
@@ -334,7 +334,7 @@ cleanup:
     return result;
 
 target_failure:
-    printf("%s: failed to build_target\n", __func__);
+    fprintf(stderr, "%s: failed to build_target\n", __func__);
     qk_target_free(target);
     return result;
 }
@@ -373,14 +373,14 @@ static int test_vf2_exact_remap(void) {
     QkVF2LayoutResult *layout_result =
         qk_transpiler_pass_standalone_vf2_layout_exact(qc, target, NULL);
     if (!qk_vf2_layout_result_has_improvement(layout_result)) {
-        printf("%s: failed to improve non-optimal layout\n", __func__);
+        fprintf(stderr, "%s: failed to improve non-optimal layout\n", __func__);
         goto cleanup;
     }
     for (uint32_t i = 0; i < num_qubits; i++) {
         // The correct result is {4, 3, 2, 1, 0}.
         uint32_t mapped = qk_vf2_layout_result_map_virtual_qubit(layout_result, i);
         if (mapped != num_qubits - i - 1) {
-            printf("%s: improvement result falsely mapped %u to %u\n", __func__, mapped, i);
+            fprintf(stderr, "%s: improvement result falsely mapped %u to %u\n", __func__, mapped, i);
             goto cleanup;
         }
     }
@@ -393,7 +393,7 @@ cleanup:
     return result;
 
 target_failure:
-    printf("%s: failed to build_target\n", __func__);
+    fprintf(stderr, "%s: failed to build_target\n", __func__);
     qk_target_free(target);
     return result;
 }


### PR DESCRIPTION
Updates all C test files to use fprintf(stderr, ...) instead of printf(...) for consistency with other test reporting and to avoid mixing with stdout.

Closes #15097