### PR TITLE
Fix Sabre disjoint layout with idle qubits

### DIFF
--- a/crates/transpiler/src/passes/disjoint_layout.rs
+++ b/crates/transpiler/src/passes/disjoint_layout.rs
@@ -175,12 +175,7 @@ pub fn distribute_components(dag: &mut DAGCircuit, target: &Target) -> PyResult<
         return Ok(DisjointSplit::NoneNeeded);
     }
     if let Some(largest_component) = cmap_components.iter().max_by_key(|x| x.len()) {
-        let num_active_qubits = dag
-            .qubit_io_map()
-            .iter()
-            .filter(|[source, target]| dag.dag().find_edge(*source, *target).is_none())
-            .count();
-        if largest_component.len() >= num_active_qubits {
+        if largest_component.len() >= dag.num_qubits() {
             return Ok(DisjointSplit::TargetSubset(
                 largest_component
                     .iter()
@@ -252,7 +247,7 @@ pub fn distribute_components(dag: &mut DAGCircuit, target: &Target) -> PyResult<
             Ok((out_dag, subgraph))
         })
         .collect::<PyResult<Vec<_>>>()?;
-    if out_component_pairs.len() == 1 {
+    if out_component_pairs.len() == 1 && out_component_pairs[0].1.node_count() >= dag.num_qubits() {
         return Ok(DisjointSplit::TargetSubset(
             out_component_pairs[0]
                 .1

--- a/crates/transpiler/src/passes/disjoint_layout.rs
+++ b/crates/transpiler/src/passes/disjoint_layout.rs
@@ -175,6 +175,10 @@ pub fn distribute_components(dag: &mut DAGCircuit, target: &Target) -> PyResult<
         return Ok(DisjointSplit::NoneNeeded);
     }
     if let Some(largest_component) = cmap_components.iter().max_by_key(|x| x.len()) {
+        // The target-subset path runs the full DAG on the restricted component, so it is only
+        // safe when every virtual qubit can fit.  If only the active qubits fit, continue to the
+        // disjoint-component path; Sabre will assign idle virtual qubits after laying out the
+        // active components.
         if largest_component.len() >= dag.num_qubits() {
             return Ok(DisjointSplit::TargetSubset(
                 largest_component

--- a/releasenotes/notes/fix-sabre-disjoint-idle-qubits-61dc02b8e0bd06d3.yaml
+++ b/releasenotes/notes/fix-sabre-disjoint-idle-qubits-61dc02b8e0bd06d3.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed :class:`.SabreLayout` and ``routing_method="sabre"`` for circuits
+    with idle virtual qubits on disconnected coupling maps. Previously, if the
+    active qubits fit in one connected component but the full circuit required
+    qubits from multiple components, Sabre could run on a too-small target
+    subset and raise a ``pyo3_runtime.PanicException``. See
+    `#15841 <https://github.com/Qiskit/qiskit/issues/15841>`__.

--- a/test/python/transpiler/test_sabre_layout.py
+++ b/test/python/transpiler/test_sabre_layout.py
@@ -533,11 +533,16 @@ class TestDisjointDeviceSabreLayout(QiskitTestCase):
         layout_routing_pass = SabreLayout(disjoint, seed=2026_04_30, swap_trials=1, layout_trials=1)
         out = layout_routing_pass(qc)
 
-        self.assertEqual(
+        layout_qubits = list(range(qc.num_qubits))
+        self.assertCountEqual(
             out.layout.initial_index_layout(filter_ancillas=False),
-            out.layout.final_index_layout(filter_ancillas=False),
+            layout_qubits,
         )
-        self.assertEqual(out.layout.routing_permutation(), [0, 1, 2, 3])
+        self.assertCountEqual(
+            out.layout.final_index_layout(filter_ancillas=False),
+            layout_qubits,
+        )
+        self.assertEqual(out.layout.routing_permutation(), layout_qubits)
         cx_qubits = [
             {out.find_bit(qubit).index for qubit in instruction.qubits}
             for instruction in out.data

--- a/test/python/transpiler/test_sabre_layout.py
+++ b/test/python/transpiler/test_sabre_layout.py
@@ -522,6 +522,30 @@ class TestDisjointDeviceSabreLayout(QiskitTestCase):
         self.assertEqual(out.layout.initial_index_layout(filter_ancillas=False), [4, 5, 3, 0, 1, 2])
         self.assertEqual(out.layout.final_index_layout(filter_ancillas=False), [3, 5, 4, 0, 1, 2])
 
+    def test_active_qubits_fit_in_one_component_with_idle_qubits(self):
+        """Test idle qubits are preserved when the active qubits fit in one component."""
+        qc = QuantumCircuit(4)
+        qc.h(0)
+        qc.h(2)
+        qc.cx(0, 2)
+
+        disjoint = CouplingMap([(0, 1), (2, 3)])
+        layout_routing_pass = SabreLayout(disjoint, seed=2026_04_30, swap_trials=1, layout_trials=1)
+        out = layout_routing_pass(qc)
+
+        self.assertEqual(out.num_qubits, 4)
+        self.assertEqual(len(out.layout.initial_layout), len(out.layout.final_layout))
+        self.assertEqual(
+            sorted(out.layout.initial_index_layout(filter_ancillas=False)), [0, 1, 2, 3]
+        )
+        cx_qubits = [
+            {out.find_bit(qubit).index for qubit in instruction.qubits}
+            for instruction in out.data
+            if instruction.operation.name == "cx"
+        ]
+        self.assertEqual(len(cx_qubits), 1)
+        self.assertIn(cx_qubits[0], [{0, 1}, {2, 3}])
+
     def test_sabre_layout_global_1q(self):
         """Test that the pass runs with a globally defined 1q gate."""
         target = Target(num_qubits=3)

--- a/test/python/transpiler/test_sabre_layout.py
+++ b/test/python/transpiler/test_sabre_layout.py
@@ -533,11 +533,11 @@ class TestDisjointDeviceSabreLayout(QiskitTestCase):
         layout_routing_pass = SabreLayout(disjoint, seed=2026_04_30, swap_trials=1, layout_trials=1)
         out = layout_routing_pass(qc)
 
-        self.assertEqual(out.num_qubits, 4)
-        self.assertEqual(len(out.layout.initial_layout), len(out.layout.final_layout))
         self.assertEqual(
-            sorted(out.layout.initial_index_layout(filter_ancillas=False)), [0, 1, 2, 3]
+            out.layout.initial_index_layout(filter_ancillas=False),
+            out.layout.final_index_layout(filter_ancillas=False),
         )
+        self.assertEqual(out.layout.routing_permutation(), [0, 1, 2, 3])
         cx_qubits = [
             {out.find_bit(qubit).index for qubit in instruction.qubits}
             for instruction in out.data


### PR DESCRIPTION
### Summary

Fixes #15841.

This adjusts Sabre's disconnected-target shortcut so it only routes the full DAG on a target subset when that subset can contain all virtual qubits. If the active qubits fit in one connected component but the circuit also has idle virtual qubits, the pass now falls back to the existing disjoint-component path, where the idle qubits can still be placed on the remaining physical qubits.

### Details

The previous shortcut could choose a component that was large enough for the active qubits, but too small for the full circuit width. Sabre would then route the full DAG against that smaller component and could hit a Rust `pyo3_runtime.PanicException`.

The regression covers a four-qubit circuit with two active qubits on a disconnected four-qubit coupling map. It checks the public layout outputs, the routing permutation, and that the remaining CX is placed within one connected component.

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: OpenAI Codex (GPT-5)
