### PR TITLE
Track `PauliLindbladMap` generators during `parity_sample`

### DIFF
--- a/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
@@ -384,19 +384,6 @@ impl PauliLindbladMap {
         Ok(log_fid.exp())
     }
 
-    /// Equal to parity_sample_generators but don't return the extra generator information
-    pub fn parity_sample(
-        &self,
-        num_samples: u64,
-        seed: Option<u64>,
-        scale: Option<f64>,
-        local_scale: Option<Vec<f64>>,
-    ) -> (Vec<bool>, QubitSparsePauliList) {
-        let (random_signs, random_paulis, _, _) =
-            self.parity_sample_generators(num_samples, seed, scale, local_scale);
-        (random_signs, random_paulis)
-    }
-
     /// Sample sign and Pauli operator pairs from the map.
     /// Note that here the "sign" bool is interpreted as the exponent of (-1)^b.
     #[allow(clippy::type_complexity)]
@@ -1613,7 +1600,8 @@ impl PyPauliLindbladMap {
         seed: Option<u64>,
     ) -> PyResult<Bound<'py, PyTuple>> {
         let inner = self.inner.read().map_err(|_| InnerReadError)?;
-        let (signs, paulis) = py.detach(|| inner.parity_sample(num_samples, seed, None, None));
+        let (signs, paulis, _, _) =
+            py.detach(|| inner.parity_sample_generators(num_samples, seed, None, None));
 
         let signs = PyArray1::from_vec(py, signs.iter().map(|b| !b).collect());
         let paulis = paulis.into_pyobject(py).unwrap();
@@ -1665,8 +1653,8 @@ impl PyPauliLindbladMap {
         local_scale: Option<Vec<f64>>,
     ) -> PyResult<Bound<'py, PyTuple>> {
         let inner = self.inner.read().map_err(|_| InnerReadError)?;
-        let (signs, paulis) =
-            py.detach(|| inner.parity_sample(num_samples, seed, scale, local_scale));
+        let (signs, paulis, _, _) =
+            py.detach(|| inner.parity_sample_generators(num_samples, seed, scale, local_scale));
 
         let signs = PyArray1::from_vec(py, signs);
         let paulis = paulis.into_pyobject(py).unwrap();
@@ -1756,7 +1744,8 @@ impl PyPauliLindbladMap {
             }
         }
 
-        let (_, paulis) = py.detach(|| inner.parity_sample(num_samples, seed, None, None));
+        let (_, paulis, _, _) =
+            py.detach(|| inner.parity_sample_generators(num_samples, seed, None, None));
 
         paulis.into_pyobject(py)
     }

--- a/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
@@ -384,8 +384,7 @@ impl PauliLindbladMap {
         Ok(log_fid.exp())
     }
 
