### PR TITLE
Add ddt to test-random group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,6 +208,7 @@ test = [
 test-random = [
     "qiskit-aer",
     "hypothesis>=4.24.3",
+    "ddt>=1.2.0",
 ]
 # Dependencies to build the documentation.  It's ok if the range of Python versions that can build
 # the docs is more restrictive than Python versions that Qiskit supports.


### PR DESCRIPTION
Since #15619, [randomized testing had been failing](https://github.com/Qiskit/qiskit/issues/2645) because ddt is not installed:

<img width="625" height="580" alt="Screenshot 2026-04-20 at 21 05 09" src="https://github.com/user-attachments/assets/4a74f0b4-b891-4d71-a0b9-dc0727b59ca1" />

This adds `"ddt>=1.2.0"` to the `test-random` group to bring randomized testing back.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
