### PR TITLE
Docs: Properly document `QkParams`

### DIFF
--- a/docs/cdoc/index.rst
+++ b/docs/cdoc/index.rst
@@ -31,6 +31,7 @@ Quantum Circuit
    qk-circuit
    qk-quantum-register
    qk-classical-register
+   qk-param
 
 Circuit Library
 +++++++++++++++

--- a/docs/cdoc/qk-param.rst
+++ b/docs/cdoc/qk-param.rst
@@ -4,9 +4,8 @@ QkParam
 
 Represents a circuit parameter which may hold real or symbolic values.
 
-
-While functionality for a ``QkParam`` is currently limited, a user is allowed
-to do several essential operations similarly to the ones allowed by :class:`.Parameter`.
+While functionality for a ``QkParam`` within a circuit is currently limited,
+a user is able to perform operations similar to the ones present in :class:`.Parameter`.
 
 Functions
 =========

--- a/docs/cdoc/qk-param.rst
+++ b/docs/cdoc/qk-param.rst
@@ -4,8 +4,6 @@ QkParam
 
 Represents a circuit parameter which may hold real or symbolic values.
 
-When added to a ``QkCircuit``, the values of all parameters must be determined,
-that is, all values must be real by the time the circuit starts execution.
 
 While functionality for a ``QkParam`` is currently limited, a user is allowed
 to do several essential operations similarly to the ones allowed by :class:`.Parameter`.

--- a/docs/cdoc/qk-param.rst
+++ b/docs/cdoc/qk-param.rst
@@ -1,0 +1,18 @@
+=======
+QkParam
+=======
+
+Represents a circuit parameter which may hold real or symbolic values.
+
+When added to a ``QkCircuit``, the values of all parameters must be determined,
+that is, all values must be real by the time the circuit starts execution.
+
+While functionality for a ``QkParam`` is currently limited, a user is allowed
+to do several essential operations similarly to the ones allowed by :class:`.Parameter`.
+
+Functions
+=========
+
+.. doxygengroup:: QkParam
+    :members:
+    :content-only:


### PR DESCRIPTION
Fixes #16071 

We had previously added API to handle `QkParams` in our C API, including a doxygen group named `QkParam`. However, we failed to include `QkParam` anywhere in our documentation and therefore it never shows up even if you manually search for any of the documented functions.

These commits add `qk-param.rst` to the cdocs directory, as well as to `index.rst` to include anything documenting `QkParam`.

### Preview

<img width="1243" height="1312" alt="image" src="https://github.com/user-attachments/assets/e0d86f31-e019-45ca-b963-4e6d9e06f154" />

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
