### PR TITLE
Fix QASM3 exporter unitary gate naming

### DIFF
--- a/qiskit/qasm3/exporter.py
+++ b/qiskit/qasm3/exporter.py
@@ -344,6 +344,13 @@ _BUILTIN_GATES = {
     "U": _CANONICAL_STANDARD_GATES[StandardGate.U],
 }
 
+# Some downstream consumers, notably qiskit-aer, interpret "unitary" as a special instruction name
+# rather than a user-defined gate.  Exported gate definitions that use the bare symbol can then be
+# misclassified, so we rename those declarations while preserving the circuit semantics.
+_DECLARED_GATE_NAME_RENAMES = {
+    "unitary": "unitary_gate",
+}
+
 
 @dataclasses.dataclass
 class GateInfo:
@@ -557,6 +564,7 @@ class SymbolTable:
     ) -> ast.Identifier:
         """Register the given gate in the symbol table, using the given components to build up the
         full AST definition."""
+        name = _DECLARED_GATE_NAME_RENAMES.get(name, name)
         name = self.escaped_declarable_name(name, allow_rename=True, unique=False)
         ident = ast.Identifier(name)
         self.gates[name] = GateInfo(

--- a/releasenotes/notes/fix-qasm3-unitary-gate-name-4c4d2d9cb6d6fcdd.yaml
+++ b/releasenotes/notes/fix-qasm3-unitary-gate-name-4c4d2d9cb6d6fcdd.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    The OpenQASM 3 exporter (:func:`.qasm3.dumps` and :func:`~.qasm3.dump`) will no longer emit a
+    declared gate called ``unitary`` when exporting circuit definitions built from
+    :class:`.UnitaryGate` instances.  This avoids collisions with downstream consumers such as
+    :mod:`qiskit_aer` that interpret ``unitary`` as a special instruction name.
+
+upgrade_qasm:
+  - |
+    OpenQASM 3 output for circuits containing exported :class:`.UnitaryGate` definitions now uses
+    gate names beginning with ``unitary_gate`` instead of the bare symbol ``unitary``.

--- a/test/python/qasm3/test_export.py
+++ b/test/python/qasm3/test_export.py
@@ -2757,14 +2757,30 @@ switch (switch_dummy_0) {
         expected = """\
 OPENQASM 3.0;
 include "stdgates.inc";
-gate unitary _gate_q_0 {
+gate unitary_gate _gate_q_0 {
   U(pi, -pi, 0) _gate_q_0;
 }
 qubit[1] q;
-unitary q[0];
+unitary_gate q[0];
 """
         test = dumps(qc)
         self.assertEqual(test, expected)
+
+    def test_nested_unitary_definitions_do_not_use_bare_unitary_name(self):
+        """Test synthesized subcircuits avoid exporting a declared gate called ``unitary``."""
+        from qiskit.circuit.library import Initialize
+
+        raw_state = [1, 2, 3, 4, 5, 6, 7, 8]
+        norm = sum(value * value for value in raw_state) ** 0.5
+
+        qc = QuantumCircuit(3)
+        qc.compose(
+            Initialize([value / norm for value in raw_state]).definition, range(3), inplace=True
+        )
+
+        test = dumps(qc)
+        self.assertNotIn("gate unitary ", test)
+        self.assertNotIn("\nunitary ", test)
 
 
 @ddt


### PR DESCRIPTION
## Summary

Rename exported OpenQASM 3 gate definitions that would otherwise use the bare symbol `unitary`.

Fixes #14310.

## Root cause

The OpenQASM 3 exporter preserved the `UnitaryGate` name when emitting a gate definition, so it produced output such as:

```openqasm
 gate unitary _gate_q_0 {
   ...
 }
 unitary q[0];
```

Downstream consumers such as Qiskit Aer treat `unitary` as a special instruction name rather than a user-defined gate symbol, so the exported program could be misclassified and fail when reloaded.

## Fix

- rename declared gate symbols derived from `unitary` to `unitary_gate` through the exporter symbol table
- keep the change scoped to exported gate declarations and call sites only
- add a regression test for nested synthesized unitary definitions
- add a release note for the user-visible QASM output change

## Tests

- `PYTHONPATH=$PWD python -m unittest -v test.python.qasm3.test_export`
- `PYTHONPATH=$PWD python -m black --check qiskit/qasm3/exporter.py test/python/qasm3/test_export.py`
- `PYTHONPATH=$PWD python -m ruff check qiskit/qasm3/exporter.py test/python/qasm3/test_export.py`

## Notes or limitations

- `reno lint` could not be completed in this checkout because the local repository hits a Dulwich missing-object error while scanning note history (`KeyError: b'09bcf1597b54b73fef724dc3f02a6fae8edbdf1f'`).

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description: OpenAI Codex (GPT-5)
- [x] I used the following tool to generate or modify code: OpenAI Codex (GPT-5)
