### PR TITLE
Fix UGate OpenQASM 3 phase note

### DIFF
--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -61,10 +61,11 @@ class UGate(Gate):
 
     .. note::
 
-        The matrix representation shown here is the same as in the `OpenQASM 3.0 specification
-        <https://openqasm.com/language/gates.html#built-in-gates>`_,
-        which differs from the `OpenQASM 2.0 specification
-        <https://doi.org/10.48550/arXiv.1707.03429>`_ by a global phase of
+        The matrix representation in the current `OpenQASM 3 specification
+        <https://openqasm.com/language/gates.html#built-in-gates>`_ is this
+        matrix multiplied by a global phase of :math:`e^{i\theta/2}`. Earlier
+        versions of the OpenQASM specification used a definition that differs
+        from Qiskit by a global phase of
         :math:`e^{i(\phi+\lambda)/2}`.
 
     Examples:


### PR DESCRIPTION
## Summary

Correct the `UGate` docstring note that compares Qiskit's matrix convention with the current OpenQASM 3 `U` definition.

Fixes #15830.

## Problem

The existing note says Qiskit's displayed `UGate` matrix is the same as OpenQASM 3. The current OpenQASM 3 specification defines `U` with an additional global phase relative to Qiskit's matrix.

## Root cause

The docstring appears to describe an older OpenQASM 3 convention. The live OpenQASM 3 specification now defines `U(theta, phi, lambda)` as Qiskit's matrix multiplied by `exp(i * theta / 2)`.

## Fix

Update the note to state the current OpenQASM 3 global-phase relationship, while preserving the existing note about earlier OpenQASM definitions.

## Tests

- `.venv/bin/python -m black --check qiskit/circuit/library/standard_gates/u.py`
- `.venv/bin/python -m ruff check qiskit/circuit/library/standard_gates/u.py`
- Verified numerically that the current OpenQASM 3 formula equals `exp(i * theta / 2)` times Qiskit's `UGate` matrix for sampled parameters.

## Notes / limitations

This is a documentation-only correction; no runtime behavior changes.

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description: OpenAI Codex (GPT-5)
- [x] I used the following tool to generate or modify code: OpenAI Codex (GPT-5)
