### PR TITLE
Fix forced block consolidation for incomplete basis sets

### DIFF
--- a/qiskit/transpiler/passes/optimization/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/optimization/consolidate_blocks.py
@@ -123,6 +123,11 @@ class ConsolidateBlocks(TransformationPass):
                     basis_fidelity=approximation_degree or 1.0,
                 )
                 self.basis_gate_name = next(iter(kak_gates))
+            elif force_consolidate:
+                # if we haven't found a decomposer but consolidation is forced,
+                # pick a default
+                self.decomposer = TwoQubitBasisDecomposer(CXGate())
+                self.basis_gate_name = "cx"
             else:
                 self.decomposer = None
         else:

--- a/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
+++ b/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
@@ -93,9 +93,10 @@ def generate_preset_pass_manager(
 
     .. note::
 
-        When the target basis consists of Clifford+T gates and no layout, routing, or translation
-        methods are set, this function constructs a specialized Clifford+T transpiler pipeline.
-        See :func:`.clifford_t_pass_manager` for more documentation.
+        When the target basis consists of Clifford+T gates, this function constructs
+        a specialized Clifford+T transpiler pipeline, see :func:`.clifford_t_pass_manager`
+        for documentation. The arguments that apply to transpiling into continuous basis sets
+        are ignored in this flow.
 
     Args:
         optimization_level (int): The optimization level to generate a

--- a/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
+++ b/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
@@ -93,10 +93,9 @@ def generate_preset_pass_manager(
 
     .. note::
 
-        When the target basis consists of Clifford+T gates, this function constructs
-        a specialized Clifford+T transpiler pipeline, see :func:`.clifford_t_pass_manager`
-        for documentation. The arguments that apply to transpiling into continuous basis sets
-        are ignored in this flow.
+        When the target basis consists of Clifford+T gates and no layout, routing, or translation
+        methods are set, this function constructs a specialized Clifford+T transpiler pipeline.
+        See :func:`.clifford_t_pass_manager` for more documentation.
 
     Args:
         optimization_level (int): The optimization level to generate a

--- a/releasenotes/notes/fix-forced-consolidate-blocks-bde22149903da7da.yaml
+++ b/releasenotes/notes/fix-forced-consolidate-blocks-bde22149903da7da.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`.ConsolidateBlocks` when ``force_consolidate=True``,
+    where the blocks and runs were not consolidated if the basis gates did not
+    allow selecting a decomposer.
+

--- a/test/python/transpiler/test_consolidate_blocks.py
+++ b/test/python/transpiler/test_consolidate_blocks.py
@@ -768,6 +768,21 @@ class TestConsolidateBlocks(QiskitTestCase):
         with self.assertRaisesRegex(IndexError, "node index.*was not a valid operation"):
             pass_.run(dag)
 
+    def test_force_consolidate_incomplete_basis(self):
+        """Test force_consolidate works even if the basis doesn't allow selecting a decomposer."""
+        qc = QuantumCircuit(1)
+        qc.rx(0.2, 0)
+
+        pm = PassManager(
+            [
+                Collect1qRuns(),
+                ConsolidateBlocks(basis_gates=["u"], force_consolidate=True),
+            ]
+        )
+
+        out = pm.run(qc)
+        self.assertEqual(set(out.count_ops().keys()), {"unitary"})
+
 
 class TestCollect1qRuns(QiskitTestCase):
     """


### PR DESCRIPTION
In case the `target` or `basis_gates` were passed into `ConsolidateBlocks`, but were not sufficiently expressive to choose a decomposer,  the decomposer was set to None and no blocks or runs were consolidated. This was even the case if `force_consolidate=True`, which should force consolidation. This commits addresses this by using a default CX-based decomposer, as is also done when neither a `target` nor `basis_gates` is set.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
