### PR TITLE
Add Performance category to the changelog and release notes

### DIFF
--- a/qiskit_bot.yaml
+++ b/qiskit_bot.yaml
@@ -28,4 +28,5 @@ categories:
   "Changelog: Deprecated": "Deprecated"
   "Changelog: Removed": "Removed"
   "Changelog: Build": "Build System"
+  "Changelog: Performance": "Performance"
   "Changelog: None": null

--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -82,6 +82,10 @@ template: |
   performance:
     - Measurable performance improvements.
 
+  # A feature is a new user-visible functionality. It can come in the form of a new function, 
+  # class, parameter, environment variable or any other user accessible and publicly documented 
+  # endpoint. In addition, new capabilities (for example "Qiskit can now compile to Clifford+T"), 
+  # newly supported workflows and new types of language interoperability are considered features.
   # Choose only the "features" sections you need and delete the rest.  Try to be concise.  You may
   # use a code example for complicated features.
   features_c:

--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -77,6 +77,11 @@ template: |
 
       See `#15019 <https://github.com/Qiskit/qiskit/issues/15019>`__.
 
+  # Performance release notes are for runtime and output quality improvements which do not 
+  # include API or semantic changes. 
+  performance:
+    - Measurable performance improvements.
+
   # Choose only the "features" sections you need and delete the rest.  Try to be concise.  You may
   # use a code example for complicated features.
   features_c:
@@ -159,8 +164,3 @@ template: |
   # These generally shouldn't concern users, just people building from source.
   build:
     - Changes to the build system that packagers might need to be aware of.
-
-  # Performance release notes are for runtime and output quality improvements which do not 
-  # include API or semantic changes. 
-  performance:
-    - Measurable performance improvements.

--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -46,6 +46,7 @@ sections:
   - [critical, Critical Issues]
   - [security, Security Issues]
   - [fixes, Bug Fixes]
+  - [performance, Performance Improvements]
   - [other, Other Notes]
 template: |
   ---
@@ -158,3 +159,8 @@ template: |
   # These generally shouldn't concern users, just people building from source.
   build:
     - Changes to the build system that packagers might need to be aware of.
+
+  # Performance release notes are for runtime and output quality improvements which do not 
+  # include API or semantic changes. 
+  performance:
+    - Measurable performance improvements.


### PR DESCRIPTION
This PR adds a new category to the release notes and changelog for reporting performance improvements. 

## Details
- I've put the performance category to appear after all the additions, changes, deprecations and issues sections in the release notes. 
- Added a new `Changelog: Performance` label to the repo (directly in Github). There is also the preexisting `performance` label, which is currently used by several PRs. We should review which PRs should switch to the new label once this PR is merged and then add release notes for those which are marked with `Changelog: None`.
### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
