### PR TITLE
Fix QPY loading delay integers durations incorrectly

### DIFF
--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -704,24 +704,7 @@ fn unpack_py_instruction(
     qpy_data: &mut QPYReadData,
 ) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
     let name = instruction.gate_class_name.clone();
-    // Ints on control flow expressions are part of expressions which are encoded as big endian
-    // BoxOp however uses floats or ints for duration as part of params which are little endian
-    // All other gates are using little endian for float or int params
-    let endian = if [
-        "IfElseOp",
-        "ForLoopOp",
-        "WhileLoopOp",
-        "SwitchCaseOp",
-        "BreakLoopOp",
-        "ContinueLoopOp",
-    ]
-    .contains(&name.as_str())
-    {
-        Endian::Big
-    } else {
-        Endian::Little
-    };
-    let mut instruction_values = get_instruction_values(instruction, qpy_data, endian)?;
+    let mut instruction_values = get_instruction_values(instruction, qpy_data, Endian::Little)?;
     Python::attach(|py| -> Result<_, QpyError> {
         let mut py_params: Vec<Bound<PyAny>> = instruction_values
             .iter()

--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -19,7 +19,7 @@
 // Ideally, serialization is done by packing in a binrw-enhanced struct and using the
 // `write` method into a `Cursor` buffer, but there might be exceptions.
 
-use binrw::Endian::Little;
+use binrw::Endian;
 use hashbrown::HashMap;
 use num_bigint::BigUint;
 use num_complex::Complex64;
@@ -48,7 +48,6 @@ use qiskit_circuit::operations::{
 };
 use qiskit_circuit::packed_instruction::{PackedInstruction, PackedOperation};
 use qiskit_circuit::parameter::parameter_expression::ParameterExpression;
-use qiskit_circuit::parameter::symbol_expr;
 use qiskit_circuit::var_stretch_container::{StretchType, VarType};
 use qiskit_circuit::{Block, classical, imports};
 use qiskit_circuit::{Clbit, Qubit};
@@ -153,7 +152,7 @@ fn unpack_condition(
     match &condition_pack.data {
         ConditionData::None => Ok(None),
         ConditionData::Expression(exp_pack) => {
-            let exp_value = unpack_generic_value(exp_pack, qpy_data)?;
+            let exp_value = unpack_generic_value(exp_pack, qpy_data, Endian::Big)?;
             match exp_value {
                 GenericValue::Expression(exp) => Ok(Some(Condition::Expr(exp.clone()))),
                 _ => Err(QpyError::InvalidExpression(
@@ -243,13 +242,16 @@ fn get_instruction_bits(
 fn get_instruction_values(
     instruction: &formats::CircuitInstructionV2Pack,
     qpy_data: &mut QPYReadData,
+    endian: Endian,
 ) -> Result<Vec<GenericValue>, QpyError> {
     // note that numbers are not read correctly - they are read in big endian, but for instruction parameters, due to historical reasons,
     // they are stored in little endian
     let inst_params: Vec<GenericValue> = instruction
         .params
         .iter()
-        .map(|packed_param: &formats::GenericDataPack| unpack_generic_value(packed_param, qpy_data))
+        .map(|packed_param: &formats::GenericDataPack| {
+            unpack_generic_value(packed_param, qpy_data, endian)
+        })
         .collect::<Result<_, QpyError>>()?;
     Ok(inst_params)
 }
@@ -287,18 +289,10 @@ pub fn instruction_values_to_params(
     } else {
         // params
         let inst_params: Vec<Param> = values
-            .iter()
+            .into_iter()
             .map(|value| -> Result<_, QpyError> {
-                match value.as_le() {
-                    // TODO: is the "as_le" here enough to solve the "params are little endian" problem?
+                match value {
                     GenericValue::Float64(float) => Ok(Param::Float(float)),
-                    GenericValue::Int64(int) => {
-                        let value_expression =
-                            symbol_expr::SymbolExpr::Value(symbol_expr::Value::Int(int));
-                        Ok(Param::ParameterExpression(Arc::new(
-                            ParameterExpression::from_symbol_expr(value_expression),
-                        )))
-                    }
                     GenericValue::ParameterExpression(exp) => Ok(Param::ParameterExpression(exp)),
                     GenericValue::ParameterExpressionSymbol(symbol) => {
                         Ok(Param::ParameterExpression(Arc::new(
@@ -310,7 +304,7 @@ pub fn instruction_values_to_params(
                             ParameterExpression::from_symbol(symbol),
                         )))
                     }
-                    _ => Ok(Param::Obj(py_convert_from_generic_value(value)?)),
+                    _ => Ok(Param::Obj(py_convert_from_generic_value(&value)?)),
                 }
             })
             .collect::<Result<_, QpyError>>()?;
@@ -403,7 +397,7 @@ fn unpack_standard_gate(
             instruction.gate_class_name
         )));
     };
-    let param_values = get_instruction_values(instruction, qpy_data)?;
+    let param_values = get_instruction_values(instruction, qpy_data, Endian::Little)?;
     Ok((op, param_values))
 }
 
@@ -420,7 +414,7 @@ fn unpack_standard_instruction(
             instruction.gate_class_name
         )));
     };
-    let param_values = get_instruction_values(instruction, qpy_data)?;
+    let param_values = get_instruction_values(instruction, qpy_data, Endian::Little)?;
     Ok((op, param_values))
 }
 
@@ -433,21 +427,21 @@ fn unpack_pauli_product_measurement(
             "Pauli Product Measurement should have exactly 3 parameters".to_string(),
         ));
     }
-    let z = unpack_generic_value(&instruction.params[0], qpy_data)?
+    let z = unpack_generic_value(&instruction.params[0], qpy_data, Endian::Little)?
         .as_typed::<Vec<bool>>()
         .ok_or_else(|| {
             QpyError::InvalidParameter(
                 "Pauli product measurement z parameter should be a boolean vector".to_string(),
             )
         })?;
-    let x = unpack_generic_value(&instruction.params[1], qpy_data)?
+    let x = unpack_generic_value(&instruction.params[1], qpy_data, Endian::Little)?
         .as_typed::<Vec<bool>>()
         .ok_or_else(|| {
             QpyError::InvalidParameter(
                 "Pauli product measurement x parameter should be a boolean vector".to_string(),
             )
         })?;
-    let neg = unpack_generic_value(&instruction.params[2], qpy_data)?
+    let neg = unpack_generic_value(&instruction.params[2], qpy_data, Endian::Little)?
         .as_typed::<bool>()
         .ok_or_else(|| {
             QpyError::InvalidParameter(
@@ -470,22 +464,22 @@ fn unpack_pauli_product_rotation(
             "No matrix for unitary op".to_string(),
         ));
     }
-    let z = unpack_generic_value(&instruction.params[0], qpy_data)?
+    let z = unpack_generic_value(&instruction.params[0], qpy_data, Endian::Little)?
         .as_typed::<Vec<bool>>()
         .ok_or_else(|| {
             QpyError::InvalidParameter(
                 "Pauli product measurement z parameter should be a boolean vector".to_string(),
             )
         })?;
-    let x = unpack_generic_value(&instruction.params[1], qpy_data)?
+    let x = unpack_generic_value(&instruction.params[1], qpy_data, Endian::Little)?
         .as_typed::<Vec<bool>>()
         .ok_or_else(|| {
             QpyError::InvalidParameter(
                 "Pauli product measurement x parameter should be a boolean vector".to_string(),
             )
         })?;
-    let angle_value = unpack_generic_value(&instruction.params[2], qpy_data)?;
-    let angle = generic_value_to_param(&angle_value, Little)?;
+    let angle_value = unpack_generic_value(&instruction.params[2], qpy_data, Endian::Little)?;
+    let angle = generic_value_to_param(&angle_value)?;
     let rotation = PauliProductRotation { z, x, angle };
     let pbc = Box::new(PauliBased::PauliProductRotation(rotation));
     let op = PackedOperation::from_pauli_based(pbc);
@@ -498,7 +492,7 @@ fn unpack_unitary(
     qpy_data: &mut QPYReadData,
 ) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
     let GenericValue::NumpyObject(py_matrix) =
-        unpack_generic_value(&instruction.params[0], qpy_data)?
+        unpack_generic_value(&instruction.params[0], qpy_data, Endian::Little)?
     else {
         return Err(QpyError::InvalidParameter(
             "No matrix for unitary op".to_string(),
@@ -543,7 +537,7 @@ fn unpack_control_flow(
                 .params
                 .iter()
                 .skip(1)
-                .map(|param| unpack_generic_value(param, qpy_data))
+                .map(|param| unpack_generic_value(param, qpy_data, Endian::Little))
                 .collect::<Result<_, QpyError>>()?;
             let duration_value = if let Some(duration_pack) = instruction.params.first() {
                 unpack_duration_value(duration_pack, qpy_data)?
@@ -566,7 +560,8 @@ fn unpack_control_flow(
         ControlFlowType::BreakLoop => ControlFlow::BreakLoop,
         ControlFlowType::ContinueLoop => ControlFlow::ContinueLoop,
         ControlFlowType::ForLoop => {
-            let mut instruction_values = get_instruction_values(instruction, qpy_data)?;
+            let mut instruction_values =
+                get_instruction_values(instruction, qpy_data, Endian::Big)?;
             param_values = instruction_values.split_off(2);
             let mut iter = instruction_values.into_iter();
             let (mut collection_value_pack, loop_param_value_pack) =
@@ -590,17 +585,18 @@ fn unpack_control_flow(
         ControlFlowType::IfElse => {
             let condition = unpack_condition(&instruction.condition, qpy_data)?
                 .ok_or_else(|| QpyError::MissingData("if else condition is missing".to_string()))?;
-            param_values = get_instruction_values(instruction, qpy_data)?;
+            param_values = get_instruction_values(instruction, qpy_data, Endian::Big)?;
             ControlFlow::IfElse { condition }
         }
         ControlFlowType::WhileLoop => {
             let condition = unpack_condition(&instruction.condition, qpy_data)?
                 .ok_or_else(|| QpyError::MissingData("if else condition is missing".to_string()))?;
-            param_values = get_instruction_values(instruction, qpy_data)?;
+            param_values = get_instruction_values(instruction, qpy_data, Endian::Big)?;
             ControlFlow::While { condition }
         }
         ControlFlowType::SwitchCase => {
-            let mut instruction_values = get_instruction_values(instruction, qpy_data)?;
+            let mut instruction_values =
+                get_instruction_values(instruction, qpy_data, Endian::Big)?;
             let (target_value, case_label_list) = if instruction_values.len() < 3 {
                 // we follow the python way of storing switch params
                 // the first param is the target, the next param is the cases specifier
@@ -708,12 +704,29 @@ fn unpack_py_instruction(
     qpy_data: &mut QPYReadData,
 ) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
     let name = instruction.gate_class_name.clone();
-    let mut instruction_values = get_instruction_values(instruction, qpy_data)?;
+    // Ints on control flow expressions are part of expressions which are encoded as big endian
+    // BoxOp however uses floats or ints for duration as part of params which are little endian
+    // All other gates are using little endian for float or int params
+    let endian = if [
+        "IfElseOp",
+        "ForLoopOp",
+        "WhileLoopOp",
+        "SwitchCaseOp",
+        "BreakLoopOp",
+        "ContinueLoopOp",
+    ]
+    .contains(&name.as_str())
+    {
+        Endian::Big
+    } else {
+        Endian::Little
+    };
+    let mut instruction_values = get_instruction_values(instruction, qpy_data, endian)?;
     Python::attach(|py| -> Result<_, QpyError> {
         let mut py_params: Vec<Bound<PyAny>> = instruction_values
             .iter()
             .map(|value| -> Result<_, QpyError> {
-                generic_value_to_param(value, binrw::Endian::Little)?
+                generic_value_to_param(value)?
                     .into_pyobject(py)
                     .map_err(QpyError::from)
             })
@@ -872,12 +885,12 @@ fn unpack_custom_instruction(
     let custom_instruction = custom_instructions_map.get(&name).ok_or_else(|| {
         QpyError::MissingData("Custom instruction data not found for {name}".to_string())
     })?;
-    let instruction_values = get_instruction_values(instruction, qpy_data)?;
+    let instruction_values = get_instruction_values(instruction, qpy_data, Endian::Little)?;
     Python::attach(|py| -> Result<_, QpyError> {
         let py_params: Vec<Bound<PyAny>> = instruction_values
             .iter()
             .map(|value| -> Result<_, QpyError> {
-                generic_value_to_param(value, binrw::Endian::Little)?
+                generic_value_to_param(value)?
                     .into_pyobject(py)
                     .map_err(QpyError::from)
             })
@@ -1171,8 +1184,12 @@ fn deserialize_pauli_evolution_gate(
                 sparse_pauli_op_pack,
             )) => {
                 // formats::PauliDataPack::SparsePauliOp(sparse_pauli_op_pack) => {
-                let data =
-                    load_value(ValueType::NumpyObject, &sparse_pauli_op_pack.data, qpy_data)?;
+                let data = load_value(
+                    ValueType::NumpyObject,
+                    &sparse_pauli_op_pack.data,
+                    qpy_data,
+                    Endian::Big,
+                )?;
                 if let GenericValue::NumpyObject(op_raw_data) = data {
                     Ok(imports::SPARSE_PAULI_OP
                         .get_bound(py)
@@ -1193,7 +1210,12 @@ fn deserialize_pauli_evolution_gate(
     };
     // time is of type ParameterValueType = Union[ParameterExpression, float]
     // we don't have a rust PauliEvolutionGate so we'll convert the time to python
-    let time = load_value(packed_data.time_type, &packed_data.time_data, qpy_data)?;
+    let time = load_value(
+        packed_data.time_type,
+        &packed_data.time_data,
+        qpy_data,
+        Endian::Big,
+    )?;
     let py_time: Py<PyAny> = match time {
         GenericValue::Float64(value) => value.into_py_any(py)?,
         GenericValue::ParameterExpression(exp) => exp.as_ref().clone().into_py_any(py)?,
@@ -1499,14 +1521,12 @@ pub(crate) fn unpack_circuit(
             .annotation_handler
             .load_deserializers(annotation_deserializers_data)?;
     }
-    let global_phase = generic_value_to_param(
-        &load_value(
-            packed_circuit.header.global_phase_type,
-            &packed_circuit.header.global_phase_data,
-            &mut qpy_data,
-        )?,
-        binrw::Endian::Big,
-    )?;
+    let global_phase = generic_value_to_param(&load_value(
+        packed_circuit.header.global_phase_type,
+        &packed_circuit.header.global_phase_data,
+        &mut qpy_data,
+        Endian::Big,
+    )?)?;
     qpy_data.circuit_data.set_global_phase_param(global_phase)?;
     add_standalone_vars(packed_circuit, &mut qpy_data)?;
     add_registers_and_bits(packed_circuit, &mut qpy_data)?;

--- a/crates/qpy/src/expr.rs
+++ b/crates/qpy/src/expr.rs
@@ -92,7 +92,7 @@ pub(crate) fn unpack_expression_value(
             ty,
         },
         ExpressionValueElementPack::Int(val) => Value::Uint {
-            raw: unpack_biguint(val),
+            raw: unpack_biguint(val, Endian::Big),
             ty,
         },
         ExpressionValueElementPack::Duration(duration) => {

--- a/crates/qpy/src/expr.rs
+++ b/crates/qpy/src/expr.rs
@@ -92,7 +92,7 @@ pub(crate) fn unpack_expression_value(
             ty,
         },
         ExpressionValueElementPack::Int(val) => Value::Uint {
-            raw: unpack_biguint(val, Endian::Big),
+            raw: unpack_biguint(val),
             ty,
         },
         ExpressionValueElementPack::Duration(duration) => {

--- a/crates/qpy/src/params.rs
+++ b/crates/qpy/src/params.rs
@@ -451,6 +451,7 @@ pub(crate) fn unpack_parameter_expression(
                             item.item_type,
                             &item.item_bytes,
                             qpy_data,
+                            Endian::Big,
                         )?)?;
                         Ok((sym, replacement))
                     })
@@ -628,14 +629,7 @@ pub(crate) fn pack_param_obj(
     })
 }
 
-pub(crate) fn generic_value_to_param(
-    value: &GenericValue,
-    endian: Endian,
-) -> Result<Param, QpyError> {
-    let value = match endian {
-        Endian::Big => value,
-        Endian::Little => &value.as_le(),
-    };
+pub(crate) fn generic_value_to_param(value: &GenericValue) -> Result<Param, QpyError> {
     match value {
         GenericValue::Float64(float_val) => Ok(Param::Float(*float_val)),
         GenericValue::ParameterExpressionSymbol(symbol) => {

--- a/crates/qpy/src/value.rs
+++ b/crates/qpy/src/value.rs
@@ -105,8 +105,11 @@ pub(crate) fn pack_biguint(bigint: &BigUint) -> BigIntPack {
     BigIntPack { bytes }
 }
 
-pub(crate) fn unpack_biguint(big_int_pack: BigIntPack) -> BigUint {
-    BigUint::from_bytes_be(&big_int_pack.bytes)
+pub(crate) fn unpack_biguint(big_int_pack: BigIntPack, endian: Endian) -> BigUint {
+    match endian {
+        Endian::Little => BigUint::from_bytes_le(&big_int_pack.bytes),
+        Endian::Big => BigUint::from_bytes_be(&big_int_pack.bytes),
+    }
 }
 
 // Data that is needed globally while writing the circuit
@@ -405,10 +408,25 @@ impl<T: FromGenericValue> FromGenericValue for Vec<T> {
     }
 }
 
+/// Load a bytes array value of a specified type
+///
+/// # Args
+///
+/// * `type_key` - The type of the data
+/// * `bytes` - The raw data as a u8 array
+/// * `qpy_data` - QPY reader metadata
+/// * `endian` - The endianess of the data used only for reading
+///   `ValueType::Integer` and `ValueType::Float` primitive types
+///   (this applies recursively for `ValueType::Tuple` too). All other
+///   data is big endian per the QPY format documentation. The use of
+///   little endian data for floats and integers in instruction parameter
+///   contexts only is an oversight/mistake in the QPY implementation for
+///   format versions <=17. All data is supposed to be network byte order.
 pub(crate) fn load_value(
     type_key: ValueType,
     bytes: &Bytes,
     qpy_data: &mut QPYReadData,
+    endian: Endian,
 ) -> Result<GenericValue, QpyError> {
     match type_key {
         ValueType::Bool => {
@@ -417,15 +435,21 @@ pub(crate) fn load_value(
         }
         ValueType::Integer => {
             // a little tricky since this can be either i64 or biguint
-            let result = bytes.try_into();
-            if let Ok(value) = result {
-                Ok(GenericValue::Int64(value))
+            if bytes.len() <= 8 {
+                let mut bytes_array: [u8; 8] = [0; 8];
+                for (idx, byte) in bytes.iter().enumerate() {
+                    bytes_array[idx] = *byte;
+                }
+                match endian {
+                    Endian::Little => Ok(GenericValue::Int64(i64::from_le_bytes(bytes_array))),
+                    Endian::Big => Ok(GenericValue::Int64(i64::from_be_bytes(bytes_array))),
+                }
             } else {
-                load_biguint_value(bytes)
+                load_biguint_value(bytes, endian)
             }
         }
         ValueType::Float => {
-            let value: f64 = bytes.try_into()?;
+            let value: f64 = bytes.try_to_f64(endian)?;
             Ok(GenericValue::Float64(value))
         }
         ValueType::Complex => {
@@ -465,7 +489,7 @@ pub(crate) fn load_value(
         }
         ValueType::Tuple => {
             let (elements_pack, _) = deserialize::<GenericDataSequencePack>(bytes)?;
-            let values = unpack_generic_value_sequence(elements_pack, qpy_data)?;
+            let values = unpack_generic_value_sequence(elements_pack, qpy_data, endian)?;
             Ok(GenericValue::Tuple(values))
         }
         ValueType::NumpyObject => {
@@ -507,9 +531,9 @@ pub(crate) fn load_value(
 
 // a specialized method used for biguints (marked by 'i' like Int64)
 // since the general load method will attempt to load a Int64 instead
-pub(crate) fn load_biguint_value(bytes: &Bytes) -> Result<GenericValue, QpyError> {
+pub(crate) fn load_biguint_value(bytes: &Bytes, endian: Endian) -> Result<GenericValue, QpyError> {
     let (bigint_pack, _) = deserialize::<BigIntPack>(bytes)?;
-    let bigint = unpack_biguint(bigint_pack);
+    let bigint = unpack_biguint(bigint_pack, endian);
     Ok(GenericValue::BigInt(bigint))
 }
 
@@ -619,8 +643,9 @@ pub(crate) fn pack_generic_value(
 pub(crate) fn unpack_generic_value(
     value_pack: &GenericDataPack,
     qpy_data: &mut QPYReadData,
+    endian: Endian,
 ) -> Result<GenericValue, QpyError> {
-    let result = load_value(value_pack.type_key, &value_pack.data, qpy_data)?;
+    let result = load_value(value_pack.type_key, &value_pack.data, qpy_data, endian)?;
     Ok(result)
 }
 
@@ -636,7 +661,7 @@ pub(crate) fn unpack_duration_value(
             let duration = unpack_duration(deserialize::<DurationPack>(&value_pack.data)?.0);
             Ok(GenericValue::Duration(duration))
         }
-        _ => unpack_generic_value(value_pack, qpy_data), // fallback (duration can also be expression)
+        _ => unpack_generic_value(value_pack, qpy_data, Endian::Little), // fallback (duration can also be expression)
     }
 }
 
@@ -690,11 +715,12 @@ pub(crate) fn pack_generic_value_sequence(
 pub(crate) fn unpack_generic_value_sequence(
     value_seqeunce_pack: GenericDataSequencePack,
     qpy_data: &mut QPYReadData,
+    endian: Endian,
 ) -> Result<Vec<GenericValue>, QpyError> {
     value_seqeunce_pack
         .elements
         .iter()
-        .map(|data_pack| unpack_generic_value(data_pack, qpy_data))
+        .map(|data_pack| unpack_generic_value(data_pack, qpy_data, endian))
         .collect()
 }
 

--- a/crates/qpy/src/value.rs
+++ b/crates/qpy/src/value.rs
@@ -105,11 +105,8 @@ pub(crate) fn pack_biguint(bigint: &BigUint) -> BigIntPack {
     BigIntPack { bytes }
 }
 
-pub(crate) fn unpack_biguint(big_int_pack: BigIntPack, endian: Endian) -> BigUint {
-    match endian {
-        Endian::Little => BigUint::from_bytes_le(&big_int_pack.bytes),
-        Endian::Big => BigUint::from_bytes_be(&big_int_pack.bytes),
-    }
+pub(crate) fn unpack_biguint(big_int_pack: BigIntPack) -> BigUint {
+    BigUint::from_bytes_be(&big_int_pack.bytes)
 }
 
 // Data that is needed globally while writing the circuit
@@ -445,7 +442,7 @@ pub(crate) fn load_value(
                     Endian::Big => Ok(GenericValue::Int64(i64::from_be_bytes(bytes_array))),
                 }
             } else {
-                load_biguint_value(bytes, endian)
+                load_biguint_value(bytes)
             }
         }
         ValueType::Float => {
@@ -531,9 +528,9 @@ pub(crate) fn load_value(
 
 // a specialized method used for biguints (marked by 'i' like Int64)
 // since the general load method will attempt to load a Int64 instead
-pub(crate) fn load_biguint_value(bytes: &Bytes, endian: Endian) -> Result<GenericValue, QpyError> {
+pub(crate) fn load_biguint_value(bytes: &Bytes) -> Result<GenericValue, QpyError> {
     let (bigint_pack, _) = deserialize::<BigIntPack>(bytes)?;
-    let bigint = unpack_biguint(bigint_pack, endian);
+    let bigint = unpack_biguint(bigint_pack);
     Ok(GenericValue::BigInt(bigint))
 }
 

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -431,7 +431,8 @@ versions, the file header is immediately followed by the circuit payloads in seq
 without any padding in-between.
 
 All values use network byte order [#f1]_ (big endian) for cross platform
-compatibility.
+compatibility. The exception to this is for QPY format versions <= 17 the encoding of
+integers and floats as part of ``INSTRUCTION_PARAM`` is little endian.
 
 Each individual circuit is composed of the following parts in order from top to bottom:
 

--- a/releasenotes/notes/fix-qpy-int-538032980959ea37.yaml
+++ b/releasenotes/notes/fix-qpy-int-538032980959ea37.yaml
@@ -1,15 +1,7 @@
 ---
 fixes:
   - |
-    Fixed an issue in the :func:`.qpy.load` function when reading QPY payloads using
-    QPY format versions >=13 that contained a circuit which contained :class:`.Delay`
-    instructions that had an integer duration value with a duration unit of ``"dt"``
-    were incorrectly loaded through a :class:`.ParameterExpression` as part of the
-    deserialization process. This typically wasn't visible through Python as the
-    :class:`.ParameterExpression` was coerced into an integer when it was accessed
-    from Python. But for code acting on the instruction internally via Rust this could
-    cause issues as it was diverging from underlying expectations around
-    :class:`.Delay` instructions. One concrete example of this is if you passed a
-    circuit loaded via :func:`.qpy.load` to the :func:`.qasm3.dumps_experimental`
-    function this would cause an internal error. This has been fixed so now an integer
-    object is correctly created directly for the duration.
+    Fixed :func:`.qpy.load` for QPY versions >=13, where :class:`.Delay` instructions with integer
+    durations could deserialize to incorrect types. This could cause later code to raise errors,
+    such as :func:`.qasm3.dumps_experimental` returning an error saying "Failed to parse parameter
+    value". See `#16076 <https://github.com/Qiskit/qiskit/pull/16076>`__ for more detail.

--- a/releasenotes/notes/fix-qpy-int-538032980959ea37.yaml
+++ b/releasenotes/notes/fix-qpy-int-538032980959ea37.yaml
@@ -1,0 +1,15 @@
+---
+fixes:
+  - |
+    Fixed an issue in the :func:`.qpy.load` function when reading QPY payloads using
+    QPY format versions >=13 that contained a circuit which contained :class:`.Delay`
+    instructions that had an integer duration value with a duration unit of ``"dt"``
+    were incorrectly loaded through a :class:`.ParameterExpression` as part of the
+    deserialization process. This typically wasn't visible through Python as the
+    :class:`.ParameterExpression` was coerced into an integer when it was accessed
+    from Python. But for code acting on the instruction internally via Rust this could
+    cause issues as it was diverging from underlying expectations around
+    :class:`.Delay` instructions. One concrete example of this is if you passed a
+    circuit loaded via :func:`.qpy.load` to the :func:`.qasm3.dumps_experimental`
+    function this would cause an internal error. This has been fixed so now an integer
+    object is correctly created directly for the duration.

--- a/test/python/qasm3/test_export.py
+++ b/test/python/qasm3/test_export.py
@@ -16,6 +16,7 @@
 
 
 from io import StringIO
+from io import BytesIO
 from math import pi
 import re
 import warnings
@@ -50,6 +51,7 @@ from qiskit.qasm3 import (
 from qiskit.qasm3.exporter import QASM3Builder
 from qiskit.qasm3.printer import BasicPrinter
 from qiskit.qasm3.exceptions import QASM3ImporterError
+from qiskit import qpy
 from qiskit.quantum_info import Pauli
 from test import QiskitTestCase
 
@@ -3391,6 +3393,19 @@ class TestQASM3ExporterRust(QiskitTestCase):
             ]
         )
         self.assertEqual(dumps_experimental(qc, allow_aliasing=True), expected_qasm)
+
+    def test_delay_qpy_roundtrip(self):
+        qc = QuantumCircuit(1)
+        qc.delay(1, 0)
+        no_qpy = dumps_experimental(qc)
+
+        with BytesIO() as buf:
+            qpy.dump(qc, buf)
+            buf.seek(0)
+            qpy_roundtrip = qpy.load(buf)[0]
+
+        with_qpy = dumps_experimental(qpy_roundtrip)
+        self.assertEqual(no_qpy, with_qpy)
 
     def test_annotations(self):
         """Test that the annotation-serialisation framework works."""

--- a/test/python/qpy/test_roundtrip.py
+++ b/test/python/qpy/test_roundtrip.py
@@ -247,3 +247,9 @@ class TestQPYRoundtrip(QiskitTestCase):
             self.assert_roundtrip_equal(
                 qc, version=version, read_with=read_with, write_with=write_with
             )
+
+    @all_qpy_combinations(QPY_RUST_READ_MIN_VERSION)
+    def test_delay_roundtrip(self, version, write_with, read_with):
+        qc = QuantumCircuit(1)
+        qc.delay(1, 0, "dt")
+        self.assert_roundtrip_equal(qc, version=version, read_with=read_with, write_with=write_with)

--- a/test/python/qpy/test_roundtrip.py
+++ b/test/python/qpy/test_roundtrip.py
@@ -255,7 +255,7 @@ class TestQPYRoundtrip(QiskitTestCase):
         qc.delay(1, 0, "dt")
         self.assert_roundtrip_equal(qc, version=version, read_with=read_with, write_with=write_with)
 
-    @all_qpy_combinations(QPY_RUST_READ_MIN_VERSION)
+    @all_qpy_combinations(14)
     def test_delay_expr_roundtrip(self, version, write_with, read_with):
         stretch_expr = QuantumCircuit(1, name="stretch_expr_delay_circuit")
         s = expr.Stretch(uuid.uuid4(), "a")
@@ -263,3 +263,22 @@ class TestQPYRoundtrip(QiskitTestCase):
         stretch_expr.delay(stretch, 0)
         stretch_expr.delay(expr.add(Duration.dt(200), stretch), 0)
         stretch_expr.delay(expr.sub(Duration.ns(3.14159), stretch), 0)
+        self.assert_roundtrip_equal(
+            stretch_expr, version=version, read_with=read_with, write_with=write_with
+        )
+
+    @all_qpy_combinations(14)
+    def test_box_expr_roundtrip(self, version, write_with, read_with):
+        qc = QuantumCircuit(1, name="box_expr_circuit")
+        s = qc.add_stretch("s")
+        duration = expr.add(Duration.dt(100), expr.sub(s, Duration.ns(16.25)))
+        with qc.box(duration=duration):
+            qc.x(0)
+        self.assert_roundtrip_equal(qc, version=version, read_with=read_with, write_with=write_with)
+
+    @all_qpy_combinations(QPY_RUST_READ_MIN_VERSION)
+    def test_literal_integers_in_for(self, version, write_with, read_with):
+        qc = QuantumCircuit(1)
+        with qc.for_loop((2, 5, (1 << 60))) as _:
+            qc.x(0)
+        self.assert_roundtrip_equal(qc, version=version, read_with=read_with, write_with=write_with)

--- a/test/python/qpy/test_roundtrip.py
+++ b/test/python/qpy/test_roundtrip.py
@@ -13,10 +13,11 @@
 """Tests for python write/rust read flow and vice versa"""
 
 import io
+import uuid
 
 from ddt import ddt, idata, unpack
 
-from qiskit.circuit import QuantumCircuit, QuantumRegister, ClassicalRegister
+from qiskit.circuit import QuantumCircuit, QuantumRegister, ClassicalRegister, Duration
 from qiskit.circuit.library import PauliEvolutionGate
 from qiskit.circuit.random import random_circuit
 from qiskit.circuit.parameter import Parameter
@@ -253,3 +254,12 @@ class TestQPYRoundtrip(QiskitTestCase):
         qc = QuantumCircuit(1)
         qc.delay(1, 0, "dt")
         self.assert_roundtrip_equal(qc, version=version, read_with=read_with, write_with=write_with)
+
+    @all_qpy_combinations(QPY_RUST_READ_MIN_VERSION)
+    def test_delay_expr_roundtrip(self, version, write_with, read_with):
+        stretch_expr = QuantumCircuit(1, name="stretch_expr_delay_circuit")
+        s = expr.Stretch(uuid.uuid4(), "a")
+        stretch = stretch_expr.add_stretch(s)
+        stretch_expr.delay(stretch, 0)
+        stretch_expr.delay(expr.add(Duration.dt(200), stretch), 0)
+        stretch_expr.delay(expr.sub(Duration.ns(3.14159), stretch), 0)

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -944,7 +944,7 @@ def generate_box():
             nested.x(0)
             nested.noop(1)
 
-    labeled = QuantumCircuit(2)
+    labeled = QuantumCircuit(2, name="labeled boxes")
     with labeled.box():
         labeled.cx(0, 1)
     with labeled.box(duration=1, unit="dt", label="hello"):
@@ -965,15 +965,16 @@ def generate_delay():
 def generate_delay_stretch():
     """Circuits that contain a stretch delay. Added in QPY 14 in Qiskit 2.0."""
     from qiskit.circuit.classical import expr
+    from qiskit.circuit import Duration
     import uuid
 
-    stretch_expr = QuantumCircuit(name="stretch_expr")
+    stretch_expr = QuantumCircuit(1, name="stretch_expr_delay_circuit")
     s = expr.Stretch(uuid.UUID(bytes=b"hallo, QPY_world", version=4), "a")
     stretch = stretch_expr.add_stretch(s)
-    qc = QuantumCircuit(1)
-    qc.add_stretch(stretch)
-    qc.delay(stretch)
-    return [qc]
+    stretch_expr.delay(stretch, 0)
+    stretch_expr.delay(expr.add(Duration.dt(200), stretch), 1)
+    stretch_expr.delay(expr.sub(Duration.ns(3.14159), stretch), 0)
+    return [stretch_expr]
 
 
 def generate_circuits(generating_version, current_version, load_context=False):

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -943,7 +943,36 @@ def generate_box():
         with nested.box(duration=200.0, unit="ns"):
             nested.x(0)
             nested.noop(1)
-    return [bare, nested]
+
+    labeled = QuantumCircuit(2)
+    with labeled.box():
+        labeled.cx(0, 1)
+    with labeled.box(duration=1, unit="dt", label="hello"):
+        with labeled.box(duration=2.5, unit="s", label="world"):
+            labeled.cx(0, 1)
+
+    return [bare, nested, labeled]
+
+
+def generate_delay():
+    """Circuits that contain a delay"""
+    qc = QuantumCircuit(1, name="delay dt")
+    qc.delay(1, 0)
+    qc.delay(9223372036854775806, 0)
+    return qc
+
+
+def generate_delay_stretch():
+    """Circuits that contain a stretch delay. Added in QPY 14 in Qiskit 2.0."""
+    from qiskit.circuit.classical import expr
+    import uuid
+
+    stretch_expr = QuantumCircuit(name="stretch_expr")
+    s = expr.Stretch(uuid.UUID(bytes=b"hello, qpy world", version=4), "a")
+    stretch = stretch_expr.add_stretch(s)
+    qc = QuantumCircuit(1)
+    qc.delay(stretch)
+    return [qc]
 
 
 def generate_circuits(generating_version, current_version, load_context=False):
@@ -960,6 +989,7 @@ def generate_circuits(generating_version, current_version, load_context=False):
         "string_parameters.qpy": [generate_string_parameters()],
         "register_edge_cases.qpy": generate_register_edge_cases(),
         "parameterized.qpy": [generate_parameterized_circuit()],
+        "delay.qpy": [generate_delay()],
     }
 
     if generating_version.release >= (0, 18, 1):
@@ -1021,6 +1051,7 @@ def generate_circuits(generating_version, current_version, load_context=False):
     if generating_version.release >= (2, 0, 0):
         output_circuits["v14_expr.qpy"] = generate_v14_expr()
         output_circuits["box.qpy"] = generate_box()
+        output_circuits["delay_stretch.qpy"] = generate_delay_stretch()
     return output_circuits
 
 

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -972,7 +972,7 @@ def generate_delay_stretch():
     s = expr.Stretch(uuid.UUID(bytes=b"hallo, QPY_world", version=4), "a")
     stretch = stretch_expr.add_stretch(s)
     stretch_expr.delay(stretch, 0)
-    stretch_expr.delay(expr.add(Duration.dt(200), stretch), 1)
+    stretch_expr.delay(expr.add(Duration.dt(200), stretch), 0)
     stretch_expr.delay(expr.sub(Duration.ns(3.14159), stretch), 0)
     return [stretch_expr]
 

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -968,9 +968,10 @@ def generate_delay_stretch():
     import uuid
 
     stretch_expr = QuantumCircuit(name="stretch_expr")
-    s = expr.Stretch(uuid.UUID(bytes=b"hello, qpy world", version=4), "a")
+    s = expr.Stretch(uuid.UUID(bytes=b"hallo, QPY_world", version=4), "a")
     stretch = stretch_expr.add_stretch(s)
     qc = QuantumCircuit(1)
+    qc.add_stretch(stretch)
     qc.delay(stretch)
     return [qc]
 


### PR DESCRIPTION
This commit fixes an issue with parsing QPY payloads which have circuits that contain delays with duration of units dt. Durations of dt are integers and that is preserved in the QPY data. However our rust data model doesn't have support for an integer in a Rust PackedInstruction's parameters (this is an inconsistency which we should arguably fix but that is separate from this bugfix). To workaround this the QPY reader in rust was sticking the integer into a ParameterExpression as a constant without any symbols. This resulted in storing the integer in Rust but treating the object as a ParameterExpression and not an int, which in Qiskit's rust data model is mapped to a Param::Obj (indicating a Python object parameter). This mismatch in types was not really noticeable to Python because the ParameterExpression with the constant integer was coerced to an integer when it's passed to Python. However, this would break underlying assumptions for Rust code that is interacting with the delay. For example, the experimental rust qasm3 exporter would encounter the ParameterExpression on the delay and error because it can't handle parameter expressions yet. However fundamentally it could because this is just an integer. The reproducer for this failure is:

```python
import io
from qiskit import qpy, qasm3, QuantumCircuit

qc = QuantumCircuit(1)
qc.delay(1, 0)

qasm3.dumps_experimental(qc)

with io.BytesIO() as fptr:
    qpy.dump(qc, fptr)
    fptr.seek(0)
    qc2 = qpy.load(fptr)[0]

qasm3.dumps_experimental(qc2)
```

The OQ3 experimental exporter is wrong not to handle `ParameterExpression::try_as_value` returning an `int`, but it's _more_ wrong that QPY is producing a `ParameterExpression` on deserialisation in the first place.

To fix this issue this commit removes the conversion of the `int` in the qpy payload into a ParameterExpression and just retains an integer until we write out the Delay's PackedInstruction where we convert that rust int into a python int for the parameter. Doing this unraveled a deeper issue in how endianess is handled in QPY. In general everything in QPY is supposed to be encoded using network byte order (i.e. big endian). However, in the case of instructions' parameters there was a mistake made in QPY where the integer and float values for an instruction's parameters were encoded in little endian. All other uses of floats or ints are correctly big endian. When the raw int was returned to Python it was incorrectly assuming all integers were a big endian bytes value. To fix this an endian arg is added to the function which is converting the bytes arrays into a `GenericValue` enum for floats and ints. Then the callers of this function in circuit_reader are updated to explicitly assert what endianess the data in the circuit payload is if there are any floats or ints. This is `Endian::Little` for any instruction params that are in the parameters list explicitly and `Endian::Big` everywhere else. At the same time the handling of flipping the endianess of value in several places was removed because this was no longer necessary as the data was read now using the correct byte order.

This fundamentally stems from all the base values being stored in a single binrw generic value pack which is trying to encode all the primitive types in a single place. Ideally we should be handling the primitive types explicitly for each data pack field. But this was not changed to keep the diff minimal for backport.

Co-authored-by: Jake Lishman <jake.lishman@ibm.com>

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