-    /// Sample sign and Pauli operator pairs from the map.
-    /// Note that here the "sign" bool is interpreted as the exponent of (-1)^b.
+    /// Equal to parity_sample_generators but don't return the extra generator information
     pub fn parity_sample(
         &self,
         num_samples: u64,
@@ -393,63 +392,13 @@ impl PauliLindbladMap {
         scale: Option<f64>,
         local_scale: Option<Vec<f64>>,
     ) -> (Vec<bool>, QubitSparsePauliList) {
-        let mut rng = match seed {
-            Some(seed) => Pcg64Mcg::seed_from_u64(seed),
-            None => Pcg64Mcg::try_from_rng(&mut SysRng).unwrap(),
-        };
-        let modified_probabilities;
-        let modified_non_negative_rates;
-        let (probabilities, non_negative_rates) = if local_scale.is_some() || scale.is_some() {
-            let global = scale.unwrap_or(1.);
-            let locals = local_scale.as_ref();
-            let rates = self
-                .rates
-                .iter()
-                .enumerate()
-                .map(|(i, rate)| *rate * locals.map(|locals| locals[i]).unwrap_or(1.) * global)
-                .collect::<Vec<_>>();
-            (_, modified_probabilities, modified_non_negative_rates) =
-                derived_values_from_rates(&rates);
-            (
-                modified_probabilities.as_slice(),
-                modified_non_negative_rates.as_slice(),
-            )
-        } else {
-            (
-                self.probabilities.as_slice(),
-                self.non_negative_rates.as_slice(),
-            )
-        };
-        let mut random_signs = Vec::with_capacity(num_samples as usize);
-        let mut random_paulis = QubitSparsePauliList::empty(self.num_qubits());
-
-        for _ in 0..num_samples {
-            let mut random_sign = false;
-            let mut random_pauli = QubitSparsePauli::identity(self.num_qubits());
-
-            for ((probability, generator), non_negative_rate) in probabilities
-                .iter()
-                .zip(self.qubit_sparse_pauli_list.iter())
-                .zip(non_negative_rates.iter())
-            {
-                // Sample true or false with given probability. If false, apply the Pauli
-                if !Bernoulli::new(*probability).unwrap().sample(&mut rng) {
-                    random_pauli = random_pauli.compose(&generator.to_term()).unwrap();
-                    // if rate is negative, flip random_sign
-                    random_sign = random_sign == *non_negative_rate;
-                }
-            }
-
-            random_signs.push(random_sign);
-            random_paulis
-                .add_qubit_sparse_pauli(random_pauli.view())
-                .unwrap();
-        }
-
+        let (random_signs, random_paulis, _, _) =
+            self.parity_sample_generators(num_samples, seed, scale, local_scale);
         (random_signs, random_paulis)
     }
 
-    /// Equal to parity_sample but also preserving the information which generators were sampled.
+    /// Sample sign and Pauli operator pairs from the map.
+    /// Note that here the "sign" bool is interpreted as the exponent of (-1)^b.
     #[allow(clippy::type_complexity)]
     pub fn parity_sample_generators(
         &self,

--- a/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
@@ -11,7 +11,7 @@
 // that they have been altered from the originals.
 
 use hashbrown::HashSet;
-use numpy::{PyArray1, PyArrayMethods, ToPyArray};
+use numpy::{PyArray1, PyArray2, PyArrayMethods, ToPyArray};
 use pyo3::{
     IntoPyObjectExt, PyErr,
     exceptions::{PyTypeError, PyValueError},
@@ -447,6 +447,92 @@ impl PauliLindbladMap {
         }
 
         (random_signs, random_paulis)
+    }
+
+    /// Equal to parity_sample but also preserving the information which generators were sampled.
+    #[allow(clippy::type_complexity)]
+    pub fn parity_sample_generators(
+        &self,
+        num_samples: u64,
+        seed: Option<u64>,
+        scale: Option<f64>,
+        local_scale: Option<Vec<f64>>,
+    ) -> (
+        Vec<bool>,
+        QubitSparsePauliList,
+        Vec<Vec<bool>>,
+        Vec<Vec<bool>>,
+    ) {
+        let mut rng = match seed {
+            Some(seed) => Pcg64Mcg::seed_from_u64(seed),
+            None => Pcg64Mcg::try_from_rng(&mut SysRng).unwrap(),
+        };
+        let modified_probabilities;
+        let modified_non_negative_rates;
+        let (probabilities, non_negative_rates) = if local_scale.is_some() || scale.is_some() {
+            let global = scale.unwrap_or(1.);
+            let locals = local_scale.as_ref();
+            let rates = self
+                .rates
+                .iter()
+                .enumerate()
+                .map(|(i, rate)| *rate * locals.map(|locals| locals[i]).unwrap_or(1.) * global)
+                .collect::<Vec<_>>();
+            (_, modified_probabilities, modified_non_negative_rates) =
+                derived_values_from_rates(&rates);
+            (
+                modified_probabilities.as_slice(),
+                modified_non_negative_rates.as_slice(),
+            )
+        } else {
+            (
+                self.probabilities.as_slice(),
+                self.non_negative_rates.as_slice(),
+            )
+        };
+        let mut random_signs = Vec::with_capacity(num_samples as usize);
+        let mut random_paulis = QubitSparsePauliList::empty(self.num_qubits());
+        let mut sampled_generators = Vec::with_capacity(num_samples as usize);
+        let mut sampled_signs = Vec::with_capacity(num_samples as usize);
+
+        for _ in 0..num_samples {
+            let mut random_sign = false;
+            let mut random_pauli = QubitSparsePauli::identity(self.num_qubits());
+            let mut inner_sampled_generators =
+                vec![false; self.qubit_sparse_pauli_list.num_terms()];
+            let mut inner_sampled_signs = vec![false; self.qubit_sparse_pauli_list.num_terms()];
+
+            for (((idx, probability), generator), non_negative_rate) in probabilities
+                .iter()
+                .enumerate()
+                .zip(self.qubit_sparse_pauli_list.iter())
+                .zip(non_negative_rates.iter())
+            {
+                // Sample true or false with given probability. If false, apply the Pauli
+                if !Bernoulli::new(*probability).unwrap().sample(&mut rng) {
+                    random_pauli = random_pauli.compose(&generator.to_term()).unwrap();
+                    // if rate is negative, flip random_sign
+                    random_sign = random_sign == *non_negative_rate;
+                    // keep track of sampled generator
+                    inner_sampled_generators[idx] = true;
+                    inner_sampled_signs[idx] = *non_negative_rate;
+                }
+            }
+
+            random_signs.push(random_sign);
+            random_paulis
+                .add_qubit_sparse_pauli(random_pauli.view())
+                .unwrap();
+            sampled_generators.push(inner_sampled_generators);
+            sampled_signs.push(inner_sampled_signs);
+        }
+
+        (
+            random_signs,
+            random_paulis,
+            sampled_generators,
+            sampled_signs,
+        )
     }
 
     /// Reduce the map to its canonical form.
@@ -1637,6 +1723,44 @@ impl PyPauliLindbladMap {
         let paulis = paulis.into_pyobject(py).unwrap();
 
         (signs, paulis).into_pyobject(py)
+    }
+
+    /// Sample sign and Pauli operator pairs from the map, preserving the sampled generators.
+    ///
+    /// This method is identical to :meth:`parity_sample` except for also returning the information
+    /// which :meth:`generators` were actually sampled to yield the final Pauli operator and sign.
+    ///
+    ///
+    /// Args:
+    ///     num_samples (int): Number of samples to draw.
+    ///     seed (int): Random seed.
+    ///     scale (float): Scale to apply to all rates.
+    ///     local_scale (list[float]): Local scale to apply on a term-by-term basis.
+    ///
+    /// Returns:
+    ///     signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs: The boolean array of
+    ///         signs, the list of qubit sparse paulis, the two dimensional boolean array
+    ///         indicating which :meth:`generators` were sampled and the two dimensional boolean
+    ///         array indicating their signs.
+    #[pyo3(signature = (num_samples, seed=None, scale=None, local_scale=None))]
+    pub fn parity_sample_generators<'py>(
+        &self,
+        py: Python<'py>,
+        num_samples: u64,
+        seed: Option<u64>,
+        scale: Option<f64>,
+        local_scale: Option<Vec<f64>>,
+    ) -> PyResult<Bound<'py, PyTuple>> {
+        let inner = self.inner.read().map_err(|_| InnerReadError)?;
+        let (signs, paulis, sampled_generators, sampled_signs) =
+            py.detach(|| inner.parity_sample_generators(num_samples, seed, scale, local_scale));
+
+        let signs = PyArray1::from_vec(py, signs);
+        let paulis = paulis.into_pyobject(py).unwrap();
+        let sampled_generators = PyArray2::from_vec2(py, &sampled_generators).unwrap();
+        let sampled_signs = PyArray2::from_vec2(py, &sampled_signs).unwrap();
+
+        (signs, paulis, sampled_generators, sampled_signs).into_pyobject(py)
     }
 
     /// For :class:`.PauliLindbladMap` instances with purely non-negative rates, sample Pauli

