### PR TITLE
Remove equality between Param::Obj and Param::ParameterExpression

### DIFF
--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -114,15 +114,11 @@ impl Param {
                 Ok(a.as_ref() == &ParameterExpression::from_f64(*b))
             }
             [Self::ParameterExpression(a), Self::ParameterExpression(b)] => Ok(a == b),
+            [Self::Obj(a), Self::Obj(b)] => Python::attach(|py| a.bind(py).eq(b)),
             [Self::Obj(_), Self::Float(_)] => Ok(false),
             [Self::Float(_), Self::Obj(_)] => Ok(false),
-            [Self::Obj(a), Self::ParameterExpression(b)] => {
-                Python::attach(|py| a.bind(py).eq(b.as_ref().clone()))
-            }
-            [Self::Obj(a), Self::Obj(b)] => Python::attach(|py| a.bind(py).eq(b)),
-            [Self::ParameterExpression(a), Self::Obj(b)] => {
-                Python::attach(|py| a.as_ref().clone().into_bound_py_any(py)?.eq(b))
-            }
+            [Self::Obj(_a), Self::ParameterExpression(_b)] => Ok(false),
+            [Self::ParameterExpression(_a), Self::Obj(_b)] => Ok(false),
         }
     }
 


### PR DESCRIPTION
This commit fixes a mismatch in the Param::eq() method where a Python object param was potentially viewed as equal to a ParameterExpression param. When comparing a python object parameter with a ParameterExpression it would convert the ParameterExpression into a pyobject and then uses Python's == to evaluate the equality. Historically this was something that was done because the ParameterExpression object was also a Python object. However, since the function was first written the source of truth for the inner ParameterExpression has moved to Rust. We're never in a situation anymore when a ParameterExpression parameter on an instruction should be treated as a Python object.

While this legacy equality may seem harmless because the equality should typically just evaluate to false (albeit slowly through Python's equality check), there are edge cases where this is doing the incorrect comparison. Primarily the bug that #16076 was fixing was not caught initially because in tests this legacy logic was converting a ParameterExpression that is a constant int expression with no symbols to a Python int during the conversion of the expression to Python. That was then being compared against a Param::Obj() of a true Python int. The equality check would incorrectly assert the ParameterExpression was the same as the python int. This is what masked the bug in #16076 because this differs from how the rust data model treats these parameters.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
