### PR TITLE
Forward port qpy version table update from 2.4.1

### DIFF
--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -199,6 +199,9 @@ of QPY in qiskit-terra 0.18.0.
    * - Qiskit (qiskit-terra for < 1.0.0) version
      - :func:`.dump` format(s) output versions
      - :func:`.load` maximum supported version (older format versions can always be read)
+   * - 2.4.1
+     - 13, 14, 15, 16, 17
+     - 17
    * - 2.4.0
      - 13, 14, 15, 16, 17
      - 17


### PR DESCRIPTION
This commit pulls in the qpy version table update from #16085. That PR was on the stable/2.4 branch to prepare the 2.4.1 release and updated the qpy version table to include the supported versions for that release. This does not change the main branch which means for a future 2.5.0 release this changes are not reflected there. This commit forward ports the change from the stable/2.4 branch to keep the version history table up-to-date.

This is just a temporary step until we automate the version history table creation. You can see a discussion of the details on this in this issue: #16086.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->