--- a/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
@@ -387,7 +387,7 @@ impl PauliLindbladMap {
     /// Sample sign and Pauli operator pairs from the map.
     /// Note that here the "sign" bool is interpreted as the exponent of (-1)^b.
     #[allow(clippy::type_complexity)]
-    pub fn parity_sample_generators(
+    pub fn parity_sample_with_history(
         &self,
         num_samples: u64,
         seed: Option<u64>,
@@ -428,15 +428,14 @@ impl PauliLindbladMap {
         };
         let mut random_signs = Vec::with_capacity(num_samples as usize);
         let mut random_paulis = QubitSparsePauliList::empty(self.num_qubits());
-        let mut sampled_generators = Vec::with_capacity(num_samples as usize);
-        let mut sampled_signs = Vec::with_capacity(num_samples as usize);
+        let mut pauli_history = Vec::with_capacity(num_samples as usize);
+        let mut signs_history = Vec::with_capacity(num_samples as usize);
 
         for _ in 0..num_samples {
             let mut random_sign = false;
             let mut random_pauli = QubitSparsePauli::identity(self.num_qubits());
-            let mut inner_sampled_generators =
-                vec![false; self.qubit_sparse_pauli_list.num_terms()];
-            let mut inner_sampled_signs = vec![false; self.qubit_sparse_pauli_list.num_terms()];
+            let mut inner_pauli_history = vec![false; self.qubit_sparse_pauli_list.num_terms()];
+            let mut inner_signs_history = vec![false; self.qubit_sparse_pauli_list.num_terms()];
 
             for (((idx, probability), generator), non_negative_rate) in probabilities
                 .iter()
@@ -450,8 +449,8 @@ impl PauliLindbladMap {
                     // if rate is negative, flip random_sign
                     random_sign = random_sign == *non_negative_rate;
                     // keep track of sampled generator
-                    inner_sampled_generators[idx] = true;
-                    inner_sampled_signs[idx] = *non_negative_rate;
+                    inner_pauli_history[idx] = true;
+                    inner_signs_history[idx] = *non_negative_rate;
                 }
             }
 
@@ -459,16 +458,11 @@ impl PauliLindbladMap {
             random_paulis
                 .add_qubit_sparse_pauli(random_pauli.view())
                 .unwrap();
-            sampled_generators.push(inner_sampled_generators);
-            sampled_signs.push(inner_sampled_signs);
+            pauli_history.push(inner_pauli_history);
+            signs_history.push(inner_signs_history);
         }
 
-        (
-            random_signs,
-            random_paulis,
-            sampled_generators,
-            sampled_signs,
-        )
+        (random_signs, random_paulis, pauli_history, signs_history)
     }
 
     /// Reduce the map to its canonical form.
@@ -1601,7 +1595,7 @@ impl PyPauliLindbladMap {
     ) -> PyResult<Bound<'py, PyTuple>> {
         let inner = self.inner.read().map_err(|_| InnerReadError)?;
         let (signs, paulis, _, _) =
-            py.detach(|| inner.parity_sample_generators(num_samples, seed, None, None));
+            py.detach(|| inner.parity_sample_with_history(num_samples, seed, None, None));
 
         let signs = PyArray1::from_vec(py, signs.iter().map(|b| !b).collect());
         let paulis = paulis.into_pyobject(py).unwrap();
@@ -1654,7 +1648,7 @@ impl PyPauliLindbladMap {
     ) -> PyResult<Bound<'py, PyTuple>> {
         let inner = self.inner.read().map_err(|_| InnerReadError)?;
         let (signs, paulis, _, _) =
-            py.detach(|| inner.parity_sample_generators(num_samples, seed, scale, local_scale));
+            py.detach(|| inner.parity_sample_with_history(num_samples, seed, scale, local_scale));
 
         let signs = PyArray1::from_vec(py, signs);
         let paulis = paulis.into_pyobject(py).unwrap();
@@ -1675,12 +1669,12 @@ impl PyPauliLindbladMap {
     ///     local_scale (list[float]): Local scale to apply on a term-by-term basis.
     ///
     /// Returns:
-    ///     signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs: The boolean array of
+    ///     signs, qubit_sparse_pauli_list, pauli_history, signs_history: The boolean array of
     ///         signs, the list of qubit sparse paulis, the two dimensional boolean array
     ///         indicating which :meth:`generators` were sampled and the two dimensional boolean
     ///         array indicating their signs.
     #[pyo3(signature = (num_samples, seed=None, scale=None, local_scale=None))]
-    pub fn parity_sample_generators<'py>(
+    pub fn parity_sample_with_history<'py>(
         &self,
         py: Python<'py>,
         num_samples: u64,
@@ -1689,15 +1683,15 @@ impl PyPauliLindbladMap {
         local_scale: Option<Vec<f64>>,
     ) -> PyResult<Bound<'py, PyTuple>> {
         let inner = self.inner.read().map_err(|_| InnerReadError)?;
-        let (signs, paulis, sampled_generators, sampled_signs) =
-            py.detach(|| inner.parity_sample_generators(num_samples, seed, scale, local_scale));
+        let (signs, paulis, pauli_history, signs_history) =
+            py.detach(|| inner.parity_sample_with_history(num_samples, seed, scale, local_scale));
 
         let signs = PyArray1::from_vec(py, signs);
         let paulis = paulis.into_pyobject(py).unwrap();
-        let sampled_generators = PyArray2::from_vec2(py, &sampled_generators).unwrap();
-        let sampled_signs = PyArray2::from_vec2(py, &sampled_signs).unwrap();
+        let pauli_history = PyArray2::from_vec2(py, &pauli_history).unwrap();
+        let signs_history = PyArray2::from_vec2(py, &signs_history).unwrap();
 
-        (signs, paulis, sampled_generators, sampled_signs).into_pyobject(py)
+        (signs, paulis, pauli_history, signs_history).into_pyobject(py)
     }
 
     /// For :class:`.PauliLindbladMap` instances with purely non-negative rates, sample Pauli
@@ -1745,7 +1739,7 @@ impl PyPauliLindbladMap {
         }
 
         let (_, paulis, _, _) =
-            py.detach(|| inner.parity_sample_generators(num_samples, seed, None, None));
+            py.detach(|| inner.parity_sample_with_history(num_samples, seed, None, None));
 
         paulis.into_pyobject(py)
     }

--- a/releasenotes/notes/paulilindbladmap-parity-sample-generators-d4a439235327e1fc.yaml
+++ b/releasenotes/notes/paulilindbladmap-parity-sample-generators-d4a439235327e1fc.yaml
@@ -1,0 +1,5 @@
+---
+features_quantum_info:
+  - Added the :meth:`.PauliLindbladMap.parity_sample_generators` method which is
+    identical to :meth:`.PauliLindbladMap.parity_sample` except for also tracking
+    and returning the underlying generators that resulted in the final Pauli terms.

--- a/releasenotes/notes/paulilindbladmap-parity-sample-generators-d4a439235327e1fc.yaml
+++ b/releasenotes/notes/paulilindbladmap-parity-sample-generators-d4a439235327e1fc.yaml
@@ -1,5 +1,6 @@
 ---
 features_quantum_info:
-  - Added the :meth:`.PauliLindbladMap.parity_sample_generators` method which is
+  - Added the :meth:`.PauliLindbladMap.parity_sample_with_history` method which is
     identical to :meth:`.PauliLindbladMap.parity_sample` except for also tracking
-    and returning the underlying generators that resulted in the final Pauli terms.
+    and returning the underlying history of Paulis and signs that resulted in the
+    final sampled terms.

--- a/test/python/quantum_info/test_pauli_lindblad_map.py
+++ b/test/python/quantum_info/test_pauli_lindblad_map.py
@@ -1239,268 +1239,104 @@ class TestPauliLindbladMap(QiskitTestCase):
         self.assertEqual(len(qubit_sparse_pauli_list), 5)
         self.assertEqual(len(signs), 5)
 
+    def _assert_parity_sample_results(
+        self,
+        plm_to_sample,
+        expected_signs,
+        num_samples=10000,
+        seed=12312,
+        scale=None,
+        local_scale=None,
+        plm_reference=None,
+    ):
+        if plm_reference is None:
+            plm_reference = plm_to_sample
+
+        generators = plm_reference.generators()
+        probs = plm_reference.probabilities()
+        probs_dict = {
+            "I": probs[0] * probs[1],
+            "X": (1 - probs[0]) * probs[1],
+            "Y": probs[0] * (1 - probs[1]),
+            "Z": (1 - probs[0]) * (1 - probs[1]),
+        }
+
+        signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs = (
+            plm_to_sample.parity_sample_generators(
+                num_samples, seed, scale=scale, local_scale=local_scale
+            )
+        )
+        counts = {"I": 0, "X": 0, "Y": 0, "Z": 0}
+        for sign, q, _gens, _signs in zip(
+            signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs
+        ):
+            for symbol in counts:
+                if q == QubitSparsePauli(symbol):
+                    counts[symbol] += 1
+                    self.assertEqual(expected_signs[symbol], sign)
+
+            sampled_sign = False
+            sampled_pauli = QubitSparsePauli.from_label("I")
+            for _i, (_g, _s) in enumerate(zip(_gens, _signs)):
+                if _g:
+                    sampled_sign = sampled_sign == _s
+                    sampled_pauli = sampled_pauli.compose(generators[_i])
+
+            self.assertEqual(sign, sampled_sign)
+            self.assertEqual(q, sampled_pauli)
+
+        for symbol, count in counts.items():
+            self.assertTrue(np.abs(count / num_samples - probs_dict[symbol]) < 1e-2)
+
     def test_parity_sample(self):
 
-        # test all negative rates
-        pauli_lindblad_map = PauliLindbladMap([("X", -1.0), ("Y", -0.5)])
-        probs = pauli_lindblad_map.probabilities()
-        probs_dict = {
-            "I": probs[0] * probs[1],
-            "X": (1 - probs[0]) * probs[1],
-            "Y": probs[0] * (1 - probs[1]),
-            "Z": (1 - probs[0]) * (1 - probs[1]),
-        }
-        expected_signs = {"I": False, "X": True, "Y": True, "Z": False}
+        with self.subTest("all negative rates"):
+            pauli_lindblad_map = PauliLindbladMap([("X", -1.0), ("Y", -0.5)])
+            expected_signs = {"I": False, "X": True, "Y": True, "Z": False}
 
-        num_samples = 10000
-        signs, qubit_sparse_pauli_list = pauli_lindblad_map.parity_sample(num_samples, 12312)
+            self._assert_parity_sample_results(pauli_lindblad_map, expected_signs)
 
-        counts = {"I": 0, "X": 0, "Y": 0, "Z": 0}
-        for sign, q in zip(signs, qubit_sparse_pauli_list):
-            for symbol in counts:
-                if q == QubitSparsePauli(symbol):
-                    counts[symbol] += 1
-                    self.assertEqual(expected_signs[symbol], sign)
+        with self.subTest("all positive rates"):
+            pauli_lindblad_map = PauliLindbladMap([("X", 1.0), ("Y", 0.5)])
+            expected_signs = {"I": False, "X": False, "Y": False, "Z": False}
 
-        for symbol, count in counts.items():
-            self.assertTrue(np.abs(count / num_samples - probs_dict[symbol]) < 1e-2)
+            self._assert_parity_sample_results(pauli_lindblad_map, expected_signs)
 
-        # test all positive rates
-        pauli_lindblad_map = PauliLindbladMap([("X", 1.0), ("Y", 0.5)])
-        probs = pauli_lindblad_map.probabilities()
-        probs_dict = {
-            "I": probs[0] * probs[1],
-            "X": (1 - probs[0]) * probs[1],
-            "Y": probs[0] * (1 - probs[1]),
-            "Z": (1 - probs[0]) * (1 - probs[1]),
-        }
-        expected_signs = {"I": False, "X": False, "Y": False, "Z": False}
+        with self.subTest("mix of positive and negative rates"):
+            pauli_lindblad_map = PauliLindbladMap([("X", 1.0), ("Y", -0.5)])
+            expected_signs = {"I": False, "X": False, "Y": True, "Z": True}
 
-        num_samples = 10000
-        signs, qubit_sparse_pauli_list = pauli_lindblad_map.parity_sample(num_samples, 12312)
+            self._assert_parity_sample_results(pauli_lindblad_map, expected_signs)
 
-        counts = {"I": 0, "X": 0, "Y": 0, "Z": 0}
-        for sign, q in zip(signs, qubit_sparse_pauli_list):
-            for symbol in counts:
-                if q == QubitSparsePauli(symbol):
-                    counts[symbol] += 1
-                    self.assertEqual(expected_signs[symbol], sign)
-        for symbol, count in counts.items():
-            self.assertTrue(np.abs(count / num_samples - probs_dict[symbol]) < 1e-2)
+        with self.subTest("scale with mix of positive and negative rates"):
+            pauli_lindblad_map = PauliLindbladMap([("X", 1.0), ("Y", -0.5)])
+            pauli_lindblad_map_downscaled = PauliLindbladMap([("X", 0.5), ("Y", -0.25)])
+            expected_signs = {"I": False, "X": False, "Y": True, "Z": True}
 
-        # test mix of positive and negative rates
+            self._assert_parity_sample_results(
+                pauli_lindblad_map_downscaled,
+                expected_signs,
+                scale=2.0,
+                plm_reference=pauli_lindblad_map,
+            )
+
+        with self.subTest("local_scale with mix of positive and negative rates"):
+            pauli_lindblad_map = PauliLindbladMap([("X", 1.0), ("Y", -0.5)])
+            pauli_lindblad_map_downscaled = PauliLindbladMap([("X", 1.0), ("Y", -0.25)])
+
+            self._assert_parity_sample_results(
+                pauli_lindblad_map_downscaled,
+                expected_signs,
+                local_scale=[1.0, 2.0],
+                plm_reference=pauli_lindblad_map,
+            )
+
+    def test_parity_sample_without_seed(self):
         pauli_lindblad_map = PauliLindbladMap([("X", 1.0), ("Y", -0.5)])
-        probs = pauli_lindblad_map.probabilities()
-        probs_dict = {
-            "I": probs[0] * probs[1],
-            "X": (1 - probs[0]) * probs[1],
-            "Y": probs[0] * (1 - probs[1]),
-            "Z": (1 - probs[0]) * (1 - probs[1]),
-        }
-        expected_signs = {"I": False, "X": False, "Y": True, "Z": True}
-
-        num_samples = 10000
-        signs, qubit_sparse_pauli_list = pauli_lindblad_map.parity_sample(num_samples, 12312)
-
-        counts = {"I": 0, "X": 0, "Y": 0, "Z": 0}
-        for sign, q in zip(signs, qubit_sparse_pauli_list):
-            for symbol in counts:
-                if q == QubitSparsePauli(symbol):
-                    counts[symbol] += 1
-                    self.assertEqual(expected_signs[symbol], sign)
-
-        for symbol, count in counts.items():
-            self.assertTrue(np.abs(count / num_samples - probs_dict[symbol]) < 1e-2)
-
-        # test scale with mix of positive and negative rates
-        pauli_lindblad_map = PauliLindbladMap([("X", 1.0), ("Y", -0.5)])
-        pauli_lindblad_map_downscaled = PauliLindbladMap([("X", 0.5), ("Y", -0.25)])
-        probs = pauli_lindblad_map.probabilities()
-        probs_dict = {
-            "I": probs[0] * probs[1],
-            "X": (1 - probs[0]) * probs[1],
-            "Y": probs[0] * (1 - probs[1]),
-            "Z": (1 - probs[0]) * (1 - probs[1]),
-        }
-        expected_signs = {"I": False, "X": False, "Y": True, "Z": True}
-
-        num_samples = 10000
-        signs, qubit_sparse_pauli_list = pauli_lindblad_map_downscaled.parity_sample(
-            num_samples, 12312, scale=2.0
-        )
-
-        counts = {"I": 0, "X": 0, "Y": 0, "Z": 0}
-        for sign, q in zip(signs, qubit_sparse_pauli_list):
-            for symbol in counts:
-                if q == QubitSparsePauli(symbol):
-                    counts[symbol] += 1
-                    self.assertEqual(expected_signs[symbol], sign)
-
-        for symbol, count in counts.items():
-            self.assertTrue(np.abs(count / num_samples - probs_dict[symbol]) < 1e-2)
-
-        # test local_scale with mix of positive and negative rates
-        pauli_lindblad_map = PauliLindbladMap([("X", 1.0), ("Y", -0.5)])
-        pauli_lindblad_map_downscaled = PauliLindbladMap([("X", 1.0), ("Y", -0.25)])
-        probs = pauli_lindblad_map.probabilities()
-        probs_dict = {
-            "I": probs[0] * probs[1],
-            "X": (1 - probs[0]) * probs[1],
-            "Y": probs[0] * (1 - probs[1]),
-            "Z": (1 - probs[0]) * (1 - probs[1]),
-        }
-        expected_signs = {"I": False, "X": False, "Y": True, "Z": True}
-
-        num_samples = 10000
-        signs, qubit_sparse_pauli_list = pauli_lindblad_map_downscaled.parity_sample(
-            num_samples, 12312, local_scale=[1.0, 2.0]
-        )
-
-        counts = {"I": 0, "X": 0, "Y": 0, "Z": 0}
-        for sign, q in zip(signs, qubit_sparse_pauli_list):
-            for symbol in counts:
-                if q == QubitSparsePauli(symbol):
-                    counts[symbol] += 1
-                    self.assertEqual(expected_signs[symbol], sign)
-
-        for symbol, count in counts.items():
-            self.assertTrue(np.abs(count / num_samples - probs_dict[symbol]) < 1e-2)
-
-        # test callable without seed
         signs, qubit_sparse_pauli_list = pauli_lindblad_map.parity_sample(5)
         self.assertTrue(isinstance(qubit_sparse_pauli_list, QubitSparsePauliList))
         self.assertEqual(len(qubit_sparse_pauli_list), 5)
         self.assertEqual(len(signs), 5)
-
-    def test_parity_sample_generators(self):
-
-        def assert_result(signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs):
-            counts = {"I": 0, "X": 0, "Y": 0, "Z": 0}
-            for sign, q, _gens, _signs in zip(
-                signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs
-            ):
-                for symbol in counts:
-                    if q == QubitSparsePauli(symbol):
-                        counts[symbol] += 1
-                        self.assertEqual(expected_signs[symbol], sign)
-
-                sampled_sign = False
-                sampled_pauli = QubitSparsePauli.from_label("I")
-                for _i, (_g, _s) in enumerate(zip(_gens, _signs)):
-                    if _g:
-                        sampled_sign = sampled_sign == _s
-                        sampled_pauli = sampled_pauli.compose(generators[_i])
-
-                self.assertEqual(sign, sampled_sign)
-                self.assertEqual(q, sampled_pauli)
-
-            for symbol, count in counts.items():
-                self.assertTrue(np.abs(count / num_samples - probs_dict[symbol]) < 1e-2)
-
-        # test all negative rates
-        pauli_lindblad_map = PauliLindbladMap([("X", -1.0), ("Y", -0.5)])
-        generators = pauli_lindblad_map.generators()
-        probs = pauli_lindblad_map.probabilities()
-        probs_dict = {
-            "I": probs[0] * probs[1],
-            "X": (1 - probs[0]) * probs[1],
-            "Y": probs[0] * (1 - probs[1]),
-            "Z": (1 - probs[0]) * (1 - probs[1]),
-        }
-        expected_signs = {"I": False, "X": True, "Y": True, "Z": False}
-
-        num_samples = 10000
-        signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs = (
-            pauli_lindblad_map.parity_sample_generators(num_samples, 12312)
-        )
-
-        assert_result(signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs)
-
-        # test all positive rates
-        pauli_lindblad_map = PauliLindbladMap([("X", 1.0), ("Y", 0.5)])
-        probs = pauli_lindblad_map.probabilities()
-        probs_dict = {
-            "I": probs[0] * probs[1],
-            "X": (1 - probs[0]) * probs[1],
-            "Y": probs[0] * (1 - probs[1]),
-            "Z": (1 - probs[0]) * (1 - probs[1]),
-        }
-        expected_signs = {"I": False, "X": False, "Y": False, "Z": False}
-
-        num_samples = 10000
-        signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs = (
-            pauli_lindblad_map.parity_sample_generators(num_samples, 12312)
-        )
-
-        assert_result(signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs)
-
-        # test mix of positive and negative rates
-        pauli_lindblad_map = PauliLindbladMap([("X", 1.0), ("Y", -0.5)])
-        probs = pauli_lindblad_map.probabilities()
-        probs_dict = {
-            "I": probs[0] * probs[1],
-            "X": (1 - probs[0]) * probs[1],
-            "Y": probs[0] * (1 - probs[1]),
-            "Z": (1 - probs[0]) * (1 - probs[1]),
-        }
-        expected_signs = {"I": False, "X": False, "Y": True, "Z": True}
-
-        num_samples = 10000
-        signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs = (
-            pauli_lindblad_map.parity_sample_generators(num_samples, 12312)
-        )
-
-        assert_result(signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs)
-
-        # test scale with mix of positive and negative rates
-        pauli_lindblad_map = PauliLindbladMap([("X", 1.0), ("Y", -0.5)])
-        pauli_lindblad_map_downscaled = PauliLindbladMap([("X", 0.5), ("Y", -0.25)])
-        probs = pauli_lindblad_map.probabilities()
-        probs_dict = {
-            "I": probs[0] * probs[1],
-            "X": (1 - probs[0]) * probs[1],
-            "Y": probs[0] * (1 - probs[1]),
-            "Z": (1 - probs[0]) * (1 - probs[1]),
-        }
-        expected_signs = {"I": False, "X": False, "Y": True, "Z": True}
-
-        num_samples = 10000
-        signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs = (
-            pauli_lindblad_map_downscaled.parity_sample_generators(num_samples, 12312, scale=2.0)
-        )
-
-        assert_result(signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs)
-
-        counts = {"I": 0, "X": 0, "Y": 0, "Z": 0}
-        for sign, q in zip(signs, qubit_sparse_pauli_list):
-            for symbol in counts:
-                if q == QubitSparsePauli(symbol):
-                    counts[symbol] += 1
-                    self.assertEqual(expected_signs[symbol], sign)
-
-        for symbol, count in counts.items():
-            self.assertTrue(np.abs(count / num_samples - probs_dict[symbol]) < 1e-2)
-
-        # test local_scale with mix of positive and negative rates
-        pauli_lindblad_map = PauliLindbladMap([("X", 1.0), ("Y", -0.5)])
-        pauli_lindblad_map_downscaled = PauliLindbladMap([("X", 1.0), ("Y", -0.25)])
-        probs = pauli_lindblad_map.probabilities()
-        probs_dict = {
-            "I": probs[0] * probs[1],
-            "X": (1 - probs[0]) * probs[1],
-            "Y": probs[0] * (1 - probs[1]),
-            "Z": (1 - probs[0]) * (1 - probs[1]),
-        }
-        expected_signs = {"I": False, "X": False, "Y": True, "Z": True}
-
-        num_samples = 10000
-        signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs = (
-            pauli_lindblad_map_downscaled.parity_sample_generators(
-                num_samples, 12312, local_scale=[1.0, 2.0]
-            )
-        )
-
-        assert_result(signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs)
 
     def test_sample(self):
         pauli_lindblad_map = PauliLindbladMap([("X", 1.0), ("Y", 0.5)])

--- a/test/python/quantum_info/test_pauli_lindblad_map.py
+++ b/test/python/quantum_info/test_pauli_lindblad_map.py
@@ -1372,6 +1372,136 @@ class TestPauliLindbladMap(QiskitTestCase):
         self.assertEqual(len(qubit_sparse_pauli_list), 5)
         self.assertEqual(len(signs), 5)
 
+    def test_parity_sample_generators(self):
+
+        def assert_result(signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs):
+            counts = {"I": 0, "X": 0, "Y": 0, "Z": 0}
+            for sign, q, _gens, _signs in zip(
+                signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs
+            ):
+                for symbol in counts:
+                    if q == QubitSparsePauli(symbol):
+                        counts[symbol] += 1
+                        self.assertEqual(expected_signs[symbol], sign)
+
+                sampled_sign = False
+                sampled_pauli = QubitSparsePauli.from_label("I")
+                for _i, (_g, _s) in enumerate(zip(_gens, _signs)):
+                    if _g:
+                        sampled_sign = sampled_sign == _s
+                        sampled_pauli = sampled_pauli.compose(generators[_i])
+
+                self.assertEqual(sign, sampled_sign)
+                self.assertEqual(q, sampled_pauli)
+
+            for symbol, count in counts.items():
+                self.assertTrue(np.abs(count / num_samples - probs_dict[symbol]) < 1e-2)
+
+        # test all negative rates
+        pauli_lindblad_map = PauliLindbladMap([("X", -1.0), ("Y", -0.5)])
+        generators = pauli_lindblad_map.generators()
+        probs = pauli_lindblad_map.probabilities()
+        probs_dict = {
+            "I": probs[0] * probs[1],
+            "X": (1 - probs[0]) * probs[1],
+            "Y": probs[0] * (1 - probs[1]),
+            "Z": (1 - probs[0]) * (1 - probs[1]),
+        }
+        expected_signs = {"I": False, "X": True, "Y": True, "Z": False}
+
+        num_samples = 10000
+        signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs = (
+            pauli_lindblad_map.parity_sample_generators(num_samples, 12312)
+        )
+
+        assert_result(signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs)
+
+        # test all positive rates
+        pauli_lindblad_map = PauliLindbladMap([("X", 1.0), ("Y", 0.5)])
+        probs = pauli_lindblad_map.probabilities()
+        probs_dict = {
+            "I": probs[0] * probs[1],
+            "X": (1 - probs[0]) * probs[1],
+            "Y": probs[0] * (1 - probs[1]),
+            "Z": (1 - probs[0]) * (1 - probs[1]),
+        }
+        expected_signs = {"I": False, "X": False, "Y": False, "Z": False}
+
+        num_samples = 10000
+        signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs = (
+            pauli_lindblad_map.parity_sample_generators(num_samples, 12312)
+        )
+
+        assert_result(signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs)
+
+        # test mix of positive and negative rates
+        pauli_lindblad_map = PauliLindbladMap([("X", 1.0), ("Y", -0.5)])
+        probs = pauli_lindblad_map.probabilities()
+        probs_dict = {
+            "I": probs[0] * probs[1],
+            "X": (1 - probs[0]) * probs[1],
+            "Y": probs[0] * (1 - probs[1]),
+            "Z": (1 - probs[0]) * (1 - probs[1]),
+        }
+        expected_signs = {"I": False, "X": False, "Y": True, "Z": True}
+
+        num_samples = 10000
+        signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs = (
+            pauli_lindblad_map.parity_sample_generators(num_samples, 12312)
+        )
+
+        assert_result(signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs)
+
+        # test scale with mix of positive and negative rates
+        pauli_lindblad_map = PauliLindbladMap([("X", 1.0), ("Y", -0.5)])
+        pauli_lindblad_map_downscaled = PauliLindbladMap([("X", 0.5), ("Y", -0.25)])
+        probs = pauli_lindblad_map.probabilities()
+        probs_dict = {
+            "I": probs[0] * probs[1],
+            "X": (1 - probs[0]) * probs[1],
+            "Y": probs[0] * (1 - probs[1]),
+            "Z": (1 - probs[0]) * (1 - probs[1]),
+        }
+        expected_signs = {"I": False, "X": False, "Y": True, "Z": True}
+
+        num_samples = 10000
+        signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs = (
+            pauli_lindblad_map_downscaled.parity_sample_generators(num_samples, 12312, scale=2.0)
+        )
+
+        assert_result(signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs)
+
+        counts = {"I": 0, "X": 0, "Y": 0, "Z": 0}
+        for sign, q in zip(signs, qubit_sparse_pauli_list):
+            for symbol in counts:
+                if q == QubitSparsePauli(symbol):
+                    counts[symbol] += 1
+                    self.assertEqual(expected_signs[symbol], sign)
+
+        for symbol, count in counts.items():
+            self.assertTrue(np.abs(count / num_samples - probs_dict[symbol]) < 1e-2)
+
+        # test local_scale with mix of positive and negative rates
+        pauli_lindblad_map = PauliLindbladMap([("X", 1.0), ("Y", -0.5)])
+        pauli_lindblad_map_downscaled = PauliLindbladMap([("X", 1.0), ("Y", -0.25)])
+        probs = pauli_lindblad_map.probabilities()
+        probs_dict = {
+            "I": probs[0] * probs[1],
+            "X": (1 - probs[0]) * probs[1],
+            "Y": probs[0] * (1 - probs[1]),
+            "Z": (1 - probs[0]) * (1 - probs[1]),
+        }
+        expected_signs = {"I": False, "X": False, "Y": True, "Z": True}
+
+        num_samples = 10000
+        signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs = (
+            pauli_lindblad_map_downscaled.parity_sample_generators(
+                num_samples, 12312, local_scale=[1.0, 2.0]
+            )
+        )
+
+        assert_result(signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs)
+
     def test_sample(self):
         pauli_lindblad_map = PauliLindbladMap([("X", 1.0), ("Y", 0.5)])
         probs = pauli_lindblad_map.probabilities()

--- a/test/python/quantum_info/test_pauli_lindblad_map.py
+++ b/test/python/quantum_info/test_pauli_lindblad_map.py
@@ -458,7 +458,7 @@ class TestPauliLindbladMap(QiskitTestCase):
         with self.assertRaisesRegex(ValueError, "assignment destination is read-only"):
             pauli_lindblad_map.rates[0] = 1.0
 
-    def test_generators(self):
+    def test_with_history(self):
         """Test that generators() method returns the same result as
         get_qubit_sparse_pauli_list_copy()."""
         pauli_lindblad_map = PauliLindbladMap.from_list([("IIXIZ", 2), ("IIZIX", 3)])
@@ -1261,14 +1261,14 @@ class TestPauliLindbladMap(QiskitTestCase):
             "Z": (1 - probs[0]) * (1 - probs[1]),
         }
 
-        signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs = (
-            plm_to_sample.parity_sample_generators(
+        signs, qubit_sparse_pauli_list, sampled_with_history, sampled_signs = (
+            plm_to_sample.parity_sample_with_history(
                 num_samples, seed, scale=scale, local_scale=local_scale
             )
         )
         counts = {"I": 0, "X": 0, "Y": 0, "Z": 0}
         for sign, q, _gens, _signs in zip(
-            signs, qubit_sparse_pauli_list, sampled_generators, sampled_signs
+            signs, qubit_sparse_pauli_list, sampled_with_history, sampled_signs
         ):
             for symbol in counts:
                 if q == QubitSparsePauli(symbol):


### PR DESCRIPTION
This introduces a new variant of `PauliLindbladMap.parity_sample` which also tracks the generators that resulted in the sampled Pauli operators and signs. This information is required from some advanced post-processing we wish to do in Shaded-Lightcone experiments.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->