### PR TITLE
Fix `restype` for void-returning functions

### DIFF
--- a/crates/bindgen/src/render/py_ctypes.rs
+++ b/crates/bindgen/src/render/py_ctypes.rs
@@ -357,12 +357,13 @@ impl Function {
             }
         }
         out.push_str("]\n");
-        if let Some(ret) = self.ret.as_ref() {
-            out.push_str(&prefix);
-            out.push_str(".restype = ");
-            ret.render(&mut out);
-            out.push('\n');
-        }
+        out.push_str(&prefix);
+        out.push_str(".restype = ");
+        match self.ret.as_ref() {
+            Some(ret) => ret.render(&mut out),
+            None => out.push_str("None"),
+        };
+        out.push('\n');
         // Re-export into main namespace.
         out.push_str(&self.name);
         out.push_str(" = ");


### PR DESCRIPTION
`ctypes` defaults to assuming `c_int` returns (as ancient C compilers also did) if `restype` is unspecified.  In the case that the return type of a function is `void`, this causes it to return nonsense to Python space.  While `ctypes` doesn't have a built-in representation of `void`, the Python-space `None` can be used specifically in this position to represent it.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

No release note because it isn't released.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
