### PR TITLE
Improve single-qubit gate count in `TwoQubitControlledUDecomposer`

### DIFF
--- a/crates/synthesis/src/two_qubit_decompose/basis_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/basis_decomposer.rs
@@ -25,7 +25,7 @@ use numpy::{IntoPyArray, ToPyArray};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
-use super::common::{DEFAULT_FIDELITY, IPZ, TraceToFidelity, rx_matrix, rz_matrix};
+use super::common::{DEFAULT_FIDELITY, HGATE, IPZ, TraceToFidelity, rx_matrix, rz_matrix};
 use super::gate_sequence::{TwoQubitGateSequence, TwoQubitSequenceVec};
 use super::weyl_decomposition::{__num_basis_gates, _num_basis_gates, TwoQubitWeylDecomposition};
 
@@ -41,7 +41,7 @@ use qiskit_circuit::bit::ShareableQubit;
 use qiskit_circuit::circuit_data::{CircuitData, PyCircuitData};
 use qiskit_circuit::circuit_instruction::OperationFromPython;
 use qiskit_circuit::dag_circuit::DAGCircuit;
-use qiskit_circuit::gate_matrix::{CX_GATE, H_GATE, ONE_QUBIT_IDENTITY};
+use qiskit_circuit::gate_matrix::{CX_GATE, ONE_QUBIT_IDENTITY};
 use qiskit_circuit::instruction::{Instruction, Parameters};
 use qiskit_circuit::operations::{Operation, OperationRef, Param, StandardGate};
 use qiskit_circuit::packed_instruction::PackedOperation;
@@ -55,9 +55,6 @@ use qiskit_util::complex::{C_M_ONE, C_ONE, IM, M_IM, c64};
 // and are just used to create a QuantumCircuit or DAGCircuit when we return to
 // Python space.
 const TWO_QUBIT_SEQUENCE_DEFAULT_CAPACITY: usize = 21;
-
-static HGATE: Matrix2<Complex64> =
-    Matrix2::new(H_GATE[0][0], H_GATE[0][1], H_GATE[1][0], H_GATE[1][1]);
 
 static K12R: Matrix2<Complex64> = Matrix2::new(
     c64(0., FRAC_1_SQRT_2),

--- a/crates/synthesis/src/two_qubit_decompose/common.rs
+++ b/crates/synthesis/src/two_qubit_decompose/common.rs
@@ -19,6 +19,7 @@ use numpy::{IntoPyArray, PyArray2, PyReadonlyArray1, PyReadonlyArray2};
 use pyo3::prelude::*;
 
 use crate::linalg::ndarray_to_faer;
+use qiskit_circuit::gate_matrix::{H_GATE, S_GATE, SDG_GATE};
 use qiskit_util::alias::GateArray2Q;
 use qiskit_util::complex::{C_M_ONE, C_ONE, C_ZERO, IM, M_IM, c64};
 pub(super) const DEFAULT_FIDELITY: f64 = 1.0 - 1.0e-9;
@@ -231,3 +232,14 @@ pub(super) fn ndarray_to_matrix2<T: Copy>(view: ArrayView2<T>) -> Matrix2<T> {
 pub(super) fn ndarray_to_matrix4(view: ArrayView2<Complex64>) -> Matrix4<Complex64> {
     Matrix4::from_row_iterator(view.iter().copied())
 }
+
+pub static HGATE: Matrix2<Complex64> =
+    Matrix2::new(H_GATE[0][0], H_GATE[0][1], H_GATE[1][0], H_GATE[1][1]);
+pub static SGATE: Matrix2<Complex64> =
+    Matrix2::new(S_GATE[0][0], S_GATE[0][1], S_GATE[1][0], S_GATE[1][1]);
+pub static SDGGATE: Matrix2<Complex64> = Matrix2::new(
+    SDG_GATE[0][0],
+    SDG_GATE[0][1],
+    SDG_GATE[1][0],
+    SDG_GATE[1][1],
+);

--- a/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
@@ -15,7 +15,7 @@ use num_complex::Complex64;
 use smallvec::{SmallVec, smallvec};
 use std::f64::consts::FRAC_PI_2;
 
-use nalgebra::{MatrixView2, U2};
+use nalgebra::{Matrix2, MatrixView2, U2};
 use ndarray::prelude::*;
 use numpy::PyReadonlyArray2;
 
@@ -31,7 +31,7 @@ use crate::linalg::nalgebra_array_view;
 
 use qiskit_circuit::circuit_data::{CircuitData, PyCircuitData};
 use qiskit_circuit::circuit_instruction::OperationFromPython;
-use qiskit_circuit::gate_matrix::{H_GATE, S_GATE, SDG_GATE};
+use qiskit_circuit::gate_matrix::{H_GATE, ONE_QUBIT_IDENTITY, S_GATE, SDG_GATE};
 use qiskit_circuit::operations::{Operation, OperationRef, Param, StandardGate};
 use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::{NoBlocks, Qubit};
@@ -39,6 +39,24 @@ use qiskit_circuit::{NoBlocks, Qubit};
 use super::common::DEFAULT_FIDELITY;
 use super::gate_sequence::{TwoQubitGateSequence, TwoQubitSequenceVec};
 use super::weyl_decomposition::{Specialization, TwoQubitWeylDecomposition};
+
+// ToDo: move to common (also used by basis_decomposer)
+static IMAT: Matrix2<Complex64> = Matrix2::new(
+    ONE_QUBIT_IDENTITY[0][0],
+    ONE_QUBIT_IDENTITY[0][1],
+    ONE_QUBIT_IDENTITY[1][0],
+    ONE_QUBIT_IDENTITY[1][1],
+);
+static HGATE: Matrix2<Complex64> =
+    Matrix2::new(H_GATE[0][0], H_GATE[0][1], H_GATE[1][0], H_GATE[1][1]);
+static SGATE: Matrix2<Complex64> =
+    Matrix2::new(S_GATE[0][0], S_GATE[0][1], S_GATE[1][0], S_GATE[1][1]);
+static SDGGATE: Matrix2<Complex64> = Matrix2::new(
+    SDG_GATE[0][0],
+    SDG_GATE[0][1],
+    SDG_GATE[1][0],
+    SDG_GATE[1][1],
+);
 
 /// invert 1q gate sequence
 fn invert_1q_gate(
@@ -114,14 +132,6 @@ pub struct TwoQubitControlledUDecomposer {
     euler_basis: EulerBasis,
     #[pyo3(get)]
     scale: f64,
-    // u0l: Matrix2<Complex64>,
-    // u0r: Matrix2<Complex64>,
-    // u1l: Matrix2<Complex64>,
-    // u1r: Matrix2<Complex64>,
-    // u2l: Matrix2<Complex64>,
-    // u2r: Matrix2<Complex64>,
-    // u3l: Matrix2<Complex64>,
-    // u3r: Matrix2<Complex64>,
 }
 
 const DEFAULT_ATOL: f64 = 1e-12;
@@ -187,7 +197,10 @@ impl TwoQubitControlledUDecomposer {
     ///      Circuit: Circuit equivalent to an RXXGate.
     ///  Raises:
     ///      QiskitError: If the circuit is not equivalent to an RXXGate.
-    fn to_rxx_gate(&self, angle: f64) -> PyResult<TwoQubitGateSequence> {
+    fn to_rxx_gate(
+        &self,
+        angle: f64,
+    ) -> PyResult<(TwoQubitGateSequence, SmallVec<[Matrix2<Complex64>; 4]>)> {
         // The user-provided RXX equivalent gate may be locally equivalent to the RXX gate
         // but with some scaling in the rotation angle. For example, RXX(angle) has Weyl
         // parameters (angle, 0, 0) for angle in [0, pi/2] but the user provided gate, i.e.
@@ -198,20 +211,30 @@ impl TwoQubitControlledUDecomposer {
         let decomposer_inv =
             TwoQubitWeylDecomposition::new_inner(mat.view(), Some(DEFAULT_FIDELITY), None)?;
 
-        let mut target_1q_basis_list = EulerBasisSet::new();
-        target_1q_basis_list.add_basis(self.euler_basis);
-
         // Express the RXX in terms of the user-provided RXX equivalent gate.
-        let mut gates = Vec::with_capacity(13);
-        let mut global_phase = -decomposer_inv.global_phase;
+        let mut gates = Vec::with_capacity(1);
+        let global_phase = -decomposer_inv.global_phase;
 
-        let decomp_k1r = decomposer_inv.K1r.as_view();
-        let decomp_k2r = decomposer_inv.K2r.as_view();
-        let decomp_k1l = decomposer_inv.K1l.as_view();
-        let decomp_k2l = decomposer_inv.K2l.as_view();
+        let decomp_k1r: Matrix2<Complex64> = decomposer_inv.K1r;
+        let decomp_k2r: Matrix2<Complex64> = decomposer_inv.K2r;
+        let decomp_k1l: Matrix2<Complex64> = decomposer_inv.K1l;
+        let decomp_k2l: Matrix2<Complex64> = decomposer_inv.K2l;
 
-        self.append_1q_sequence(&mut gates, &mut global_phase, decomp_k2r, 0, true);
-        self.append_1q_sequence(&mut gates, &mut global_phase, decomp_k2l, 1, true);
+        // 1-qubit gates before the rxx_op, on qubits 0 and 1 respectively
+        let k2r_inv: Matrix2<Complex64> = decomp_k2r
+            .try_inverse()
+            .expect("matrix k2r is not invertible");
+        let k2l_inv: Matrix2<Complex64> = decomp_k2l
+            .try_inverse()
+            .expect("matrix k2l is not invertible");
+
+        // 1-qubit gates after the rxx_op, on qubits 0 and 1 respectively
+        let k1r_inv: Matrix2<Complex64> = decomp_k1r
+            .try_inverse()
+            .expect("matrix k1r is not invertible");
+        let k1l_inv: Matrix2<Complex64> = decomp_k1l
+            .try_inverse()
+            .expect("matrix k1l is not invertible");
 
         let rxx_op = match &self.rxx_equivalent_gate {
             RXXEquivalent::Standard(gate) => PackedOperation::from_standard_gate(*gate),
@@ -225,13 +248,13 @@ impl TwoQubitControlledUDecomposer {
         };
         gates.push((rxx_op, smallvec![self.scale * angle], smallvec![0, 1]));
 
-        self.append_1q_sequence(&mut gates, &mut global_phase, decomp_k1r, 0, true);
-        self.append_1q_sequence(&mut gates, &mut global_phase, decomp_k1l, 1, true);
-
-        Ok(TwoQubitGateSequence {
-            gates,
-            global_phase,
-        })
+        Ok((
+            TwoQubitGateSequence {
+                gates,
+                global_phase,
+            },
+            smallvec![k2r_inv, k2l_inv, k1r_inv, k1l_inv],
+        ))
     }
 
     /// Appends U_d(a, b, c) to the circuit.
@@ -240,62 +263,84 @@ impl TwoQubitControlledUDecomposer {
         circ: &mut TwoQubitGateSequence,
         target_decomposed: &TwoQubitWeylDecomposition,
         atol: f64,
+        c_mats: SmallVec<[Matrix2<Complex64>; 4]>,
     ) -> PyResult<()> {
-        let circ_a = self.to_rxx_gate(-2.0 * target_decomposed.a)?;
-        circ.gates.extend(circ_a.gates);
-        let mut global_phase = circ_a.global_phase;
-
         let mut target_1q_basis_list = EulerBasisSet::new();
         target_1q_basis_list.add_basis(self.euler_basis);
 
-        let s_decomp = unitary_to_gate_sequence_inner(
-            aview2(&S_GATE),
-            &target_1q_basis_list,
+        // RXX(a)
+        let (circ_a, rxx_mats) = self.to_rxx_gate(-2.0 * target_decomposed.a)?;
+        let mut global_phase = circ_a.global_phase;
+
+        let c2r: Matrix2<Complex64> = c_mats[0]; // before weyl_gate, qubit 0
+        let c2l: Matrix2<Complex64> = c_mats[1]; // before weyl_gate, qubit 1
+        let c1r: Matrix2<Complex64> = c_mats[2]; // after weyl_gate, qubit 0
+        let c1l: Matrix2<Complex64> = c_mats[3]; // after weyl_gate, qubit 1
+
+        let mut rxx_k2r_inv: Matrix2<Complex64> = rxx_mats[0]; // before RXX(a), qubit 0
+        let mut rxx_k2l_inv: Matrix2<Complex64> = rxx_mats[1]; // before RXX(a), qubit 1
+        let rxx_k1r_inv: Matrix2<Complex64> = rxx_mats[2]; // after RXX(a), qubit 0
+        let rxx_k1l_inv: Matrix2<Complex64> = rxx_mats[3]; // after RXX(a), qubit 1
+
+        let mut ryy_k2r_inv: Matrix2<Complex64> = IMAT; // before RXX(b), qubit 0
+        let mut ryy_k2l_inv: Matrix2<Complex64> = IMAT; // before RXX(b), qubit 1
+        let mut ryy_k1r_inv: Matrix2<Complex64> = IMAT; // after RXX(b), qubit 0
+        let mut ryy_k1l_inv: Matrix2<Complex64> = IMAT; // after RXX(b), qubit 1
+
+        let mut rzz_k2r_inv: Matrix2<Complex64> = IMAT; // before RXX(c), qubit 0
+        let mut rzz_k2l_inv: Matrix2<Complex64> = IMAT; // before RXX(c), qubit 1
+        let mut rzz_k1r_inv: Matrix2<Complex64> = IMAT; // after RXX(c), qubit 0
+        let mut rzz_k1l_inv: Matrix2<Complex64> = IMAT; // after RXX(c), qubit 1
+
+        rxx_k2r_inv = c2r * rxx_k2r_inv;
+        rxx_k2l_inv = c2l * rxx_k2l_inv;
+
+        self.append_1q_sequence(
+            &mut circ.gates,
+            &mut global_phase,
+            rxx_k2r_inv.as_view(),
             0,
-            None,
-            true,
-            None,
+            false,
         );
-        let sdg_decomp = unitary_to_gate_sequence_inner(
-            aview2(&SDG_GATE),
-            &target_1q_basis_list,
-            0,
-            None,
-            true,
-            None,
+        self.append_1q_sequence(
+            &mut circ.gates,
+            &mut global_phase,
+            rxx_k2l_inv.as_view(),
+            1,
+            false,
         );
-        let h_decomp = unitary_to_gate_sequence_inner(
-            aview2(&H_GATE),
-            &target_1q_basis_list,
-            0,
-            None,
-            true,
-            None,
-        );
+        circ.gates.extend(circ_a.gates);
 
         // translate RYY(b) into a circuit based on the desired Ctrl-U gate.
         if (target_decomposed.b).abs() > atol {
-            let circ_b = self.to_rxx_gate(-2.0 * target_decomposed.b)?;
+            let (circ_b, ryy_mats) = self.to_rxx_gate(-2.0 * target_decomposed.b)?;
             global_phase += circ_b.global_phase;
-            if let Some(sdg_decomp) = sdg_decomp {
-                global_phase += 2.0 * sdg_decomp.global_phase;
-                for gate in sdg_decomp.gates.into_iter() {
-                    let gate_params = gate.1;
-                    circ.gates
-                        .push((gate.0.into(), gate_params.clone(), smallvec![0]));
-                    circ.gates.push((gate.0.into(), gate_params, smallvec![1]));
-                }
-            }
+
+            ryy_k2r_inv = ryy_mats[0]; // before RXX(b), qubit 0
+            ryy_k2l_inv = ryy_mats[1]; // before RXX(b), qubit 1
+            ryy_k1r_inv = ryy_mats[2]; // after RXX(b), qubit 0
+            ryy_k1l_inv = ryy_mats[3]; // after RXX(b), qubit 1
+
+            ryy_k2r_inv = rxx_k1r_inv * SDGGATE * ryy_k2r_inv; // between RXX(a) and RXX(b), qubit 0
+            ryy_k2l_inv = rxx_k1l_inv * SDGGATE * ryy_k2l_inv; // between RXX(a) and RXX(b), qubit 1
+            ryy_k1r_inv = ryy_k1r_inv * SGATE; // between RXX(b) and RXX(c), qubit 0
+            ryy_k1l_inv = ryy_k1l_inv * SGATE; // between RXX(b) and RXX(c), qubit 1
+
+            self.append_1q_sequence(
+                &mut circ.gates,
+                &mut global_phase,
+                ryy_k2r_inv.as_view(),
+                0,
+                false,
+            );
+            self.append_1q_sequence(
+                &mut circ.gates,
+                &mut global_phase,
+                ryy_k2l_inv.as_view(),
+                1,
+                false,
+            );
             circ.gates.extend(circ_b.gates);
-            if let Some(s_decomp) = s_decomp {
-                global_phase += 2.0 * s_decomp.global_phase;
-                for gate in s_decomp.gates.into_iter() {
-                    let gate_params = gate.1;
-                    circ.gates
-                        .push((gate.0.into(), gate_params.clone(), smallvec![0]));
-                    circ.gates.push((gate.0.into(), gate_params, smallvec![1]));
-                }
-            }
         }
 
         // translate RZZ(c) into a circuit based on the desired Ctrl-U gate.
@@ -307,61 +352,111 @@ impl TwoQubitControlledUDecomposer {
             // circuit if c < 0.
             let mut gamma = -2.0 * target_decomposed.c;
             if gamma <= 0.0 {
-                let circ_c = self.to_rxx_gate(gamma)?;
+                let (circ_c, rzz_mats) = self.to_rxx_gate(gamma)?;
                 global_phase += circ_c.global_phase;
 
-                if let Some(ref h_decomp) = h_decomp {
-                    global_phase += 2.0 * h_decomp.global_phase;
-                    for gate in h_decomp.gates.clone().into_iter() {
-                        let gate_params = gate.1;
-                        circ.gates
-                            .push((gate.0.into(), gate_params.clone(), smallvec![0]));
-                        circ.gates.push((gate.0.into(), gate_params, smallvec![1]));
-                    }
-                }
+                rzz_k2r_inv = rzz_mats[0]; // before RZZ(c), qubit 0
+                rzz_k2l_inv = rzz_mats[1]; // before RZZ(c), qubit 1
+                rzz_k1r_inv = rzz_mats[2]; // after RZZ(c), qubit 0
+                rzz_k1l_inv = rzz_mats[3]; // after RZZ(c), qubit 1
+
+                rzz_k2r_inv = ryy_k1r_inv * HGATE * rzz_k2r_inv; // between RZZ(b) and RZZ(c), qubit 0
+                rzz_k2l_inv = ryy_k1l_inv * HGATE * rzz_k2l_inv; // between RZZ(b) and RZZ(c), qubit 1
+                rzz_k1r_inv = rzz_k1r_inv * HGATE * c1r; // after RZZ(c), qubit 0
+                rzz_k1l_inv = rzz_k1l_inv * HGATE * c1l; // after RZZ(c), qubit 1
+
+                self.append_1q_sequence(
+                    &mut circ.gates,
+                    &mut global_phase,
+                    rzz_k2r_inv.as_view(),
+                    0,
+                    false,
+                );
+                self.append_1q_sequence(
+                    &mut circ.gates,
+                    &mut global_phase,
+                    rzz_k2l_inv.as_view(),
+                    1,
+                    false,
+                );
                 circ.gates.extend(circ_c.gates);
-                if let Some(ref h_decomp) = h_decomp {
-                    global_phase += 2.0 * h_decomp.global_phase;
-                    for gate in h_decomp.gates.clone().into_iter() {
-                        let gate_params = gate.1;
-                        circ.gates
-                            .push((gate.0.into(), gate_params.clone(), smallvec![0]));
-                        circ.gates.push((gate.0.into(), gate_params, smallvec![1]));
-                    }
-                }
+                self.append_1q_sequence(
+                    &mut circ.gates,
+                    &mut global_phase,
+                    rzz_k1r_inv.as_view(),
+                    0,
+                    false,
+                );
+                self.append_1q_sequence(
+                    &mut circ.gates,
+                    &mut global_phase,
+                    rzz_k1l_inv.as_view(),
+                    1,
+                    false,
+                );
             } else {
                 // invert the circuit above
                 gamma *= -1.0;
-                let circ_c = self.to_rxx_gate(gamma)?;
+                let (circ_c, rzz_mats) = self.to_rxx_gate(gamma)?;
                 global_phase -= circ_c.global_phase;
-                if let Some(ref h_decomp) = h_decomp {
-                    global_phase += 2.0 * h_decomp.global_phase;
-                    for gate in h_decomp.gates.clone().into_iter() {
-                        let gate_params = gate.1;
-                        circ.gates
-                            .push((gate.0.into(), gate_params.clone(), smallvec![0]));
-                        circ.gates.push((gate.0.into(), gate_params, smallvec![1]));
-                    }
-                }
+
+                // inverting the 1-qubit matrices
+                rzz_k2r_inv = rzz_mats[2]
+                    .try_inverse()
+                    .expect("matrix k2r is not invertible"); // before RZZ(c), qubit 0
+                rzz_k2l_inv = rzz_mats[3]
+                    .try_inverse()
+                    .expect("matrix k2l is not invertible"); // before RZZ(c), qubit 1
+                rzz_k1r_inv = rzz_mats[0]
+                    .try_inverse()
+                    .expect("matrix k1r is not invertible"); // after RZZ(c), qubit 0
+                rzz_k1l_inv = rzz_mats[1]
+                    .try_inverse()
+                    .expect("matrix k1l is not invertible"); // qfter RZZ(c), qubit 1
+
+                rzz_k2r_inv = ryy_k1r_inv * HGATE * rzz_k2r_inv;
+                rzz_k2l_inv = ryy_k1l_inv * HGATE * rzz_k2l_inv;
+                rzz_k1r_inv = rzz_k1r_inv * HGATE * c1r;
+                rzz_k1l_inv = rzz_k1l_inv * HGATE * c1l;
+
+                self.append_1q_sequence(
+                    &mut circ.gates,
+                    &mut global_phase,
+                    rzz_k2r_inv.as_view(),
+                    0,
+                    false,
+                );
+                self.append_1q_sequence(
+                    &mut circ.gates,
+                    &mut global_phase,
+                    rzz_k2l_inv.as_view(),
+                    0,
+                    false,
+                );
+
                 for gate in circ_c.gates.into_iter().rev() {
                     let (inv_gate_name, inv_gate_params, inv_gate_qubits) =
                         self.invert_2q_gate(gate)?;
                     circ.gates
                         .push((inv_gate_name, inv_gate_params, inv_gate_qubits));
                 }
-                if let Some(ref h_decomp) = h_decomp {
-                    global_phase += 2.0 * h_decomp.global_phase;
-                    for gate in h_decomp.gates.clone().into_iter() {
-                        let gate_params = gate.1;
-                        circ.gates
-                            .push((gate.0.into(), gate_params.clone(), smallvec![0]));
-                        circ.gates.push((gate.0.into(), gate_params, smallvec![1]));
-                    }
-                }
+                self.append_1q_sequence(
+                    &mut circ.gates,
+                    &mut global_phase,
+                    rzz_k1r_inv.as_view(),
+                    0,
+                    false,
+                );
+                self.append_1q_sequence(
+                    &mut circ.gates,
+                    &mut global_phase,
+                    rzz_k1l_inv.as_view(),
+                    0,
+                    false,
+                );
             }
         }
 
-        circ.global_phase = global_phase;
         Ok(())
     }
 
@@ -378,16 +473,17 @@ impl TwoQubitControlledUDecomposer {
         let mut target_1q_basis_list = EulerBasisSet::new();
         target_1q_basis_list.add_basis(self.euler_basis);
 
-        let c1r = target_decomposed.K1r.as_view();
-        let c2r = target_decomposed.K2r.as_view();
-        let c1l = target_decomposed.K1l.as_view();
-        let c2l = target_decomposed.K2l.as_view();
+        let c2r: Matrix2<Complex64> = target_decomposed.K2r; // qubit 0, before weyl_gate
+        let c2l: Matrix2<Complex64> = target_decomposed.K2l; // qubit 1, before weyl_gate
+        let c1r: Matrix2<Complex64> = target_decomposed.K1r; // qubit 0, after weyl_gate
+        let c1l: Matrix2<Complex64> = target_decomposed.K1l; // qubit 1, after weyl_gate
 
-        let mut gates = Vec::with_capacity(59);
+        // Capacity = 5*8 + 3 = 43
+        // 3 2-qubit gates
+        // 8 1-qubit unitaries
+        // max 5 1-qubit gates per 1-qubit unitary
+        let mut gates = Vec::with_capacity(43);
         let mut global_phase = target_decomposed.global_phase;
-
-        self.append_1q_sequence(&mut gates, &mut global_phase, c2r, 0, false);
-        self.append_1q_sequence(&mut gates, &mut global_phase, c2l, 1, false);
 
         let mut gates1 = TwoQubitGateSequence {
             gates,
@@ -397,11 +493,9 @@ impl TwoQubitControlledUDecomposer {
             &mut gates1,
             &target_decomposed,
             atol.unwrap_or(DEFAULT_ATOL),
+            smallvec![c2r, c2l, c1r, c1l],
         )?;
         global_phase += gates1.global_phase;
-
-        self.append_1q_sequence(&mut gates1.gates, &mut global_phase, c1r, 0, false);
-        self.append_1q_sequence(&mut gates1.gates, &mut global_phase, c1l, 1, false);
 
         gates1.global_phase = global_phase;
         Ok(gates1)
@@ -479,6 +573,7 @@ impl TwoQubitControlledUDecomposer {
         })
     }
 
+    // ToDo: move to common (also used by basis_decomposer)
     fn append_1q_sequence(
         &self,
         gates: &mut TwoQubitSequenceVec,

--- a/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
@@ -31,26 +31,13 @@ use crate::linalg::nalgebra_array_view;
 
 use qiskit_circuit::circuit_data::{CircuitData, PyCircuitData};
 use qiskit_circuit::circuit_instruction::OperationFromPython;
-use qiskit_circuit::gate_matrix::{H_GATE, S_GATE, SDG_GATE};
 use qiskit_circuit::operations::{Operation, OperationRef, Param, StandardGate};
 use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::{NoBlocks, Qubit};
 
-use super::common::DEFAULT_FIDELITY;
+use super::common::{DEFAULT_FIDELITY, HGATE, SDGGATE, SGATE};
 use super::gate_sequence::{TwoQubitGateSequence, TwoQubitSequenceVec};
 use super::weyl_decomposition::{Specialization, TwoQubitWeylDecomposition};
-
-// ToDo: move to common (also used by basis_decomposer)
-static HGATE: Matrix2<Complex64> =
-    Matrix2::new(H_GATE[0][0], H_GATE[0][1], H_GATE[1][0], H_GATE[1][1]);
-static SGATE: Matrix2<Complex64> =
-    Matrix2::new(S_GATE[0][0], S_GATE[0][1], S_GATE[1][0], S_GATE[1][1]);
-static SDGGATE: Matrix2<Complex64> = Matrix2::new(
-    SDG_GATE[0][0],
-    SDG_GATE[0][1],
-    SDG_GATE[1][0],
-    SDG_GATE[1][1],
-);
 
 /// invert 1q gate sequence
 fn invert_1q_gate(

--- a/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
@@ -183,30 +183,32 @@ impl TwoQubitControlledUDecomposer {
         // Express the RXX in terms of the user-provided RXX equivalent gate.
         let global_phase = -decomposer_inv.global_phase;
 
-        let mut k1r = decomposer_inv.K1r;
-        let mut k2r = decomposer_inv.K2r;
-        let mut k1l = decomposer_inv.K1l;
-        let mut k2l = decomposer_inv.K2l;
+        let k1r = decomposer_inv.K1r;
+        let k2r = decomposer_inv.K2r;
+        let k1l = decomposer_inv.K1l;
+        let k2l = decomposer_inv.K2l;
 
         // the k matrices where RXX is inverted
         let mut k_mats = [k1r, k1l, k2r, k2l];
 
         if !is_inv_rxx {
             // 1-qubit gates before the rxx_op, on qubits 0 and 1 respectively
-            if !k2r.try_inverse_mut() {
+            if !k_mats[2].try_inverse_mut() {
                 panic!("TwoQubitWeylDecomposition failed. Matrix K2r is not unitary");
             }
-            if !k2l.try_inverse_mut() {
+            if !k_mats[3].try_inverse_mut() {
                 panic!("TwoQubitWeylDecomposition failed. Matrix K2l is not unitary");
             }
             // 1-qubit gates after the rxx_op, on qubits 0 and 1 respectively
-            if !k1r.try_inverse_mut() {
+            if !k_mats[0].try_inverse_mut() {
                 panic!("TwoQubitWeylDecomposition failed. Matrix K1R is not unitary");
             }
-            if !k1l.try_inverse_mut() {
+            if !k_mats[1].try_inverse_mut() {
                 panic!("TwoQubitWeylDecomposition failed. Matrix K1l is not unitary");
             }
-            k_mats = [k2r, k2l, k1r, k1l];
+            // k_mats = [k2r_inv, k2l_inv, k1r_inv, k1l_inv];
+            k_mats.swap(0, 2);
+            k_mats.swap(1, 3);
         }
         let rxx_op = match &self.rxx_equivalent_gate {
             RXXEquivalent::Standard(gate) => PackedOperation::from_standard_gate(*gate),

--- a/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
@@ -154,7 +154,7 @@ impl TwoQubitControlledUDecomposer {
     ///  RXX equivalent gate as the two-qubit unitary.
     ///  Args:
     ///      angle: Rotation angle (in this case one of the Weyl parameters a, b, or c)
-    ///      inv_rxx: Whether the RXX equivalent gate should be inverted or not
+    ///      is_inv_rxx: Whether the RXX equivalent gate should be inverted or not
     ///  Returns:
     ///      Circuit: Circuit equivalent to an RXXGate.
     ///  Raises:
@@ -162,7 +162,7 @@ impl TwoQubitControlledUDecomposer {
     fn to_rxx_gate(
         &self,
         angle: f64,
-        inv_rxx: bool,
+        is_inv_rxx: bool,
     ) -> PyResult<(TwoQubitGateSequence, [Matrix2<Complex64>; 4])> {
         // The user-provided RXX equivalent gate may be locally equivalent to the RXX gate
         // but with some scaling in the rotation angle. For example, RXX(angle) has Weyl
@@ -176,6 +176,7 @@ impl TwoQubitControlledUDecomposer {
 
         // Express the RXX in terms of the user-provided RXX equivalent gate.
         let mut gates = Vec::with_capacity(1);
+        let mut gates_inv = Vec::with_capacity(1);
         let global_phase = -decomposer_inv.global_phase;
 
         let mut k1r = decomposer_inv.K1r;
@@ -186,7 +187,7 @@ impl TwoQubitControlledUDecomposer {
         // the k matrices where RXX is inverted
         let mut k_mats = [k1r, k1l, k2r, k2l];
 
-        if !inv_rxx {
+        if !is_inv_rxx {
             // 1-qubit gates before the rxx_op, on qubits 0 and 1 respectively
             if !k2r.try_inverse_mut() {
                 panic!("matrix k2r is not invertible");
@@ -214,6 +215,16 @@ impl TwoQubitControlledUDecomposer {
             }
         };
         gates.push((rxx_op, smallvec![self.scale * angle], smallvec![0, 1]));
+
+        if is_inv_rxx {
+            // invert the rxx_op
+            for gate in gates.into_iter().rev() {
+                let (inv_gate_name, inv_gate_params, inv_gate_qubits) =
+                    self.invert_2q_gate(gate)?;
+                gates_inv.push((inv_gate_name, inv_gate_params, inv_gate_qubits));
+            }
+            gates = gates_inv;
+        }
 
         Ok((
             TwoQubitGateSequence {
@@ -319,10 +330,11 @@ impl TwoQubitControlledUDecomposer {
             } else {
                 // invert the circuit above
                 gamma *= -1.0;
+                // the inverted 2-qubit RXX gate
                 let (circ_c, rzz_mats) = self.to_rxx_gate(gamma, true)?;
                 global_phase -= circ_c.global_phase;
 
-                // taking the inverted 1-qubit matrices
+                // the inverted 1-qubit matrices
                 rzz_k2r = rzz_mats[0]; // before RZZ(c), qubit 0
                 rzz_k2l = rzz_mats[1]; // before RZZ(c), qubit 1
                 rzz_k1r = rzz_mats[2]; // after RZZ(c), qubit 0
@@ -335,13 +347,7 @@ impl TwoQubitControlledUDecomposer {
 
                 self.append_1q_sequence(&mut circ.gates, &mut global_phase, rzz_k2r.as_view(), 0);
                 self.append_1q_sequence(&mut circ.gates, &mut global_phase, rzz_k2l.as_view(), 1);
-
-                for gate in circ_c.gates.into_iter().rev() {
-                    let (inv_gate_name, inv_gate_params, inv_gate_qubits) =
-                        self.invert_2q_gate(gate)?;
-                    circ.gates
-                        .push((inv_gate_name, inv_gate_params, inv_gate_qubits));
-                }
+                circ.gates.extend(circ_c.gates);
             }
         } else {
             // no circ_c

--- a/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
@@ -242,10 +242,8 @@ impl TwoQubitControlledUDecomposer {
         target_decomposed: &TwoQubitWeylDecomposition,
         atol: f64,
         c_mats: [Matrix2<Complex64>; 4],
+        target_1q_basis_list: EulerBasisSet,
     ) -> PyResult<()> {
-        let mut target_1q_basis_list = EulerBasisSet::new();
-        target_1q_basis_list.add_basis(self.euler_basis);
-
         // RXX(a)
         let (circ_a, rxx_mats) = self.to_rxx_gate(-2.0 * target_decomposed.a, false)?;
         let mut global_phase = circ_a.global_phase;
@@ -274,8 +272,20 @@ impl TwoQubitControlledUDecomposer {
         c2r = rxx_k2r * c2r;
         c2l = rxx_k2l * c2l;
 
-        self.append_1q_sequence(&mut circ.gates, &mut global_phase, c2r.as_view(), 0);
-        self.append_1q_sequence(&mut circ.gates, &mut global_phase, c2l.as_view(), 1);
+        self.append_1q_sequence(
+            &mut circ.gates,
+            &mut global_phase,
+            c2r.as_view(),
+            0,
+            target_1q_basis_list,
+        );
+        self.append_1q_sequence(
+            &mut circ.gates,
+            &mut global_phase,
+            c2l.as_view(),
+            1,
+            target_1q_basis_list,
+        );
         circ.gates.extend(circ_a.gates);
 
         // translate RYY(b) into a circuit based on the desired Ctrl-U gate.
@@ -293,8 +303,20 @@ impl TwoQubitControlledUDecomposer {
             ryy_k1r = SGATE * ryy_k1r; // between RYY(b) and RZZ(c), qubit 0
             ryy_k1l = SGATE * ryy_k1l; // between RYY(b) and RZZ(c), qubit 1
 
-            self.append_1q_sequence(&mut circ.gates, &mut global_phase, ryy_k2r.as_view(), 0);
-            self.append_1q_sequence(&mut circ.gates, &mut global_phase, ryy_k2l.as_view(), 1);
+            self.append_1q_sequence(
+                &mut circ.gates,
+                &mut global_phase,
+                ryy_k2r.as_view(),
+                0,
+                target_1q_basis_list,
+            );
+            self.append_1q_sequence(
+                &mut circ.gates,
+                &mut global_phase,
+                ryy_k2l.as_view(),
+                1,
+                target_1q_basis_list,
+            );
             circ.gates.extend(circ_b.gates);
         } else {
             // no circ_b
@@ -324,8 +346,20 @@ impl TwoQubitControlledUDecomposer {
                 rzz_k1r = HGATE * rzz_k1r; // after RZZ(c), qubit 0
                 rzz_k1l = HGATE * rzz_k1l; // after RZZ(c), qubit 1
 
-                self.append_1q_sequence(&mut circ.gates, &mut global_phase, rzz_k2r.as_view(), 0);
-                self.append_1q_sequence(&mut circ.gates, &mut global_phase, rzz_k2l.as_view(), 1);
+                self.append_1q_sequence(
+                    &mut circ.gates,
+                    &mut global_phase,
+                    rzz_k2r.as_view(),
+                    0,
+                    target_1q_basis_list,
+                );
+                self.append_1q_sequence(
+                    &mut circ.gates,
+                    &mut global_phase,
+                    rzz_k2l.as_view(),
+                    1,
+                    target_1q_basis_list,
+                );
                 circ.gates.extend(circ_c.gates);
             } else {
                 // invert the circuit above
@@ -345,8 +379,20 @@ impl TwoQubitControlledUDecomposer {
                 rzz_k1r = HGATE * rzz_k1r; // after RZZ(c), qubit 0
                 rzz_k1l = HGATE * rzz_k1l; // after RZZ(c), qubit 1
 
-                self.append_1q_sequence(&mut circ.gates, &mut global_phase, rzz_k2r.as_view(), 0);
-                self.append_1q_sequence(&mut circ.gates, &mut global_phase, rzz_k2l.as_view(), 1);
+                self.append_1q_sequence(
+                    &mut circ.gates,
+                    &mut global_phase,
+                    rzz_k2r.as_view(),
+                    0,
+                    target_1q_basis_list,
+                );
+                self.append_1q_sequence(
+                    &mut circ.gates,
+                    &mut global_phase,
+                    rzz_k2l.as_view(),
+                    1,
+                    target_1q_basis_list,
+                );
                 circ.gates.extend(circ_c.gates);
             }
         } else {
@@ -359,8 +405,20 @@ impl TwoQubitControlledUDecomposer {
         c1r *= rzz_k1r;
         c1l *= rzz_k1l;
 
-        self.append_1q_sequence(&mut circ.gates, &mut global_phase, c1r.as_view(), 0);
-        self.append_1q_sequence(&mut circ.gates, &mut global_phase, c1l.as_view(), 1);
+        self.append_1q_sequence(
+            &mut circ.gates,
+            &mut global_phase,
+            c1r.as_view(),
+            0,
+            target_1q_basis_list,
+        );
+        self.append_1q_sequence(
+            &mut circ.gates,
+            &mut global_phase,
+            c1l.as_view(),
+            1,
+            target_1q_basis_list,
+        );
 
         circ.global_phase = global_phase;
         Ok(())
@@ -400,6 +458,7 @@ impl TwoQubitControlledUDecomposer {
             &target_decomposed,
             atol.unwrap_or(DEFAULT_ATOL),
             [c2r, c2l, c1r, c1l],
+            target_1q_basis_list,
         )?;
         weyl_gates.global_phase += global_phase;
 
@@ -485,9 +544,8 @@ impl TwoQubitControlledUDecomposer {
         global_phase: &mut f64,
         unitary: MatrixView2<Complex64>,
         qubit: u8,
+        target_1q_basis_list: EulerBasisSet,
     ) {
-        let mut target_1q_basis_list = EulerBasisSet::new();
-        target_1q_basis_list.add_basis(self.euler_basis);
         let sequence = unitary_to_gate_sequence_inner(
             nalgebra_array_view::<Complex64, U2, U2>(unitary),
             &target_1q_basis_list,

--- a/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
@@ -194,17 +194,17 @@ impl TwoQubitControlledUDecomposer {
         if !is_inv_rxx {
             // 1-qubit gates before the rxx_op, on qubits 0 and 1 respectively
             if !k2r.try_inverse_mut() {
-                panic!("matrix k2r is not invertible");
+                panic!("TwoQubitWeylDecomposition failed. Matrix K2r is not unitary");
             }
             if !k2l.try_inverse_mut() {
-                panic!("matrix k2l is not invertible");
+                panic!("TwoQubitWeylDecomposition failed. Matrix K2l is not unitary");
             }
             // 1-qubit gates after the rxx_op, on qubits 0 and 1 respectively
             if !k1r.try_inverse_mut() {
-                panic!("matrix k1r is not invertible");
+                panic!("TwoQubitWeylDecomposition failed. Matrix K1R is not unitary");
             }
             if !k1l.try_inverse_mut() {
-                panic!("matrix k1l is not invertible");
+                panic!("TwoQubitWeylDecomposition failed. Matrix K1l is not unitary");
             }
             k_mats = [k2r, k2l, k1r, k1l];
         }

--- a/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
@@ -215,21 +215,21 @@ impl TwoQubitControlledUDecomposer {
         let mut gates = Vec::with_capacity(1);
         let global_phase = -decomposer_inv.global_phase;
 
-        let decomp_k1r: Matrix2<Complex64> = decomposer_inv.K1r;
-        let decomp_k2r: Matrix2<Complex64> = decomposer_inv.K2r;
-        let decomp_k1l: Matrix2<Complex64> = decomposer_inv.K1l;
-        let decomp_k2l: Matrix2<Complex64> = decomposer_inv.K2l;
+        let decomp_k1r = decomposer_inv.K1r;
+        let decomp_k2r = decomposer_inv.K2r;
+        let decomp_k1l = decomposer_inv.K1l;
+        let decomp_k2l = decomposer_inv.K2l;
 
         // 1-qubit gates before the rxx_op, on qubits 0 and 1 respectively
-        let k2r_inv: Matrix2<Complex64> = decomp_k2r
+        let k2r_inv = decomp_k2r
             .try_inverse()
             .expect("matrix k2r is not invertible");
-        let k2l_inv: Matrix2<Complex64> = decomp_k2l
+        let k2l_inv = decomp_k2l
             .try_inverse()
             .expect("matrix k2l is not invertible");
 
         // 1-qubit gates after the rxx_op, on qubits 0 and 1 respectively
-        let k1r_inv: Matrix2<Complex64> = decomp_k1r
+        let k1r_inv = decomp_k1r
             .try_inverse()
             .expect("matrix k1r is not invertible");
         let k1l_inv: Matrix2<Complex64> = decomp_k1l
@@ -272,28 +272,28 @@ impl TwoQubitControlledUDecomposer {
         let (circ_a, rxx_mats) = self.to_rxx_gate(-2.0 * target_decomposed.a)?;
         let mut global_phase = circ_a.global_phase;
 
-        let mut c2r: Matrix2<Complex64> = c_mats[0]; // before weyl_gate, qubit 0
-        let mut c2l: Matrix2<Complex64> = c_mats[1]; // before weyl_gate, qubit 1
-        let mut c1r: Matrix2<Complex64> = c_mats[2]; // after weyl_gate, qubit 0
-        let mut c1l: Matrix2<Complex64> = c_mats[3]; // after weyl_gate, qubit 1
+        let mut c2r = c_mats[0]; // before weyl_gate, qubit 0
+        let mut c2l = c_mats[1]; // before weyl_gate, qubit 1
+        let mut c1r = c_mats[2]; // after weyl_gate, qubit 0
+        let mut c1l = c_mats[3]; // after weyl_gate, qubit 1
 
-        let rxx_k2r_inv: Matrix2<Complex64> = rxx_mats[0]; // before RXX(a), qubit 0
-        let rxx_k2l_inv: Matrix2<Complex64> = rxx_mats[1]; // before RXX(a), qubit 1
-        let rxx_k1r_inv: Matrix2<Complex64> = rxx_mats[2]; // after RXX(a), qubit 0
-        let rxx_k1l_inv: Matrix2<Complex64> = rxx_mats[3]; // after RXX(a), qubit 1
+        let rxx_k2r_inv = rxx_mats[0]; // before RXX(a), qubit 0
+        let rxx_k2l_inv = rxx_mats[1]; // before RXX(a), qubit 1
+        let rxx_k1r_inv = rxx_mats[2]; // after RXX(a), qubit 0
+        let rxx_k1l_inv = rxx_mats[3]; // after RXX(a), qubit 1
 
-        let mut ryy_k2r_inv: Matrix2<Complex64> = IMAT; // before RXX(b), qubit 0
-        let mut ryy_k2l_inv: Matrix2<Complex64> = IMAT; // before RXX(b), qubit 1
-        let mut ryy_k1r_inv: Matrix2<Complex64> = IMAT; // after RXX(b), qubit 0
-        let mut ryy_k1l_inv: Matrix2<Complex64> = IMAT; // after RXX(b), qubit 1
+        let mut ryy_k2r_inv = IMAT; // before RXX(b), qubit 0
+        let mut ryy_k2l_inv = IMAT; // before RXX(b), qubit 1
+        let mut ryy_k1r_inv = IMAT; // after RXX(b), qubit 0
+        let mut ryy_k1l_inv = IMAT; // after RXX(b), qubit 1
 
-        let mut rzz_k2r_inv: Matrix2<Complex64> = IMAT; // before RXX(c), qubit 0
-        let mut rzz_k2l_inv: Matrix2<Complex64> = IMAT; // before RXX(c), qubit 1
-        let mut rzz_k1r_inv: Matrix2<Complex64> = IMAT; // after RXX(c), qubit 0
-        let mut rzz_k1l_inv: Matrix2<Complex64> = IMAT; // after RXX(c), qubit 1
+        let mut rzz_k2r_inv = IMAT; // before RXX(c), qubit 0
+        let mut rzz_k2l_inv = IMAT; // before RXX(c), qubit 1
+        let mut rzz_k1r_inv = IMAT; // after RXX(c), qubit 0
+        let mut rzz_k1l_inv = IMAT; // after RXX(c), qubit 1
 
-        c2r = c2r * rxx_k2r_inv;
-        c2l = c2l * rxx_k2l_inv;
+        c2r = rxx_k2r_inv * c2r;
+        c2l = rxx_k2l_inv * c2l;
 
         self.append_1q_sequence(&mut circ.gates, &mut global_phase, c2r.as_view(), 0, false);
         self.append_1q_sequence(&mut circ.gates, &mut global_phase, c2l.as_view(), 1, false);
@@ -309,10 +309,10 @@ impl TwoQubitControlledUDecomposer {
             ryy_k1r_inv = ryy_mats[2]; // after RXX(b), qubit 0
             ryy_k1l_inv = ryy_mats[3]; // after RXX(b), qubit 1
 
-            ryy_k2r_inv = rxx_k1r_inv * SDGGATE * ryy_k2r_inv; // between RXX(a) and RXX(b), qubit 0
-            ryy_k2l_inv = rxx_k1l_inv * SDGGATE * ryy_k2l_inv; // between RXX(a) and RXX(b), qubit 1
-            ryy_k1r_inv = ryy_k1r_inv * SGATE; // between RXX(b) and RXX(c), qubit 0
-            ryy_k1l_inv = ryy_k1l_inv * SGATE; // between RXX(b) and RXX(c), qubit 1
+            ryy_k2r_inv = ryy_k2r_inv * SDGGATE * rxx_k1r_inv; // between RXX(a) and RXX(b), qubit 0
+            ryy_k2l_inv = ryy_k2l_inv * SDGGATE * rxx_k1l_inv; // between RXX(a) and RXX(b), qubit 1
+            ryy_k1r_inv = SGATE * ryy_k1r_inv; // between RXX(b) and RXX(c), qubit 0
+            ryy_k1l_inv = SGATE * ryy_k1l_inv; // between RXX(b) and RXX(c), qubit 1
 
             self.append_1q_sequence(
                 &mut circ.gates,
@@ -329,6 +329,10 @@ impl TwoQubitControlledUDecomposer {
                 false,
             );
             circ.gates.extend(circ_b.gates);
+        } else {
+            // no circ_b
+            ryy_k1r_inv = rxx_k1r_inv;
+            ryy_k1l_inv = rxx_k1l_inv;
         }
 
         // translate RZZ(c) into a circuit based on the desired Ctrl-U gate.
@@ -348,10 +352,10 @@ impl TwoQubitControlledUDecomposer {
                 rzz_k1r_inv = rzz_mats[2]; // after RZZ(c), qubit 0
                 rzz_k1l_inv = rzz_mats[3]; // after RZZ(c), qubit 1
 
-                rzz_k2r_inv = ryy_k1r_inv * HGATE * rzz_k2r_inv; // between RZZ(b) and RZZ(c), qubit 0
-                rzz_k2l_inv = ryy_k1l_inv * HGATE * rzz_k2l_inv; // between RZZ(b) and RZZ(c), qubit 1
-                rzz_k1r_inv = rzz_k1r_inv * HGATE; // after RZZ(c), qubit 0
-                rzz_k1l_inv = rzz_k1l_inv * HGATE; // after RZZ(c), qubit 1
+                rzz_k2r_inv = rzz_k2r_inv * HGATE * ryy_k1r_inv; // between RZZ(b) and RZZ(c), qubit 0
+                rzz_k2l_inv = rzz_k2l_inv * HGATE * ryy_k1l_inv; // between RZZ(b) and RZZ(c), qubit 1
+                rzz_k1r_inv = HGATE * rzz_k1r_inv; // after RZZ(c), qubit 0
+                rzz_k1l_inv = HGATE * rzz_k1l_inv; // after RZZ(c), qubit 1
 
                 self.append_1q_sequence(
                     &mut circ.gates,
@@ -388,10 +392,10 @@ impl TwoQubitControlledUDecomposer {
                     .try_inverse()
                     .expect("matrix k1l is not invertible"); // qfter RZZ(c), qubit 1
 
-                rzz_k2r_inv = ryy_k1r_inv * HGATE * rzz_k2r_inv;
-                rzz_k2l_inv = ryy_k1l_inv * HGATE * rzz_k2l_inv;
-                rzz_k1r_inv = rzz_k1r_inv * HGATE;
-                rzz_k1l_inv = rzz_k1l_inv * HGATE;
+                rzz_k2r_inv = rzz_k2r_inv * HGATE * ryy_k1r_inv; // between RZZ(b) and RZZ(c), qubit 0
+                rzz_k2l_inv = rzz_k2l_inv * HGATE * ryy_k1l_inv; // between RZZ(b) and RZZ(c), qubit 1
+                rzz_k1r_inv = HGATE * rzz_k1r_inv; // after RZZ(c), qubit 0
+                rzz_k1l_inv = HGATE * rzz_k1l_inv; // after RZZ(c), qubit 1
 
                 self.append_1q_sequence(
                     &mut circ.gates,
@@ -415,14 +419,19 @@ impl TwoQubitControlledUDecomposer {
                         .push((inv_gate_name, inv_gate_params, inv_gate_qubits));
                 }
             }
+        } else {
+            // no circ_c
+            rzz_k1r_inv = ryy_k1r_inv;
+            rzz_k1l_inv = ryy_k1l_inv;
         }
 
-        c1r = rzz_k1r_inv * c1r;
-        c1l = rzz_k1l_inv * c1l;
+        c1r = c1r * rzz_k1r_inv;
+        c1l = c1l * rzz_k1l_inv;
 
         self.append_1q_sequence(&mut circ.gates, &mut global_phase, c1r.as_view(), 0, false);
         self.append_1q_sequence(&mut circ.gates, &mut global_phase, c1l.as_view(), 1, false);
 
+        circ.global_phase = global_phase;
         Ok(())
     }
 

--- a/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
@@ -389,7 +389,7 @@ impl TwoQubitControlledUDecomposer {
         // 8 1-qubit unitaries
         // max 5 1-qubit gates per 1-qubit unitary
         let gates = Vec::with_capacity(43);
-        let mut global_phase = target_decomposed.global_phase;
+        let global_phase = target_decomposed.global_phase;
 
         let mut weyl_gates = TwoQubitGateSequence {
             gates,
@@ -401,8 +401,7 @@ impl TwoQubitControlledUDecomposer {
             atol.unwrap_or(DEFAULT_ATOL),
             [c2r, c2l, c1r, c1l],
         )?;
-        global_phase += weyl_gates.global_phase;
-        weyl_gates.global_phase = global_phase;
+        weyl_gates.global_phase += global_phase;
 
         Ok(weyl_gates)
     }

--- a/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
@@ -31,7 +31,7 @@ use crate::linalg::nalgebra_array_view;
 
 use qiskit_circuit::circuit_data::{CircuitData, PyCircuitData};
 use qiskit_circuit::circuit_instruction::OperationFromPython;
-use qiskit_circuit::gate_matrix::{H_GATE, ONE_QUBIT_IDENTITY, S_GATE, SDG_GATE};
+use qiskit_circuit::gate_matrix::{H_GATE, S_GATE, SDG_GATE};
 use qiskit_circuit::operations::{Operation, OperationRef, Param, StandardGate};
 use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::{NoBlocks, Qubit};
@@ -41,12 +41,6 @@ use super::gate_sequence::{TwoQubitGateSequence, TwoQubitSequenceVec};
 use super::weyl_decomposition::{Specialization, TwoQubitWeylDecomposition};
 
 // ToDo: move to common (also used by basis_decomposer)
-static IMAT: Matrix2<Complex64> = Matrix2::new(
-    ONE_QUBIT_IDENTITY[0][0],
-    ONE_QUBIT_IDENTITY[0][1],
-    ONE_QUBIT_IDENTITY[1][0],
-    ONE_QUBIT_IDENTITY[1][1],
-);
 static HGATE: Matrix2<Complex64> =
     Matrix2::new(H_GATE[0][0], H_GATE[0][1], H_GATE[1][0], H_GATE[1][1]);
 static SGATE: Matrix2<Complex64> =
@@ -282,16 +276,17 @@ impl TwoQubitControlledUDecomposer {
         let rxx_k1r_inv = rxx_mats[2]; // after RXX(a), qubit 0
         let rxx_k1l_inv = rxx_mats[3]; // after RXX(a), qubit 1
 
-        let mut ryy_k2r_inv = IMAT; // before RXX(b), qubit 0
-        let mut ryy_k2l_inv = IMAT; // before RXX(b), qubit 1
-        let mut ryy_k1r_inv = IMAT; // after RXX(b), qubit 0
-        let mut ryy_k1l_inv = IMAT; // after RXX(b), qubit 1
+        let mut ryy_k2r_inv: Matrix2<Complex64>; // before RYY(b), qubit 0
+        let mut ryy_k2l_inv: Matrix2<Complex64>; // before RYY(b), qubit 1
+        let mut ryy_k1r_inv: Matrix2<Complex64>; // after RYY(b), qubit 0
+        let mut ryy_k1l_inv: Matrix2<Complex64>; // after RYY(b), qubit 1
 
-        let mut rzz_k2r_inv = IMAT; // before RXX(c), qubit 0
-        let mut rzz_k2l_inv = IMAT; // before RXX(c), qubit 1
-        let mut rzz_k1r_inv = IMAT; // after RXX(c), qubit 0
-        let mut rzz_k1l_inv = IMAT; // after RXX(c), qubit 1
+        let mut rzz_k2r_inv: Matrix2<Complex64>; // before RZZ(c), qubit 0
+        let mut rzz_k2l_inv: Matrix2<Complex64>; // before RZZ(c), qubit 1
+        let mut rzz_k1r_inv: Matrix2<Complex64>; // after RZZ(c), qubit 0
+        let mut rzz_k1l_inv: Matrix2<Complex64>; // after RZZ(c), qubit 1
 
+        // before the weyl_gate
         c2r = rxx_k2r_inv * c2r;
         c2l = rxx_k2l_inv * c2l;
 
@@ -304,15 +299,15 @@ impl TwoQubitControlledUDecomposer {
             let (circ_b, ryy_mats) = self.to_rxx_gate(-2.0 * target_decomposed.b)?;
             global_phase += circ_b.global_phase;
 
-            ryy_k2r_inv = ryy_mats[0]; // before RXX(b), qubit 0
-            ryy_k2l_inv = ryy_mats[1]; // before RXX(b), qubit 1
-            ryy_k1r_inv = ryy_mats[2]; // after RXX(b), qubit 0
-            ryy_k1l_inv = ryy_mats[3]; // after RXX(b), qubit 1
+            ryy_k2r_inv = ryy_mats[0]; // before RYY(b), qubit 0
+            ryy_k2l_inv = ryy_mats[1]; // before RYY(b), qubit 1
+            ryy_k1r_inv = ryy_mats[2]; // after RYY(b), qubit 0
+            ryy_k1l_inv = ryy_mats[3]; // after RYY(b), qubit 1
 
-            ryy_k2r_inv = ryy_k2r_inv * SDGGATE * rxx_k1r_inv; // between RXX(a) and RXX(b), qubit 0
-            ryy_k2l_inv = ryy_k2l_inv * SDGGATE * rxx_k1l_inv; // between RXX(a) and RXX(b), qubit 1
-            ryy_k1r_inv = SGATE * ryy_k1r_inv; // between RXX(b) and RXX(c), qubit 0
-            ryy_k1l_inv = SGATE * ryy_k1l_inv; // between RXX(b) and RXX(c), qubit 1
+            ryy_k2r_inv = ryy_k2r_inv * SDGGATE * rxx_k1r_inv; // between RXX(a) and RYY(b), qubit 0
+            ryy_k2l_inv = ryy_k2l_inv * SDGGATE * rxx_k1l_inv; // between RXX(a) and RYY(b), qubit 1
+            ryy_k1r_inv = SGATE * ryy_k1r_inv; // between RYY(b) and RZZ(c), qubit 0
+            ryy_k1l_inv = SGATE * ryy_k1l_inv; // between RYY(b) and RZZ(c), qubit 1
 
             self.append_1q_sequence(
                 &mut circ.gates,
@@ -352,8 +347,8 @@ impl TwoQubitControlledUDecomposer {
                 rzz_k1r_inv = rzz_mats[2]; // after RZZ(c), qubit 0
                 rzz_k1l_inv = rzz_mats[3]; // after RZZ(c), qubit 1
 
-                rzz_k2r_inv = rzz_k2r_inv * HGATE * ryy_k1r_inv; // between RZZ(b) and RZZ(c), qubit 0
-                rzz_k2l_inv = rzz_k2l_inv * HGATE * ryy_k1l_inv; // between RZZ(b) and RZZ(c), qubit 1
+                rzz_k2r_inv = rzz_k2r_inv * HGATE * ryy_k1r_inv; // between RYY(b) and RZZ(c), qubit 0
+                rzz_k2l_inv = rzz_k2l_inv * HGATE * ryy_k1l_inv; // between RYY(b) and RZZ(c), qubit 1
                 rzz_k1r_inv = HGATE * rzz_k1r_inv; // after RZZ(c), qubit 0
                 rzz_k1l_inv = HGATE * rzz_k1l_inv; // after RZZ(c), qubit 1
 
@@ -392,8 +387,8 @@ impl TwoQubitControlledUDecomposer {
                     .try_inverse()
                     .expect("matrix k1l is not invertible"); // qfter RZZ(c), qubit 1
 
-                rzz_k2r_inv = rzz_k2r_inv * HGATE * ryy_k1r_inv; // between RZZ(b) and RZZ(c), qubit 0
-                rzz_k2l_inv = rzz_k2l_inv * HGATE * ryy_k1l_inv; // between RZZ(b) and RZZ(c), qubit 1
+                rzz_k2r_inv = rzz_k2r_inv * HGATE * ryy_k1r_inv; // between RYY(b) and RZZ(c), qubit 0
+                rzz_k2l_inv = rzz_k2l_inv * HGATE * ryy_k1l_inv; // between RYY(b) and RZZ(c), qubit 1
                 rzz_k1r_inv = HGATE * rzz_k1r_inv; // after RZZ(c), qubit 0
                 rzz_k1l_inv = HGATE * rzz_k1l_inv; // after RZZ(c), qubit 1
 
@@ -425,8 +420,9 @@ impl TwoQubitControlledUDecomposer {
             rzz_k1l_inv = ryy_k1l_inv;
         }
 
-        c1r = c1r * rzz_k1r_inv;
-        c1l = c1l * rzz_k1l_inv;
+        // after the weyl_gate
+        c1r *= rzz_k1r_inv;
+        c1l *= rzz_k1l_inv;
 
         self.append_1q_sequence(&mut circ.gates, &mut global_phase, c1r.as_view(), 0, false);
         self.append_1q_sequence(&mut circ.gates, &mut global_phase, c1l.as_view(), 1, false);

--- a/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
@@ -404,7 +404,7 @@ impl TwoQubitControlledUDecomposer {
                     &mut circ.gates,
                     &mut global_phase,
                     rzz_k2l_inv.as_view(),
-                    0,
+                    1,
                     false,
                 );
 

--- a/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
@@ -15,7 +15,7 @@ use num_complex::Complex64;
 use smallvec::{SmallVec, smallvec};
 use std::f64::consts::FRAC_PI_2;
 
-use nalgebra::U2;
+use nalgebra::{MatrixView2, U2};
 use ndarray::prelude::*;
 use numpy::PyReadonlyArray2;
 
@@ -37,7 +37,7 @@ use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::{NoBlocks, Qubit};
 
 use super::common::DEFAULT_FIDELITY;
-use super::gate_sequence::TwoQubitGateSequence;
+use super::gate_sequence::{TwoQubitGateSequence, TwoQubitSequenceVec};
 use super::weyl_decomposition::{Specialization, TwoQubitWeylDecomposition};
 
 /// invert 1q gate sequence
@@ -114,6 +114,14 @@ pub struct TwoQubitControlledUDecomposer {
     euler_basis: EulerBasis,
     #[pyo3(get)]
     scale: f64,
+    // u0l: Matrix2<Complex64>,
+    // u0r: Matrix2<Complex64>,
+    // u1l: Matrix2<Complex64>,
+    // u1r: Matrix2<Complex64>,
+    // u2l: Matrix2<Complex64>,
+    // u2r: Matrix2<Complex64>,
+    // u3l: Matrix2<Complex64>,
+    // u3r: Matrix2<Complex64>,
 }
 
 const DEFAULT_ATOL: f64 = 1e-12;
@@ -197,34 +205,14 @@ impl TwoQubitControlledUDecomposer {
         let mut gates = Vec::with_capacity(13);
         let mut global_phase = -decomposer_inv.global_phase;
 
-        let decomp_k1r = nalgebra_array_view::<Complex64, U2, U2>(decomposer_inv.K1r.as_view());
-        let decomp_k2r = nalgebra_array_view::<Complex64, U2, U2>(decomposer_inv.K2r.as_view());
-        let decomp_k1l = nalgebra_array_view::<Complex64, U2, U2>(decomposer_inv.K1l.as_view());
-        let decomp_k2l = nalgebra_array_view::<Complex64, U2, U2>(decomposer_inv.K2l.as_view());
+        let decomp_k1r = decomposer_inv.K1r.as_view();
+        let decomp_k2r = decomposer_inv.K2r.as_view();
+        let decomp_k1l = decomposer_inv.K1l.as_view();
+        let decomp_k2l = decomposer_inv.K2l.as_view();
 
-        let unitary_k1r =
-            unitary_to_gate_sequence_inner(decomp_k1r, &target_1q_basis_list, 0, None, true, None);
-        let unitary_k2r =
-            unitary_to_gate_sequence_inner(decomp_k2r, &target_1q_basis_list, 0, None, true, None);
-        let unitary_k1l =
-            unitary_to_gate_sequence_inner(decomp_k1l, &target_1q_basis_list, 0, None, true, None);
-        let unitary_k2l =
-            unitary_to_gate_sequence_inner(decomp_k2l, &target_1q_basis_list, 0, None, true, None);
+        self.append_1q_sequence(&mut gates, &mut global_phase, decomp_k2r, 0, true);
+        self.append_1q_sequence(&mut gates, &mut global_phase, decomp_k2l, 1, true);
 
-        if let Some(unitary_k2r) = unitary_k2r {
-            global_phase -= unitary_k2r.global_phase;
-            for gate in unitary_k2r.gates.into_iter().rev() {
-                let (inv_gate_name, inv_gate_params) = invert_1q_gate(gate);
-                gates.push((inv_gate_name, inv_gate_params, smallvec![0]));
-            }
-        }
-        if let Some(unitary_k2l) = unitary_k2l {
-            global_phase -= unitary_k2l.global_phase;
-            for gate in unitary_k2l.gates.into_iter().rev() {
-                let (inv_gate_name, inv_gate_params) = invert_1q_gate(gate);
-                gates.push((inv_gate_name, inv_gate_params, smallvec![1]));
-            }
-        }
         let rxx_op = match &self.rxx_equivalent_gate {
             RXXEquivalent::Standard(gate) => PackedOperation::from_standard_gate(*gate),
             RXXEquivalent::CustomPython(gate_cls) => {
@@ -237,20 +225,8 @@ impl TwoQubitControlledUDecomposer {
         };
         gates.push((rxx_op, smallvec![self.scale * angle], smallvec![0, 1]));
 
-        if let Some(unitary_k1r) = unitary_k1r {
-            global_phase -= unitary_k1r.global_phase;
-            for gate in unitary_k1r.gates.into_iter().rev() {
-                let (inv_gate_name, inv_gate_params) = invert_1q_gate(gate);
-                gates.push((inv_gate_name, inv_gate_params, smallvec![0]));
-            }
-        }
-        if let Some(unitary_k1l) = unitary_k1l {
-            global_phase -= unitary_k1l.global_phase;
-            for gate in unitary_k1l.gates.into_iter().rev() {
-                let (inv_gate_name, inv_gate_params) = invert_1q_gate(gate);
-                gates.push((inv_gate_name, inv_gate_params, smallvec![1]));
-            }
-        }
+        self.append_1q_sequence(&mut gates, &mut global_phase, decomp_k1r, 0, true);
+        self.append_1q_sequence(&mut gates, &mut global_phase, decomp_k1l, 1, true);
 
         Ok(TwoQubitGateSequence {
             gates,
@@ -525,6 +501,41 @@ impl TwoQubitControlledUDecomposer {
             rxx_equivalent_gate,
             euler_basis: EulerBasis::__new__(euler_basis)?,
         })
+    }
+
+    fn append_1q_sequence(
+        &self,
+        gates: &mut TwoQubitSequenceVec,
+        global_phase: &mut f64,
+        unitary: MatrixView2<Complex64>,
+        qubit: u8,
+        is_inv: bool,
+    ) {
+        let mut target_1q_basis_list = EulerBasisSet::new();
+        target_1q_basis_list.add_basis(self.euler_basis);
+        let sequence = unitary_to_gate_sequence_inner(
+            nalgebra_array_view::<Complex64, U2, U2>(unitary),
+            &target_1q_basis_list,
+            qubit as usize,
+            None,
+            true,
+            None,
+        );
+        if let Some(sequence) = sequence {
+            if !is_inv {
+                *global_phase += sequence.global_phase;
+                for gate in sequence.gates {
+                    gates.push((gate.0.into(), gate.1, smallvec![qubit]));
+                }
+            } else {
+                // invert the sequence of gates
+                *global_phase -= sequence.global_phase;
+                for gate in sequence.gates.into_iter().rev() {
+                    let (inv_gate_name, inv_gate_params) = invert_1q_gate(gate);
+                    gates.push((inv_gate_name, inv_gate_params, smallvec![qubit]));
+                }
+            }
+        }
     }
 }
 

--- a/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
@@ -39,12 +39,12 @@ use super::common::{DEFAULT_FIDELITY, HGATE, SDGGATE, SGATE};
 use super::gate_sequence::{TwoQubitGateSequence, TwoQubitSequenceVec};
 use super::weyl_decomposition::{Specialization, TwoQubitWeylDecomposition};
 
-type TwoQubitUnitary = (
-    PackedOperation,
-    SmallVec<[f64; 3]>,
-    f64,
-    [Matrix2<Complex64>; 4],
-);
+struct TwoQubitUnitary {
+    op: PackedOperation,
+    params: SmallVec<[f64; 3]>,
+    global_phase: f64,
+    one_qubit_components: [Matrix2<Complex64>; 4],
+}
 
 #[derive(Clone, Debug, FromPyObject)]
 pub enum RXXEquivalent {
@@ -243,7 +243,12 @@ impl TwoQubitControlledUDecomposer {
             out_gate_params = inv_gate_params;
         }
 
-        Ok((out_gate_name, out_gate_params, global_phase, k_mats))
+        Ok(TwoQubitUnitary {
+            op: out_gate_name,
+            params: out_gate_params,
+            global_phase,
+            one_qubit_components: k_mats,
+        })
     }
 
     /// Appends U_d(a, b, c) to the circuit.
@@ -255,11 +260,11 @@ impl TwoQubitControlledUDecomposer {
     /// q_1: ┤ c2l ├┤1      ├┤ c1l ├
     ///      └─────┘└───────┘└─────┘
     /// The Weyl gate can be decomposed into the following product of 2-qubit gates
-    ///      ┌─────────┐┌─────────┐        
+    ///      ┌─────────┐┌─────────┐
     /// q_0: ┤0        ├┤0        ├─■──────
     ///      │  Rxx(a) ││  Ryy(b) │ │ZZ(c)
     /// q_1: ┤1        ├┤1        ├─■──────
-    ///      └─────────┘└─────────┘       
+    ///      └─────────┘└─────────┘
     /// RYY(b) is decomposed as
     ///      ┌─────┐┌─────────┐┌───┐
     /// q_0: ┤ Sdg ├┤0        ├┤ S ├
@@ -300,8 +305,12 @@ impl TwoQubitControlledUDecomposer {
         target_1q_basis_list: EulerBasisSet,
     ) -> PyResult<()> {
         // RXX(a)
-        let (circ_a_name, circ_a_params, global_phase_a, rxx_mats) =
-            self.to_rxx_gate(-2.0 * target_decomposed.a, false)?;
+        let TwoQubitUnitary {
+            op: circ_a_name,
+            params: circ_a_params,
+            global_phase: global_phase_a,
+            one_qubit_components: rxx_mats,
+        } = self.to_rxx_gate(-2.0 * target_decomposed.a, false)?;
         let mut global_phase = global_phase_a;
 
         let mut c2r = c_mats[0]; // before weyl_gate, qubit 0
@@ -347,8 +356,12 @@ impl TwoQubitControlledUDecomposer {
 
         // translate RYY(b) into a circuit based on the desired Ctrl-U gate.
         if (target_decomposed.b).abs() > atol {
-            let (circ_b_name, circ_b_params, global_phase_b, ryy_mats) =
-                self.to_rxx_gate(-2.0 * target_decomposed.b, false)?;
+            let TwoQubitUnitary {
+                op: circ_b_name,
+                params: circ_b_params,
+                global_phase: global_phase_b,
+                one_qubit_components: ryy_mats,
+            } = self.to_rxx_gate(-2.0 * target_decomposed.b, false)?;
             global_phase += global_phase_b;
 
             ryy_k2r = ryy_mats[0]; // before RXX(b), qubit 0
@@ -392,8 +405,12 @@ impl TwoQubitControlledUDecomposer {
             // circuit if c < 0.
             let mut gamma = -2.0 * target_decomposed.c;
             if gamma <= 0.0 {
-                let (circ_c_name, circ_c_params, global_phase_c, rzz_mats) =
-                    self.to_rxx_gate(gamma, false)?;
+                let TwoQubitUnitary {
+                    op: circ_c_name,
+                    params: circ_c_params,
+                    global_phase: global_phase_c,
+                    one_qubit_components: rzz_mats,
+                } = self.to_rxx_gate(gamma, false)?;
                 global_phase += global_phase_c;
 
                 rzz_k2r = rzz_mats[0]; // before RXX(c), qubit 0
@@ -426,8 +443,12 @@ impl TwoQubitControlledUDecomposer {
                 // invert the circuit above
                 gamma *= -1.0;
                 // the inverted 2-qubit RXX gate
-                let (circ_c_name, circ_c_params, global_phase_c, rzz_mats) =
-                    self.to_rxx_gate(gamma, true)?;
+                let TwoQubitUnitary {
+                    op: circ_c_name,
+                    params: circ_c_params,
+                    global_phase: global_phase_c,
+                    one_qubit_components: rzz_mats,
+                } = self.to_rxx_gate(gamma, true)?;
                 global_phase -= global_phase_c;
 
                 // the inverted 1-qubit matrices

--- a/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
@@ -39,7 +39,12 @@ use super::common::{DEFAULT_FIDELITY, HGATE, SDGGATE, SGATE};
 use super::gate_sequence::{TwoQubitGateSequence, TwoQubitSequenceVec};
 use super::weyl_decomposition::{Specialization, TwoQubitWeylDecomposition};
 
-type TwoQubitGateType = (PackedOperation, SmallVec<[f64; 3]>, SmallVec<[u8; 2]>);
+type TwoQubitUnitary = (
+    PackedOperation,
+    SmallVec<[f64; 3]>,
+    f64,
+    [Matrix2<Complex64>; 4],
+);
 
 #[derive(Clone, Debug, FromPyObject)]
 pub enum RXXEquivalent {
@@ -158,16 +163,13 @@ impl TwoQubitControlledUDecomposer {
     ///      angle: Rotation angle (in this case one of the Weyl parameters a, b, or c)
     ///      is_inv_rxx: Whether the RXX equivalent gate should be inverted or not
     ///  Returns:
-    ///      out_gate: An equivalent gate to an RXXGate (or its inverse)
+    ///      out_gate_name: An equivalent 2-qubit gate (or its inverse)
+    ///      out_gate_params: The equivalent 2-qubit gate params
     ///      global_phase: The global phase of the equivalent circuit
-    ///      k_mats: Four 1-qubit gates in the equivalent circuit
+    ///      k_mats: Four 1-qubit gates in the equivalent circuit (before and after the 2-qubit gate)
     ///  Raises:
     ///      QiskitError: If the circuit is not equivalent to an RXXGate.
-    fn to_rxx_gate(
-        &self,
-        angle: f64,
-        is_inv_rxx: bool,
-    ) -> PyResult<(TwoQubitGateType, f64, [Matrix2<Complex64>; 4])> {
+    fn to_rxx_gate(&self, angle: f64, is_inv_rxx: bool) -> PyResult<TwoQubitUnitary> {
         // The user-provided RXX equivalent gate may be locally equivalent to the RXX gate
         // but with some scaling in the rotation angle. For example, RXX(angle) has Weyl
         // parameters (angle, 0, 0) for angle in [0, pi/2] but the user provided gate, i.e.
@@ -216,16 +218,18 @@ impl TwoQubitControlledUDecomposer {
                 })?
             }
         };
-        let mut out_gate = (rxx_op, smallvec![self.scale * angle], smallvec![0, 1]);
+        let mut out_gate_name = rxx_op;
+        let mut out_gate_params = smallvec![self.scale * angle];
 
         if is_inv_rxx {
             // invert the rxx_op
-            let (inv_gate_name, inv_gate_params, inv_gate_qubits) =
-                self.invert_2q_gate(out_gate)?;
-            out_gate = (inv_gate_name, inv_gate_params, inv_gate_qubits);
+            let (inv_gate_name, inv_gate_params, _inv_gate_qubits) =
+                self.invert_2q_gate((out_gate_name, out_gate_params, smallvec![0, 1]))?;
+            out_gate_name = inv_gate_name;
+            out_gate_params = inv_gate_params;
         }
 
-        Ok((out_gate, global_phase, k_mats))
+        Ok((out_gate_name, out_gate_params, global_phase, k_mats))
     }
 
     /// Appends U_d(a, b, c) to the circuit.
@@ -238,7 +242,7 @@ impl TwoQubitControlledUDecomposer {
         target_1q_basis_list: EulerBasisSet,
     ) -> PyResult<()> {
         // RXX(a)
-        let (circ_a, global_phase_a, rxx_mats) =
+        let (circ_a_name, circ_a_params, global_phase_a, rxx_mats) =
             self.to_rxx_gate(-2.0 * target_decomposed.a, false)?;
         let mut global_phase = global_phase_a;
 
@@ -280,11 +284,12 @@ impl TwoQubitControlledUDecomposer {
             1,
             target_1q_basis_list,
         );
-        circ.gates.push(circ_a);
+        circ.gates
+            .push((circ_a_name, circ_a_params, smallvec![0, 1]));
 
         // translate RYY(b) into a circuit based on the desired Ctrl-U gate.
         if (target_decomposed.b).abs() > atol {
-            let (circ_b, global_phase_b, ryy_mats) =
+            let (circ_b_name, circ_b_params, global_phase_b, ryy_mats) =
                 self.to_rxx_gate(-2.0 * target_decomposed.b, false)?;
             global_phase += global_phase_b;
 
@@ -312,7 +317,8 @@ impl TwoQubitControlledUDecomposer {
                 1,
                 target_1q_basis_list,
             );
-            circ.gates.push(circ_b);
+            circ.gates
+                .push((circ_b_name, circ_b_params, smallvec![0, 1]));
         } else {
             // no circ_b
             ryy_k1r = rxx_k1r;
@@ -328,7 +334,8 @@ impl TwoQubitControlledUDecomposer {
             // circuit if c < 0.
             let mut gamma = -2.0 * target_decomposed.c;
             if gamma <= 0.0 {
-                let (circ_c, global_phase_c, rzz_mats) = self.to_rxx_gate(gamma, false)?;
+                let (circ_c_name, circ_c_params, global_phase_c, rzz_mats) =
+                    self.to_rxx_gate(gamma, false)?;
                 global_phase += global_phase_c;
 
                 rzz_k2r = rzz_mats[0]; // before RZZ(c), qubit 0
@@ -355,12 +362,14 @@ impl TwoQubitControlledUDecomposer {
                     1,
                     target_1q_basis_list,
                 );
-                circ.gates.push(circ_c);
+                circ.gates
+                    .push((circ_c_name, circ_c_params, smallvec![0, 1]));
             } else {
                 // invert the circuit above
                 gamma *= -1.0;
                 // the inverted 2-qubit RXX gate
-                let (circ_c, global_phase_c, rzz_mats) = self.to_rxx_gate(gamma, true)?;
+                let (circ_c_name, circ_c_params, global_phase_c, rzz_mats) =
+                    self.to_rxx_gate(gamma, true)?;
                 global_phase -= global_phase_c;
 
                 // the inverted 1-qubit matrices
@@ -388,7 +397,8 @@ impl TwoQubitControlledUDecomposer {
                     1,
                     target_1q_basis_list,
                 );
-                circ.gates.push(circ_c);
+                circ.gates
+                    .push((circ_c_name, circ_c_params, smallvec![0, 1]));
             }
         } else {
             // no circ_c

--- a/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
@@ -154,6 +154,7 @@ impl TwoQubitControlledUDecomposer {
     ///  RXX equivalent gate as the two-qubit unitary.
     ///  Args:
     ///      angle: Rotation angle (in this case one of the Weyl parameters a, b, or c)
+    ///      inv_rxx: Whether the RXX equivalent gate should be inverted or not
     ///  Returns:
     ///      Circuit: Circuit equivalent to an RXXGate.
     ///  Raises:
@@ -161,7 +162,8 @@ impl TwoQubitControlledUDecomposer {
     fn to_rxx_gate(
         &self,
         angle: f64,
-    ) -> PyResult<(TwoQubitGateSequence, SmallVec<[Matrix2<Complex64>; 4]>)> {
+        inv_rxx: bool,
+    ) -> PyResult<(TwoQubitGateSequence, [Matrix2<Complex64>; 4])> {
         // The user-provided RXX equivalent gate may be locally equivalent to the RXX gate
         // but with some scaling in the rotation angle. For example, RXX(angle) has Weyl
         // parameters (angle, 0, 0) for angle in [0, pi/2] but the user provided gate, i.e.
@@ -181,19 +183,25 @@ impl TwoQubitControlledUDecomposer {
         let mut k1l = decomposer_inv.K1l;
         let mut k2l = decomposer_inv.K2l;
 
-        // 1-qubit gates before the rxx_op, on qubits 0 and 1 respectively
-        if !k2r.try_inverse_mut() {
-            panic!("matrix k2r is not invertible");
-        }
-        if !k2l.try_inverse_mut() {
-            panic!("matrix k2l is not invertible");
-        }
-        // 1-qubit gates after the rxx_op, on qubits 0 and 1 respectively
-        if !k1r.try_inverse_mut() {
-            panic!("matrix k1r is not invertible");
-        }
-        if !k1l.try_inverse_mut() {
-            panic!("matrix k1l is not invertible");
+        // the k matrices where RXX is inverted
+        let mut k_mats = [k1r, k1l, k2r, k2l];
+
+        if !inv_rxx {
+            // 1-qubit gates before the rxx_op, on qubits 0 and 1 respectively
+            if !k2r.try_inverse_mut() {
+                panic!("matrix k2r is not invertible");
+            }
+            if !k2l.try_inverse_mut() {
+                panic!("matrix k2l is not invertible");
+            }
+            // 1-qubit gates after the rxx_op, on qubits 0 and 1 respectively
+            if !k1r.try_inverse_mut() {
+                panic!("matrix k1r is not invertible");
+            }
+            if !k1l.try_inverse_mut() {
+                panic!("matrix k1l is not invertible");
+            }
+            k_mats = [k2r, k2l, k1r, k1l];
         }
         let rxx_op = match &self.rxx_equivalent_gate {
             RXXEquivalent::Standard(gate) => PackedOperation::from_standard_gate(*gate),
@@ -212,7 +220,7 @@ impl TwoQubitControlledUDecomposer {
                 gates,
                 global_phase,
             },
-            smallvec![k2r, k2l, k1r, k1l],
+            k_mats,
         ))
     }
 
@@ -222,13 +230,13 @@ impl TwoQubitControlledUDecomposer {
         circ: &mut TwoQubitGateSequence,
         target_decomposed: &TwoQubitWeylDecomposition,
         atol: f64,
-        c_mats: SmallVec<[Matrix2<Complex64>; 4]>,
+        c_mats: [Matrix2<Complex64>; 4],
     ) -> PyResult<()> {
         let mut target_1q_basis_list = EulerBasisSet::new();
         target_1q_basis_list.add_basis(self.euler_basis);
 
         // RXX(a)
-        let (circ_a, rxx_mats) = self.to_rxx_gate(-2.0 * target_decomposed.a)?;
+        let (circ_a, rxx_mats) = self.to_rxx_gate(-2.0 * target_decomposed.a, false)?;
         let mut global_phase = circ_a.global_phase;
 
         let mut c2r = c_mats[0]; // before weyl_gate, qubit 0
@@ -261,7 +269,7 @@ impl TwoQubitControlledUDecomposer {
 
         // translate RYY(b) into a circuit based on the desired Ctrl-U gate.
         if (target_decomposed.b).abs() > atol {
-            let (circ_b, ryy_mats) = self.to_rxx_gate(-2.0 * target_decomposed.b)?;
+            let (circ_b, ryy_mats) = self.to_rxx_gate(-2.0 * target_decomposed.b, false)?;
             global_phase += circ_b.global_phase;
 
             ryy_k2r = ryy_mats[0]; // before RYY(b), qubit 0
@@ -292,7 +300,7 @@ impl TwoQubitControlledUDecomposer {
             // circuit if c < 0.
             let mut gamma = -2.0 * target_decomposed.c;
             if gamma <= 0.0 {
-                let (circ_c, rzz_mats) = self.to_rxx_gate(gamma)?;
+                let (circ_c, rzz_mats) = self.to_rxx_gate(gamma, false)?;
                 global_phase += circ_c.global_phase;
 
                 rzz_k2r = rzz_mats[0]; // before RZZ(c), qubit 0
@@ -311,22 +319,14 @@ impl TwoQubitControlledUDecomposer {
             } else {
                 // invert the circuit above
                 gamma *= -1.0;
-                let (circ_c, rzz_mats) = self.to_rxx_gate(gamma)?;
+                let (circ_c, rzz_mats) = self.to_rxx_gate(gamma, true)?;
                 global_phase -= circ_c.global_phase;
 
-                // inverting the 1-qubit matrices
-                rzz_k2r = rzz_mats[2]
-                    .try_inverse()
-                    .expect("matrix k2r is not invertible"); // before RZZ(c), qubit 0
-                rzz_k2l = rzz_mats[3]
-                    .try_inverse()
-                    .expect("matrix k2l is not invertible"); // before RZZ(c), qubit 1
-                rzz_k1r = rzz_mats[0]
-                    .try_inverse()
-                    .expect("matrix k1r is not invertible"); // after RZZ(c), qubit 0
-                rzz_k1l = rzz_mats[1]
-                    .try_inverse()
-                    .expect("matrix k1l is not invertible"); // qfter RZZ(c), qubit 1
+                // taking the inverted 1-qubit matrices
+                rzz_k2r = rzz_mats[0]; // before RZZ(c), qubit 0
+                rzz_k2l = rzz_mats[1]; // before RZZ(c), qubit 1
+                rzz_k1r = rzz_mats[2]; // after RZZ(c), qubit 0
+                rzz_k1l = rzz_mats[3]; // after RZZ(c), qubit 1
 
                 rzz_k2r = rzz_k2r * HGATE * ryy_k1r; // between RYY(b) and RZZ(c), qubit 0
                 rzz_k2l = rzz_k2l * HGATE * ryy_k1l; // between RYY(b) and RZZ(c), qubit 1
@@ -393,7 +393,7 @@ impl TwoQubitControlledUDecomposer {
             &mut weyl_gates,
             &target_decomposed,
             atol.unwrap_or(DEFAULT_ATOL),
-            smallvec![c2r, c2l, c1r, c1l],
+            [c2r, c2l, c1r, c1l],
         )?;
         global_phase += weyl_gates.global_phase;
         weyl_gates.global_phase = global_phase;

--- a/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
@@ -238,7 +238,7 @@ impl TwoQubitControlledUDecomposer {
     fn weyl_gate(
         &self,
         circ: &mut TwoQubitGateSequence,
-        target_decomposed: TwoQubitWeylDecomposition,
+        target_decomposed: &TwoQubitWeylDecomposition,
         atol: f64,
     ) -> PyResult<()> {
         let circ_a = self.to_rxx_gate(-2.0 * target_decomposed.a)?;
@@ -378,54 +378,30 @@ impl TwoQubitControlledUDecomposer {
         let mut target_1q_basis_list = EulerBasisSet::new();
         target_1q_basis_list.add_basis(self.euler_basis);
 
-        let c1r = nalgebra_array_view::<Complex64, U2, U2>(target_decomposed.K1r.as_view());
-        let c2r = nalgebra_array_view::<Complex64, U2, U2>(target_decomposed.K2r.as_view());
-        let c1l = nalgebra_array_view::<Complex64, U2, U2>(target_decomposed.K1l.as_view());
-        let c2l = nalgebra_array_view::<Complex64, U2, U2>(target_decomposed.K2l.as_view());
-
-        let unitary_c1r =
-            unitary_to_gate_sequence_inner(c1r, &target_1q_basis_list, 0, None, true, None);
-        let unitary_c2r =
-            unitary_to_gate_sequence_inner(c2r, &target_1q_basis_list, 0, None, true, None);
-        let unitary_c1l =
-            unitary_to_gate_sequence_inner(c1l, &target_1q_basis_list, 0, None, true, None);
-        let unitary_c2l =
-            unitary_to_gate_sequence_inner(c2l, &target_1q_basis_list, 0, None, true, None);
+        let c1r = target_decomposed.K1r.as_view();
+        let c2r = target_decomposed.K2r.as_view();
+        let c1l = target_decomposed.K1l.as_view();
+        let c2l = target_decomposed.K2l.as_view();
 
         let mut gates = Vec::with_capacity(59);
         let mut global_phase = target_decomposed.global_phase;
 
-        if let Some(unitary_c2r) = unitary_c2r {
-            global_phase += unitary_c2r.global_phase;
-            for gate in unitary_c2r.gates.into_iter() {
-                gates.push((gate.0.into(), gate.1, smallvec![0]));
-            }
-        }
-        if let Some(unitary_c2l) = unitary_c2l {
-            global_phase += unitary_c2l.global_phase;
-            for gate in unitary_c2l.gates.into_iter() {
-                gates.push((gate.0.into(), gate.1, smallvec![1]));
-            }
-        }
+        self.append_1q_sequence(&mut gates, &mut global_phase, c2r, 0, false);
+        self.append_1q_sequence(&mut gates, &mut global_phase, c2l, 1, false);
+
         let mut gates1 = TwoQubitGateSequence {
             gates,
             global_phase,
         };
-        self.weyl_gate(&mut gates1, target_decomposed, atol.unwrap_or(DEFAULT_ATOL))?;
+        self.weyl_gate(
+            &mut gates1,
+            &target_decomposed,
+            atol.unwrap_or(DEFAULT_ATOL),
+        )?;
         global_phase += gates1.global_phase;
 
-        if let Some(unitary_c1r) = unitary_c1r {
-            global_phase += unitary_c1r.global_phase;
-            for gate in unitary_c1r.gates.into_iter() {
-                gates1.gates.push((gate.0.into(), gate.1, smallvec![0]));
-            }
-        }
-        if let Some(unitary_c1l) = unitary_c1l {
-            global_phase += unitary_c1l.global_phase;
-            for gate in unitary_c1l.gates.into_iter() {
-                gates1.gates.push((gate.0.into(), gate.1, smallvec![1]));
-            }
-        }
+        self.append_1q_sequence(&mut gates1.gates, &mut global_phase, c1r, 0, false);
+        self.append_1q_sequence(&mut gates1.gates, &mut global_phase, c1l, 1, false);
 
         gates1.global_phase = global_phase;
         Ok(gates1)

--- a/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
@@ -39,26 +39,6 @@ use super::common::{DEFAULT_FIDELITY, HGATE, SDGGATE, SGATE};
 use super::gate_sequence::{TwoQubitGateSequence, TwoQubitSequenceVec};
 use super::weyl_decomposition::{Specialization, TwoQubitWeylDecomposition};
 
-/// invert 1q gate sequence
-fn invert_1q_gate(
-    gate: (StandardGate, SmallVec<[f64; 3]>),
-) -> (PackedOperation, SmallVec<[f64; 3]>) {
-    let gate_params = gate.1.into_iter().map(Param::Float).collect::<Vec<_>>();
-    let inv_gate = gate
-        .0
-        .inverse(&gate_params)
-        .expect("An unexpected standard gate was inverted");
-    let inv_gate_params = inv_gate
-        .1
-        .into_iter()
-        .map(|param| match param {
-            Param::Float(val) => val,
-            _ => unreachable!("Parameterized inverse generated from non-parameterized gate."),
-        })
-        .collect::<SmallVec<_>>();
-    (inv_gate.0.into(), inv_gate_params)
-}
-
 #[derive(Clone, Debug, FromPyObject)]
 pub enum RXXEquivalent {
     Standard(StandardGate),
@@ -277,8 +257,8 @@ impl TwoQubitControlledUDecomposer {
         c2r = rxx_k2r_inv * c2r;
         c2l = rxx_k2l_inv * c2l;
 
-        self.append_1q_sequence(&mut circ.gates, &mut global_phase, c2r.as_view(), 0, false);
-        self.append_1q_sequence(&mut circ.gates, &mut global_phase, c2l.as_view(), 1, false);
+        self.append_1q_sequence(&mut circ.gates, &mut global_phase, c2r.as_view(), 0);
+        self.append_1q_sequence(&mut circ.gates, &mut global_phase, c2l.as_view(), 1);
         circ.gates.extend(circ_a.gates);
 
         // translate RYY(b) into a circuit based on the desired Ctrl-U gate.
@@ -296,20 +276,8 @@ impl TwoQubitControlledUDecomposer {
             ryy_k1r_inv = SGATE * ryy_k1r_inv; // between RYY(b) and RZZ(c), qubit 0
             ryy_k1l_inv = SGATE * ryy_k1l_inv; // between RYY(b) and RZZ(c), qubit 1
 
-            self.append_1q_sequence(
-                &mut circ.gates,
-                &mut global_phase,
-                ryy_k2r_inv.as_view(),
-                0,
-                false,
-            );
-            self.append_1q_sequence(
-                &mut circ.gates,
-                &mut global_phase,
-                ryy_k2l_inv.as_view(),
-                1,
-                false,
-            );
+            self.append_1q_sequence(&mut circ.gates, &mut global_phase, ryy_k2r_inv.as_view(), 0);
+            self.append_1q_sequence(&mut circ.gates, &mut global_phase, ryy_k2l_inv.as_view(), 1);
             circ.gates.extend(circ_b.gates);
         } else {
             // no circ_b
@@ -344,14 +312,12 @@ impl TwoQubitControlledUDecomposer {
                     &mut global_phase,
                     rzz_k2r_inv.as_view(),
                     0,
-                    false,
                 );
                 self.append_1q_sequence(
                     &mut circ.gates,
                     &mut global_phase,
                     rzz_k2l_inv.as_view(),
                     1,
-                    false,
                 );
                 circ.gates.extend(circ_c.gates);
             } else {
@@ -384,14 +350,12 @@ impl TwoQubitControlledUDecomposer {
                     &mut global_phase,
                     rzz_k2r_inv.as_view(),
                     0,
-                    false,
                 );
                 self.append_1q_sequence(
                     &mut circ.gates,
                     &mut global_phase,
                     rzz_k2l_inv.as_view(),
                     1,
-                    false,
                 );
 
                 for gate in circ_c.gates.into_iter().rev() {
@@ -411,8 +375,8 @@ impl TwoQubitControlledUDecomposer {
         c1r *= rzz_k1r_inv;
         c1l *= rzz_k1l_inv;
 
-        self.append_1q_sequence(&mut circ.gates, &mut global_phase, c1r.as_view(), 0, false);
-        self.append_1q_sequence(&mut circ.gates, &mut global_phase, c1l.as_view(), 1, false);
+        self.append_1q_sequence(&mut circ.gates, &mut global_phase, c1r.as_view(), 0);
+        self.append_1q_sequence(&mut circ.gates, &mut global_phase, c1l.as_view(), 1);
 
         circ.global_phase = global_phase;
         Ok(())
@@ -531,14 +495,13 @@ impl TwoQubitControlledUDecomposer {
         })
     }
 
-    // ToDo: move to common (also used by basis_decomposer)
+    // Note: this function also appears in TwoQubitBasisDecomposer)
     fn append_1q_sequence(
         &self,
         gates: &mut TwoQubitSequenceVec,
         global_phase: &mut f64,
         unitary: MatrixView2<Complex64>,
         qubit: u8,
-        is_inv: bool,
     ) {
         let mut target_1q_basis_list = EulerBasisSet::new();
         target_1q_basis_list.add_basis(self.euler_basis);
@@ -551,18 +514,9 @@ impl TwoQubitControlledUDecomposer {
             None,
         );
         if let Some(sequence) = sequence {
-            if !is_inv {
-                *global_phase += sequence.global_phase;
-                for gate in sequence.gates {
-                    gates.push((gate.0.into(), gate.1, smallvec![qubit]));
-                }
-            } else {
-                // invert the sequence of gates
-                *global_phase -= sequence.global_phase;
-                for gate in sequence.gates.into_iter().rev() {
-                    let (inv_gate_name, inv_gate_params) = invert_1q_gate(gate);
-                    gates.push((inv_gate_name, inv_gate_params, smallvec![qubit]));
-                }
+            *global_phase += sequence.global_phase;
+            for gate in sequence.gates {
+                gates.push((gate.0.into(), gate.1, smallvec![qubit]));
             }
         }
     }

--- a/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
@@ -272,13 +272,13 @@ impl TwoQubitControlledUDecomposer {
         let (circ_a, rxx_mats) = self.to_rxx_gate(-2.0 * target_decomposed.a)?;
         let mut global_phase = circ_a.global_phase;
 
-        let c2r: Matrix2<Complex64> = c_mats[0]; // before weyl_gate, qubit 0
-        let c2l: Matrix2<Complex64> = c_mats[1]; // before weyl_gate, qubit 1
-        let c1r: Matrix2<Complex64> = c_mats[2]; // after weyl_gate, qubit 0
-        let c1l: Matrix2<Complex64> = c_mats[3]; // after weyl_gate, qubit 1
+        let mut c2r: Matrix2<Complex64> = c_mats[0]; // before weyl_gate, qubit 0
+        let mut c2l: Matrix2<Complex64> = c_mats[1]; // before weyl_gate, qubit 1
+        let mut c1r: Matrix2<Complex64> = c_mats[2]; // after weyl_gate, qubit 0
+        let mut c1l: Matrix2<Complex64> = c_mats[3]; // after weyl_gate, qubit 1
 
-        let mut rxx_k2r_inv: Matrix2<Complex64> = rxx_mats[0]; // before RXX(a), qubit 0
-        let mut rxx_k2l_inv: Matrix2<Complex64> = rxx_mats[1]; // before RXX(a), qubit 1
+        let rxx_k2r_inv: Matrix2<Complex64> = rxx_mats[0]; // before RXX(a), qubit 0
+        let rxx_k2l_inv: Matrix2<Complex64> = rxx_mats[1]; // before RXX(a), qubit 1
         let rxx_k1r_inv: Matrix2<Complex64> = rxx_mats[2]; // after RXX(a), qubit 0
         let rxx_k1l_inv: Matrix2<Complex64> = rxx_mats[3]; // after RXX(a), qubit 1
 
@@ -292,23 +292,11 @@ impl TwoQubitControlledUDecomposer {
         let mut rzz_k1r_inv: Matrix2<Complex64> = IMAT; // after RXX(c), qubit 0
         let mut rzz_k1l_inv: Matrix2<Complex64> = IMAT; // after RXX(c), qubit 1
 
-        rxx_k2r_inv = c2r * rxx_k2r_inv;
-        rxx_k2l_inv = c2l * rxx_k2l_inv;
+        c2r = c2r * rxx_k2r_inv;
+        c2l = c2l * rxx_k2l_inv;
 
-        self.append_1q_sequence(
-            &mut circ.gates,
-            &mut global_phase,
-            rxx_k2r_inv.as_view(),
-            0,
-            false,
-        );
-        self.append_1q_sequence(
-            &mut circ.gates,
-            &mut global_phase,
-            rxx_k2l_inv.as_view(),
-            1,
-            false,
-        );
+        self.append_1q_sequence(&mut circ.gates, &mut global_phase, c2r.as_view(), 0, false);
+        self.append_1q_sequence(&mut circ.gates, &mut global_phase, c2l.as_view(), 1, false);
         circ.gates.extend(circ_a.gates);
 
         // translate RYY(b) into a circuit based on the desired Ctrl-U gate.
@@ -362,8 +350,8 @@ impl TwoQubitControlledUDecomposer {
 
                 rzz_k2r_inv = ryy_k1r_inv * HGATE * rzz_k2r_inv; // between RZZ(b) and RZZ(c), qubit 0
                 rzz_k2l_inv = ryy_k1l_inv * HGATE * rzz_k2l_inv; // between RZZ(b) and RZZ(c), qubit 1
-                rzz_k1r_inv = rzz_k1r_inv * HGATE * c1r; // after RZZ(c), qubit 0
-                rzz_k1l_inv = rzz_k1l_inv * HGATE * c1l; // after RZZ(c), qubit 1
+                rzz_k1r_inv = rzz_k1r_inv * HGATE; // after RZZ(c), qubit 0
+                rzz_k1l_inv = rzz_k1l_inv * HGATE; // after RZZ(c), qubit 1
 
                 self.append_1q_sequence(
                     &mut circ.gates,
@@ -380,20 +368,6 @@ impl TwoQubitControlledUDecomposer {
                     false,
                 );
                 circ.gates.extend(circ_c.gates);
-                self.append_1q_sequence(
-                    &mut circ.gates,
-                    &mut global_phase,
-                    rzz_k1r_inv.as_view(),
-                    0,
-                    false,
-                );
-                self.append_1q_sequence(
-                    &mut circ.gates,
-                    &mut global_phase,
-                    rzz_k1l_inv.as_view(),
-                    1,
-                    false,
-                );
             } else {
                 // invert the circuit above
                 gamma *= -1.0;
@@ -416,8 +390,8 @@ impl TwoQubitControlledUDecomposer {
 
                 rzz_k2r_inv = ryy_k1r_inv * HGATE * rzz_k2r_inv;
                 rzz_k2l_inv = ryy_k1l_inv * HGATE * rzz_k2l_inv;
-                rzz_k1r_inv = rzz_k1r_inv * HGATE * c1r;
-                rzz_k1l_inv = rzz_k1l_inv * HGATE * c1l;
+                rzz_k1r_inv = rzz_k1r_inv * HGATE;
+                rzz_k1l_inv = rzz_k1l_inv * HGATE;
 
                 self.append_1q_sequence(
                     &mut circ.gates,
@@ -440,22 +414,14 @@ impl TwoQubitControlledUDecomposer {
                     circ.gates
                         .push((inv_gate_name, inv_gate_params, inv_gate_qubits));
                 }
-                self.append_1q_sequence(
-                    &mut circ.gates,
-                    &mut global_phase,
-                    rzz_k1r_inv.as_view(),
-                    0,
-                    false,
-                );
-                self.append_1q_sequence(
-                    &mut circ.gates,
-                    &mut global_phase,
-                    rzz_k1l_inv.as_view(),
-                    0,
-                    false,
-                );
             }
         }
+
+        c1r = rzz_k1r_inv * c1r;
+        c1l = rzz_k1l_inv * c1l;
+
+        self.append_1q_sequence(&mut circ.gates, &mut global_phase, c1r.as_view(), 0, false);
+        self.append_1q_sequence(&mut circ.gates, &mut global_phase, c1l.as_view(), 1, false);
 
         Ok(())
     }

--- a/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
@@ -39,6 +39,8 @@ use super::common::{DEFAULT_FIDELITY, HGATE, SDGGATE, SGATE};
 use super::gate_sequence::{TwoQubitGateSequence, TwoQubitSequenceVec};
 use super::weyl_decomposition::{Specialization, TwoQubitWeylDecomposition};
 
+type TwoQubitGateType = (PackedOperation, SmallVec<[f64; 3]>, SmallVec<[u8; 2]>);
+
 #[derive(Clone, Debug, FromPyObject)]
 pub enum RXXEquivalent {
     Standard(StandardGate),
@@ -156,14 +158,16 @@ impl TwoQubitControlledUDecomposer {
     ///      angle: Rotation angle (in this case one of the Weyl parameters a, b, or c)
     ///      is_inv_rxx: Whether the RXX equivalent gate should be inverted or not
     ///  Returns:
-    ///      Circuit: Circuit equivalent to an RXXGate.
+    ///      out_gate: An equivalent gate to an RXXGate (or its inverse)
+    ///      global_phase: The global phase of the equivalent circuit
+    ///      k_mats: Four 1-qubit gates in the equivalent circuit
     ///  Raises:
     ///      QiskitError: If the circuit is not equivalent to an RXXGate.
     fn to_rxx_gate(
         &self,
         angle: f64,
         is_inv_rxx: bool,
-    ) -> PyResult<(TwoQubitGateSequence, [Matrix2<Complex64>; 4])> {
+    ) -> PyResult<(TwoQubitGateType, f64, [Matrix2<Complex64>; 4])> {
         // The user-provided RXX equivalent gate may be locally equivalent to the RXX gate
         // but with some scaling in the rotation angle. For example, RXX(angle) has Weyl
         // parameters (angle, 0, 0) for angle in [0, pi/2] but the user provided gate, i.e.
@@ -175,8 +179,6 @@ impl TwoQubitControlledUDecomposer {
             TwoQubitWeylDecomposition::new_inner(mat.view(), Some(DEFAULT_FIDELITY), None)?;
 
         // Express the RXX in terms of the user-provided RXX equivalent gate.
-        let mut gates = Vec::with_capacity(1);
-        let mut gates_inv = Vec::with_capacity(1);
         let global_phase = -decomposer_inv.global_phase;
 
         let mut k1r = decomposer_inv.K1r;
@@ -214,25 +216,16 @@ impl TwoQubitControlledUDecomposer {
                 })?
             }
         };
-        gates.push((rxx_op, smallvec![self.scale * angle], smallvec![0, 1]));
+        let mut out_gate = (rxx_op, smallvec![self.scale * angle], smallvec![0, 1]);
 
         if is_inv_rxx {
             // invert the rxx_op
-            for gate in gates.into_iter().rev() {
-                let (inv_gate_name, inv_gate_params, inv_gate_qubits) =
-                    self.invert_2q_gate(gate)?;
-                gates_inv.push((inv_gate_name, inv_gate_params, inv_gate_qubits));
-            }
-            gates = gates_inv;
+            let (inv_gate_name, inv_gate_params, inv_gate_qubits) =
+                self.invert_2q_gate(out_gate)?;
+            out_gate = (inv_gate_name, inv_gate_params, inv_gate_qubits);
         }
 
-        Ok((
-            TwoQubitGateSequence {
-                gates,
-                global_phase,
-            },
-            k_mats,
-        ))
+        Ok((out_gate, global_phase, k_mats))
     }
 
     /// Appends U_d(a, b, c) to the circuit.
@@ -245,8 +238,9 @@ impl TwoQubitControlledUDecomposer {
         target_1q_basis_list: EulerBasisSet,
     ) -> PyResult<()> {
         // RXX(a)
-        let (circ_a, rxx_mats) = self.to_rxx_gate(-2.0 * target_decomposed.a, false)?;
-        let mut global_phase = circ_a.global_phase;
+        let (circ_a, global_phase_a, rxx_mats) =
+            self.to_rxx_gate(-2.0 * target_decomposed.a, false)?;
+        let mut global_phase = global_phase_a;
 
         let mut c2r = c_mats[0]; // before weyl_gate, qubit 0
         let mut c2l = c_mats[1]; // before weyl_gate, qubit 1
@@ -286,12 +280,13 @@ impl TwoQubitControlledUDecomposer {
             1,
             target_1q_basis_list,
         );
-        circ.gates.extend(circ_a.gates);
+        circ.gates.push(circ_a);
 
         // translate RYY(b) into a circuit based on the desired Ctrl-U gate.
         if (target_decomposed.b).abs() > atol {
-            let (circ_b, ryy_mats) = self.to_rxx_gate(-2.0 * target_decomposed.b, false)?;
-            global_phase += circ_b.global_phase;
+            let (circ_b, global_phase_b, ryy_mats) =
+                self.to_rxx_gate(-2.0 * target_decomposed.b, false)?;
+            global_phase += global_phase_b;
 
             ryy_k2r = ryy_mats[0]; // before RYY(b), qubit 0
             ryy_k2l = ryy_mats[1]; // before RYY(b), qubit 1
@@ -317,7 +312,7 @@ impl TwoQubitControlledUDecomposer {
                 1,
                 target_1q_basis_list,
             );
-            circ.gates.extend(circ_b.gates);
+            circ.gates.push(circ_b);
         } else {
             // no circ_b
             ryy_k1r = rxx_k1r;
@@ -333,8 +328,8 @@ impl TwoQubitControlledUDecomposer {
             // circuit if c < 0.
             let mut gamma = -2.0 * target_decomposed.c;
             if gamma <= 0.0 {
-                let (circ_c, rzz_mats) = self.to_rxx_gate(gamma, false)?;
-                global_phase += circ_c.global_phase;
+                let (circ_c, global_phase_c, rzz_mats) = self.to_rxx_gate(gamma, false)?;
+                global_phase += global_phase_c;
 
                 rzz_k2r = rzz_mats[0]; // before RZZ(c), qubit 0
                 rzz_k2l = rzz_mats[1]; // before RZZ(c), qubit 1
@@ -360,13 +355,13 @@ impl TwoQubitControlledUDecomposer {
                     1,
                     target_1q_basis_list,
                 );
-                circ.gates.extend(circ_c.gates);
+                circ.gates.push(circ_c);
             } else {
                 // invert the circuit above
                 gamma *= -1.0;
                 // the inverted 2-qubit RXX gate
-                let (circ_c, rzz_mats) = self.to_rxx_gate(gamma, true)?;
-                global_phase -= circ_c.global_phase;
+                let (circ_c, global_phase_c, rzz_mats) = self.to_rxx_gate(gamma, true)?;
+                global_phase -= global_phase_c;
 
                 // the inverted 1-qubit matrices
                 rzz_k2r = rzz_mats[0]; // before RZZ(c), qubit 0
@@ -393,7 +388,7 @@ impl TwoQubitControlledUDecomposer {
                     1,
                     target_1q_basis_list,
                 );
-                circ.gates.extend(circ_c.gates);
+                circ.gates.push(circ_c);
             }
         } else {
             // no circ_c

--- a/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
@@ -457,23 +457,23 @@ impl TwoQubitControlledUDecomposer {
         // 3 2-qubit gates
         // 8 1-qubit unitaries
         // max 5 1-qubit gates per 1-qubit unitary
-        let mut gates = Vec::with_capacity(43);
+        let gates = Vec::with_capacity(43);
         let mut global_phase = target_decomposed.global_phase;
 
-        let mut gates1 = TwoQubitGateSequence {
+        let mut weyl_gates = TwoQubitGateSequence {
             gates,
             global_phase,
         };
         self.weyl_gate(
-            &mut gates1,
+            &mut weyl_gates,
             &target_decomposed,
             atol.unwrap_or(DEFAULT_ATOL),
             smallvec![c2r, c2l, c1r, c1l],
         )?;
-        global_phase += gates1.global_phase;
+        global_phase += weyl_gates.global_phase;
+        weyl_gates.global_phase = global_phase;
 
-        gates1.global_phase = global_phase;
-        Ok(gates1)
+        Ok(weyl_gates)
     }
 
     /// Initialize the KAK decomposition.

--- a/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
@@ -176,27 +176,25 @@ impl TwoQubitControlledUDecomposer {
         let mut gates = Vec::with_capacity(1);
         let global_phase = -decomposer_inv.global_phase;
 
-        let decomp_k1r = decomposer_inv.K1r;
-        let decomp_k2r = decomposer_inv.K2r;
-        let decomp_k1l = decomposer_inv.K1l;
-        let decomp_k2l = decomposer_inv.K2l;
+        let mut k1r = decomposer_inv.K1r;
+        let mut k2r = decomposer_inv.K2r;
+        let mut k1l = decomposer_inv.K1l;
+        let mut k2l = decomposer_inv.K2l;
 
         // 1-qubit gates before the rxx_op, on qubits 0 and 1 respectively
-        let k2r_inv = decomp_k2r
-            .try_inverse()
-            .expect("matrix k2r is not invertible");
-        let k2l_inv = decomp_k2l
-            .try_inverse()
-            .expect("matrix k2l is not invertible");
-
+        if !k2r.try_inverse_mut() {
+            panic!("matrix k2r is not invertible");
+        }
+        if !k2l.try_inverse_mut() {
+            panic!("matrix k2l is not invertible");
+        }
         // 1-qubit gates after the rxx_op, on qubits 0 and 1 respectively
-        let k1r_inv = decomp_k1r
-            .try_inverse()
-            .expect("matrix k1r is not invertible");
-        let k1l_inv: Matrix2<Complex64> = decomp_k1l
-            .try_inverse()
-            .expect("matrix k1l is not invertible");
-
+        if !k1r.try_inverse_mut() {
+            panic!("matrix k1r is not invertible");
+        }
+        if !k1l.try_inverse_mut() {
+            panic!("matrix k1l is not invertible");
+        }
         let rxx_op = match &self.rxx_equivalent_gate {
             RXXEquivalent::Standard(gate) => PackedOperation::from_standard_gate(*gate),
             RXXEquivalent::CustomPython(gate_cls) => {
@@ -214,7 +212,7 @@ impl TwoQubitControlledUDecomposer {
                 gates,
                 global_phase,
             },
-            smallvec![k2r_inv, k2l_inv, k1r_inv, k1l_inv],
+            smallvec![k2r, k2l, k1r, k1l],
         ))
     }
 
@@ -238,24 +236,24 @@ impl TwoQubitControlledUDecomposer {
         let mut c1r = c_mats[2]; // after weyl_gate, qubit 0
         let mut c1l = c_mats[3]; // after weyl_gate, qubit 1
 
-        let rxx_k2r_inv = rxx_mats[0]; // before RXX(a), qubit 0
-        let rxx_k2l_inv = rxx_mats[1]; // before RXX(a), qubit 1
-        let rxx_k1r_inv = rxx_mats[2]; // after RXX(a), qubit 0
-        let rxx_k1l_inv = rxx_mats[3]; // after RXX(a), qubit 1
+        let rxx_k2r = rxx_mats[0]; // before RXX(a), qubit 0
+        let rxx_k2l = rxx_mats[1]; // before RXX(a), qubit 1
+        let rxx_k1r = rxx_mats[2]; // after RXX(a), qubit 0
+        let rxx_k1l = rxx_mats[3]; // after RXX(a), qubit 1
 
-        let mut ryy_k2r_inv: Matrix2<Complex64>; // before RYY(b), qubit 0
-        let mut ryy_k2l_inv: Matrix2<Complex64>; // before RYY(b), qubit 1
-        let mut ryy_k1r_inv: Matrix2<Complex64>; // after RYY(b), qubit 0
-        let mut ryy_k1l_inv: Matrix2<Complex64>; // after RYY(b), qubit 1
+        let mut ryy_k2r: Matrix2<Complex64>; // before RYY(b), qubit 0
+        let mut ryy_k2l: Matrix2<Complex64>; // before RYY(b), qubit 1
+        let mut ryy_k1r: Matrix2<Complex64>; // after RYY(b), qubit 0
+        let mut ryy_k1l: Matrix2<Complex64>; // after RYY(b), qubit 1
 
-        let mut rzz_k2r_inv: Matrix2<Complex64>; // before RZZ(c), qubit 0
-        let mut rzz_k2l_inv: Matrix2<Complex64>; // before RZZ(c), qubit 1
-        let mut rzz_k1r_inv: Matrix2<Complex64>; // after RZZ(c), qubit 0
-        let mut rzz_k1l_inv: Matrix2<Complex64>; // after RZZ(c), qubit 1
+        let mut rzz_k2r: Matrix2<Complex64>; // before RZZ(c), qubit 0
+        let mut rzz_k2l: Matrix2<Complex64>; // before RZZ(c), qubit 1
+        let mut rzz_k1r: Matrix2<Complex64>; // after RZZ(c), qubit 0
+        let mut rzz_k1l: Matrix2<Complex64>; // after RZZ(c), qubit 1
 
         // before the weyl_gate
-        c2r = rxx_k2r_inv * c2r;
-        c2l = rxx_k2l_inv * c2l;
+        c2r = rxx_k2r * c2r;
+        c2l = rxx_k2l * c2l;
 
         self.append_1q_sequence(&mut circ.gates, &mut global_phase, c2r.as_view(), 0);
         self.append_1q_sequence(&mut circ.gates, &mut global_phase, c2l.as_view(), 1);
@@ -266,23 +264,23 @@ impl TwoQubitControlledUDecomposer {
             let (circ_b, ryy_mats) = self.to_rxx_gate(-2.0 * target_decomposed.b)?;
             global_phase += circ_b.global_phase;
 
-            ryy_k2r_inv = ryy_mats[0]; // before RYY(b), qubit 0
-            ryy_k2l_inv = ryy_mats[1]; // before RYY(b), qubit 1
-            ryy_k1r_inv = ryy_mats[2]; // after RYY(b), qubit 0
-            ryy_k1l_inv = ryy_mats[3]; // after RYY(b), qubit 1
+            ryy_k2r = ryy_mats[0]; // before RYY(b), qubit 0
+            ryy_k2l = ryy_mats[1]; // before RYY(b), qubit 1
+            ryy_k1r = ryy_mats[2]; // after RYY(b), qubit 0
+            ryy_k1l = ryy_mats[3]; // after RYY(b), qubit 1
 
-            ryy_k2r_inv = ryy_k2r_inv * SDGGATE * rxx_k1r_inv; // between RXX(a) and RYY(b), qubit 0
-            ryy_k2l_inv = ryy_k2l_inv * SDGGATE * rxx_k1l_inv; // between RXX(a) and RYY(b), qubit 1
-            ryy_k1r_inv = SGATE * ryy_k1r_inv; // between RYY(b) and RZZ(c), qubit 0
-            ryy_k1l_inv = SGATE * ryy_k1l_inv; // between RYY(b) and RZZ(c), qubit 1
+            ryy_k2r = ryy_k2r * SDGGATE * rxx_k1r; // between RXX(a) and RYY(b), qubit 0
+            ryy_k2l = ryy_k2l * SDGGATE * rxx_k1l; // between RXX(a) and RYY(b), qubit 1
+            ryy_k1r = SGATE * ryy_k1r; // between RYY(b) and RZZ(c), qubit 0
+            ryy_k1l = SGATE * ryy_k1l; // between RYY(b) and RZZ(c), qubit 1
 
-            self.append_1q_sequence(&mut circ.gates, &mut global_phase, ryy_k2r_inv.as_view(), 0);
-            self.append_1q_sequence(&mut circ.gates, &mut global_phase, ryy_k2l_inv.as_view(), 1);
+            self.append_1q_sequence(&mut circ.gates, &mut global_phase, ryy_k2r.as_view(), 0);
+            self.append_1q_sequence(&mut circ.gates, &mut global_phase, ryy_k2l.as_view(), 1);
             circ.gates.extend(circ_b.gates);
         } else {
             // no circ_b
-            ryy_k1r_inv = rxx_k1r_inv;
-            ryy_k1l_inv = rxx_k1l_inv;
+            ryy_k1r = rxx_k1r;
+            ryy_k1l = rxx_k1l;
         }
 
         // translate RZZ(c) into a circuit based on the desired Ctrl-U gate.
@@ -297,28 +295,18 @@ impl TwoQubitControlledUDecomposer {
                 let (circ_c, rzz_mats) = self.to_rxx_gate(gamma)?;
                 global_phase += circ_c.global_phase;
 
-                rzz_k2r_inv = rzz_mats[0]; // before RZZ(c), qubit 0
-                rzz_k2l_inv = rzz_mats[1]; // before RZZ(c), qubit 1
-                rzz_k1r_inv = rzz_mats[2]; // after RZZ(c), qubit 0
-                rzz_k1l_inv = rzz_mats[3]; // after RZZ(c), qubit 1
+                rzz_k2r = rzz_mats[0]; // before RZZ(c), qubit 0
+                rzz_k2l = rzz_mats[1]; // before RZZ(c), qubit 1
+                rzz_k1r = rzz_mats[2]; // after RZZ(c), qubit 0
+                rzz_k1l = rzz_mats[3]; // after RZZ(c), qubit 1
 
-                rzz_k2r_inv = rzz_k2r_inv * HGATE * ryy_k1r_inv; // between RYY(b) and RZZ(c), qubit 0
-                rzz_k2l_inv = rzz_k2l_inv * HGATE * ryy_k1l_inv; // between RYY(b) and RZZ(c), qubit 1
-                rzz_k1r_inv = HGATE * rzz_k1r_inv; // after RZZ(c), qubit 0
-                rzz_k1l_inv = HGATE * rzz_k1l_inv; // after RZZ(c), qubit 1
+                rzz_k2r = rzz_k2r * HGATE * ryy_k1r; // between RYY(b) and RZZ(c), qubit 0
+                rzz_k2l = rzz_k2l * HGATE * ryy_k1l; // between RYY(b) and RZZ(c), qubit 1
+                rzz_k1r = HGATE * rzz_k1r; // after RZZ(c), qubit 0
+                rzz_k1l = HGATE * rzz_k1l; // after RZZ(c), qubit 1
 
-                self.append_1q_sequence(
-                    &mut circ.gates,
-                    &mut global_phase,
-                    rzz_k2r_inv.as_view(),
-                    0,
-                );
-                self.append_1q_sequence(
-                    &mut circ.gates,
-                    &mut global_phase,
-                    rzz_k2l_inv.as_view(),
-                    1,
-                );
+                self.append_1q_sequence(&mut circ.gates, &mut global_phase, rzz_k2r.as_view(), 0);
+                self.append_1q_sequence(&mut circ.gates, &mut global_phase, rzz_k2l.as_view(), 1);
                 circ.gates.extend(circ_c.gates);
             } else {
                 // invert the circuit above
@@ -327,36 +315,26 @@ impl TwoQubitControlledUDecomposer {
                 global_phase -= circ_c.global_phase;
 
                 // inverting the 1-qubit matrices
-                rzz_k2r_inv = rzz_mats[2]
+                rzz_k2r = rzz_mats[2]
                     .try_inverse()
                     .expect("matrix k2r is not invertible"); // before RZZ(c), qubit 0
-                rzz_k2l_inv = rzz_mats[3]
+                rzz_k2l = rzz_mats[3]
                     .try_inverse()
                     .expect("matrix k2l is not invertible"); // before RZZ(c), qubit 1
-                rzz_k1r_inv = rzz_mats[0]
+                rzz_k1r = rzz_mats[0]
                     .try_inverse()
                     .expect("matrix k1r is not invertible"); // after RZZ(c), qubit 0
-                rzz_k1l_inv = rzz_mats[1]
+                rzz_k1l = rzz_mats[1]
                     .try_inverse()
                     .expect("matrix k1l is not invertible"); // qfter RZZ(c), qubit 1
 
-                rzz_k2r_inv = rzz_k2r_inv * HGATE * ryy_k1r_inv; // between RYY(b) and RZZ(c), qubit 0
-                rzz_k2l_inv = rzz_k2l_inv * HGATE * ryy_k1l_inv; // between RYY(b) and RZZ(c), qubit 1
-                rzz_k1r_inv = HGATE * rzz_k1r_inv; // after RZZ(c), qubit 0
-                rzz_k1l_inv = HGATE * rzz_k1l_inv; // after RZZ(c), qubit 1
+                rzz_k2r = rzz_k2r * HGATE * ryy_k1r; // between RYY(b) and RZZ(c), qubit 0
+                rzz_k2l = rzz_k2l * HGATE * ryy_k1l; // between RYY(b) and RZZ(c), qubit 1
+                rzz_k1r = HGATE * rzz_k1r; // after RZZ(c), qubit 0
+                rzz_k1l = HGATE * rzz_k1l; // after RZZ(c), qubit 1
 
-                self.append_1q_sequence(
-                    &mut circ.gates,
-                    &mut global_phase,
-                    rzz_k2r_inv.as_view(),
-                    0,
-                );
-                self.append_1q_sequence(
-                    &mut circ.gates,
-                    &mut global_phase,
-                    rzz_k2l_inv.as_view(),
-                    1,
-                );
+                self.append_1q_sequence(&mut circ.gates, &mut global_phase, rzz_k2r.as_view(), 0);
+                self.append_1q_sequence(&mut circ.gates, &mut global_phase, rzz_k2l.as_view(), 1);
 
                 for gate in circ_c.gates.into_iter().rev() {
                     let (inv_gate_name, inv_gate_params, inv_gate_qubits) =
@@ -367,13 +345,13 @@ impl TwoQubitControlledUDecomposer {
             }
         } else {
             // no circ_c
-            rzz_k1r_inv = ryy_k1r_inv;
-            rzz_k1l_inv = ryy_k1l_inv;
+            rzz_k1r = ryy_k1r;
+            rzz_k1l = ryy_k1l;
         }
 
         // after the weyl_gate
-        c1r *= rzz_k1r_inv;
-        c1l *= rzz_k1l_inv;
+        c1r *= rzz_k1r;
+        c1l *= rzz_k1l;
 
         self.append_1q_sequence(&mut circ.gates, &mut global_phase, c1r.as_view(), 0);
         self.append_1q_sequence(&mut circ.gates, &mut global_phase, c1l.as_view(), 1);

--- a/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
@@ -39,10 +39,15 @@ use super::common::{DEFAULT_FIDELITY, HGATE, SDGGATE, SGATE};
 use super::gate_sequence::{TwoQubitGateSequence, TwoQubitSequenceVec};
 use super::weyl_decomposition::{Specialization, TwoQubitWeylDecomposition};
 
+/// The output representing an equivalent circuit to an RXXGate
 struct TwoQubitUnitary {
+    /// An equivalent 2-qubit gate (or its inverse)
     op: PackedOperation,
+    /// The equivalent 2-qubit gate's params
     params: SmallVec<[f64; 3]>,
+    /// The global phase of the equivalent circuit
     global_phase: f64,
+    /// Four 1-qubit gates in the equivalent circuit (before and after the 2-qubit gate)
     one_qubit_components: [Matrix2<Complex64>; 4],
 }
 
@@ -163,10 +168,7 @@ impl TwoQubitControlledUDecomposer {
     ///      angle: Rotation angle (in this case one of the Weyl parameters a, b, or c)
     ///      is_inv_rxx: Whether the RXX equivalent gate should be inverted or not
     ///  Returns:
-    ///      out_gate_name: An equivalent 2-qubit gate (or its inverse)
-    ///      out_gate_params: The equivalent 2-qubit gate params
-    ///      global_phase: The global phase of the equivalent circuit
-    ///      k_mats: Four 1-qubit gates in the equivalent circuit (before and after the 2-qubit gate)
+    ///      A TwoQubitUnitary representing the equivalent circuit
     ///  Raises:
     ///      QiskitError: If the circuit is not equivalent to an RXXGate.
     ///
@@ -232,19 +234,19 @@ impl TwoQubitControlledUDecomposer {
                 })?
             }
         };
-        let mut out_gate_name = rxx_op;
+        let mut out_gate = rxx_op;
         let mut out_gate_params = smallvec![self.scale * angle];
 
         if is_inv_rxx {
             // invert the rxx_op
-            let (inv_gate_name, inv_gate_params, _inv_gate_qubits) =
-                self.invert_2q_gate((out_gate_name, out_gate_params, smallvec![0, 1]))?;
-            out_gate_name = inv_gate_name;
+            let (inv_gate, inv_gate_params, _inv_gate_qubits) =
+                self.invert_2q_gate((out_gate, out_gate_params, smallvec![0, 1]))?;
+            out_gate = inv_gate;
             out_gate_params = inv_gate_params;
         }
 
         Ok(TwoQubitUnitary {
-            op: out_gate_name,
+            op: out_gate,
             params: out_gate_params,
             global_phase,
             one_qubit_components: k_mats,
@@ -306,7 +308,7 @@ impl TwoQubitControlledUDecomposer {
     ) -> PyResult<()> {
         // RXX(a)
         let TwoQubitUnitary {
-            op: circ_a_name,
+            op: circ_a_gate,
             params: circ_a_params,
             global_phase: global_phase_a,
             one_qubit_components: rxx_mats,
@@ -352,12 +354,12 @@ impl TwoQubitControlledUDecomposer {
             target_1q_basis_list,
         );
         circ.gates
-            .push((circ_a_name, circ_a_params, smallvec![0, 1]));
+            .push((circ_a_gate, circ_a_params, smallvec![0, 1]));
 
         // translate RYY(b) into a circuit based on the desired Ctrl-U gate.
         if (target_decomposed.b).abs() > atol {
             let TwoQubitUnitary {
-                op: circ_b_name,
+                op: circ_b_gate,
                 params: circ_b_params,
                 global_phase: global_phase_b,
                 one_qubit_components: ryy_mats,
@@ -389,7 +391,7 @@ impl TwoQubitControlledUDecomposer {
                 target_1q_basis_list,
             );
             circ.gates
-                .push((circ_b_name, circ_b_params, smallvec![0, 1]));
+                .push((circ_b_gate, circ_b_params, smallvec![0, 1]));
         } else {
             // no circ_b
             ryy_k1r = rxx_k1r;
@@ -406,7 +408,7 @@ impl TwoQubitControlledUDecomposer {
             let mut gamma = -2.0 * target_decomposed.c;
             if gamma <= 0.0 {
                 let TwoQubitUnitary {
-                    op: circ_c_name,
+                    op: circ_c_gate,
                     params: circ_c_params,
                     global_phase: global_phase_c,
                     one_qubit_components: rzz_mats,
@@ -438,13 +440,13 @@ impl TwoQubitControlledUDecomposer {
                     target_1q_basis_list,
                 );
                 circ.gates
-                    .push((circ_c_name, circ_c_params, smallvec![0, 1]));
+                    .push((circ_c_gate, circ_c_params, smallvec![0, 1]));
             } else {
                 // invert the circuit above
                 gamma *= -1.0;
                 // the inverted 2-qubit RXX gate
                 let TwoQubitUnitary {
-                    op: circ_c_name,
+                    op: circ_c_gate,
                     params: circ_c_params,
                     global_phase: global_phase_c,
                     one_qubit_components: rzz_mats,
@@ -477,7 +479,7 @@ impl TwoQubitControlledUDecomposer {
                     target_1q_basis_list,
                 );
                 circ.gates
-                    .push((circ_c_name, circ_c_params, smallvec![0, 1]));
+                    .push((circ_c_gate, circ_c_params, smallvec![0, 1]));
             }
         } else {
             // no circ_c

--- a/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/controlled_u_decomposer.rs
@@ -169,6 +169,20 @@ impl TwoQubitControlledUDecomposer {
     ///      k_mats: Four 1-qubit gates in the equivalent circuit (before and after the 2-qubit gate)
     ///  Raises:
     ///      QiskitError: If the circuit is not equivalent to an RXXGate.
+    ///
+    /// Example:
+    ///      If Equiv is an RXX equivalent gate and `is_inv_rxx=false` then the output circuit is of the form:
+    ///      ┌─────────┐┌────────┐┌─────────┐
+    /// q_0: ┤ k2r_inv ├┤0       ├┤ k1r_inv ├
+    ///      ├─────────┤│  Equiv │├─────────┤
+    /// q_1: ┤ k2l_inv ├┤1       ├┤ k1l_inv ├
+    ///      └─────────┘└────────┘└─────────┘
+    ///     If Equiv is an RXX equivalent gate and `is_inv_rxx=true` then the output circuit is of the form:
+    ///      ┌─────┐┌────────────┐┌─────┐
+    /// q_0: ┤ k1r ├┤0           ├┤ k2r ├
+    ///      ├─────┤│  Equiv_inv │├─────┤
+    /// q_1: ┤ k1l ├┤1           ├┤ k2l ├
+    ///      └─────┘└────────────┘└─────┘
     fn to_rxx_gate(&self, angle: f64, is_inv_rxx: bool) -> PyResult<TwoQubitUnitary> {
         // The user-provided RXX equivalent gate may be locally equivalent to the RXX gate
         // but with some scaling in the rotation angle. For example, RXX(angle) has Weyl
@@ -192,14 +206,12 @@ impl TwoQubitControlledUDecomposer {
         let mut k_mats = [k1r, k1l, k2r, k2l];
 
         if !is_inv_rxx {
-            // 1-qubit gates before the rxx_op, on qubits 0 and 1 respectively
             if !k_mats[2].try_inverse_mut() {
                 panic!("TwoQubitWeylDecomposition failed. Matrix K2r is not unitary");
             }
             if !k_mats[3].try_inverse_mut() {
                 panic!("TwoQubitWeylDecomposition failed. Matrix K2l is not unitary");
             }
-            // 1-qubit gates after the rxx_op, on qubits 0 and 1 respectively
             if !k_mats[0].try_inverse_mut() {
                 panic!("TwoQubitWeylDecomposition failed. Matrix K1R is not unitary");
             }
@@ -235,6 +247,50 @@ impl TwoQubitControlledUDecomposer {
     }
 
     /// Appends U_d(a, b, c) to the circuit.
+    ///
+    /// Any 2-qubit unitary can be decompose into a Weyl gate and four 1-qubit unitary gates:
+    ///      ┌─────┐┌───────┐┌─────┐
+    /// q_0: ┤ c2r ├┤0      ├┤ c1r ├
+    ///      ├─────┤│  Weyl │├─────┤
+    /// q_1: ┤ c2l ├┤1      ├┤ c1l ├
+    ///      └─────┘└───────┘└─────┘
+    /// The Weyl gate can be decomposed into the following product of 2-qubit gates
+    ///      ┌─────────┐┌─────────┐        
+    /// q_0: ┤0        ├┤0        ├─■──────
+    ///      │  Rxx(a) ││  Ryy(b) │ │ZZ(c)
+    /// q_1: ┤1        ├┤1        ├─■──────
+    ///      └─────────┘└─────────┘       
+    /// RYY(b) is decomposed as
+    ///      ┌─────┐┌─────────┐┌───┐
+    /// q_0: ┤ Sdg ├┤0        ├┤ S ├
+    ///      ├─────┤│  Rxx(b) │├───┤
+    /// q_1: ┤ Sdg ├┤1        ├┤ S ├
+    ///      └─────┘└─────────┘└───┘
+    /// and RZZ(c) is decomposed as
+    ///      ┌───┐┌─────────┐┌───┐
+    /// q_0: ┤ H ├┤0        ├┤ H ├
+    ///      ├───┤│  Rxx(c) │├───┤
+    /// q_1: ┤ H ├┤1        ├┤ H ├
+    ///      └───┘└─────────┘└───┘
+    /// So the original 2-qubit unitary is decomposed as
+    ///      ┌─────┐┌─────────┐┌─────┐┌─────────┐┌───┐┌───┐┌─────────┐┌───┐┌─────┐
+    /// q_0: ┤ c2r ├┤0        ├┤ Sdg ├┤0        ├┤ S ├┤ H ├┤0        ├┤ H ├┤ c1r ├
+    ///      ├─────┤│  Rxx(a) │├─────┤│  Rxx(b) │├───┤├───┤│  Rxx(c) │├───┤├─────┤
+    /// q_1: ┤ c2l ├┤1        ├┤ Sdg ├┤1        ├┤ S ├┤ H ├┤1        ├┤ H ├┤ c1l ├
+    ///      └─────┘└─────────┘└─────┘└─────────┘└───┘└───┘└─────────┘└───┘└─────┘
+    ///
+    /// Now, RXX(a), RXX(b) and RXX(c) are decomposed into the RXX Equivalent gate,
+    /// so the final circuit obtained contains three 2-qubit gates and 24 1-qubit gates.
+    ///      ┌─────┐┌─────────┐┌───────────┐┌─────────┐┌─────┐┌─────────┐┌───────────┐»
+    /// q_0: ┤ c2r ├┤ rxx_k2r ├┤0          ├┤ rxx_k1r ├┤ Sdg ├┤ ryy_k2r ├┤0          ├»
+    ///      ├─────┤├─────────┤│  Equiv(a) │├─────────┤├─────┤├─────────┤│  Equiv(b) │»
+    /// q_1: ┤ c2l ├┤ rxx_k2l ├┤1          ├┤ rxx_k1l ├┤ Sdg ├┤ ryy_k2l ├┤1          ├»
+    ///      └─────┘└─────────┘└───────────┘└─────────┘└─────┘└─────────┘└───────────┘»
+    /// «     ┌─────────┐┌───┐┌───┐┌─────────┐┌───────────┐┌─────────┐┌───┐┌─────┐
+    /// «q_0: ┤ ryy_k1r ├┤ S ├┤ H ├┤ rzz_k2r ├┤0          ├┤ rzz_k1r ├┤ H ├┤ c1r ├
+    /// «     ├─────────┤├───┤├───┤├─────────┤│  Equiv(c) │├─────────┤├───┤├─────┤
+    /// «q_1: ┤ ryy_k1l ├┤ S ├┤ H ├┤ rzz_k2l ├┤1          ├┤ rzz_k1l ├┤ H ├┤ c1l ├
+    /// «     └─────────┘└───┘└───┘└─────────┘└───────────┘└─────────┘└───┘└─────┘
     fn weyl_gate(
         &self,
         circ: &mut TwoQubitGateSequence,
@@ -258,15 +314,15 @@ impl TwoQubitControlledUDecomposer {
         let rxx_k1r = rxx_mats[2]; // after RXX(a), qubit 0
         let rxx_k1l = rxx_mats[3]; // after RXX(a), qubit 1
 
-        let mut ryy_k2r: Matrix2<Complex64>; // before RYY(b), qubit 0
-        let mut ryy_k2l: Matrix2<Complex64>; // before RYY(b), qubit 1
-        let mut ryy_k1r: Matrix2<Complex64>; // after RYY(b), qubit 0
-        let mut ryy_k1l: Matrix2<Complex64>; // after RYY(b), qubit 1
+        let mut ryy_k2r: Matrix2<Complex64>; // before RXX(b), qubit 0
+        let mut ryy_k2l: Matrix2<Complex64>; // before RXX(b), qubit 1
+        let mut ryy_k1r: Matrix2<Complex64>; // after RXX(b), qubit 0
+        let mut ryy_k1l: Matrix2<Complex64>; // after RXX(b), qubit 1
 
-        let mut rzz_k2r: Matrix2<Complex64>; // before RZZ(c), qubit 0
-        let mut rzz_k2l: Matrix2<Complex64>; // before RZZ(c), qubit 1
-        let mut rzz_k1r: Matrix2<Complex64>; // after RZZ(c), qubit 0
-        let mut rzz_k1l: Matrix2<Complex64>; // after RZZ(c), qubit 1
+        let mut rzz_k2r: Matrix2<Complex64>; // before RXX(c), qubit 0
+        let mut rzz_k2l: Matrix2<Complex64>; // before RXX(c), qubit 1
+        let mut rzz_k1r: Matrix2<Complex64>; // after RXX(c), qubit 0
+        let mut rzz_k1l: Matrix2<Complex64>; // after RXX(c), qubit 1
 
         // before the weyl_gate
         c2r = rxx_k2r * c2r;
@@ -295,15 +351,15 @@ impl TwoQubitControlledUDecomposer {
                 self.to_rxx_gate(-2.0 * target_decomposed.b, false)?;
             global_phase += global_phase_b;
 
-            ryy_k2r = ryy_mats[0]; // before RYY(b), qubit 0
-            ryy_k2l = ryy_mats[1]; // before RYY(b), qubit 1
-            ryy_k1r = ryy_mats[2]; // after RYY(b), qubit 0
-            ryy_k1l = ryy_mats[3]; // after RYY(b), qubit 1
+            ryy_k2r = ryy_mats[0]; // before RXX(b), qubit 0
+            ryy_k2l = ryy_mats[1]; // before RXX(b), qubit 1
+            ryy_k1r = ryy_mats[2]; // after RXX(b), qubit 0
+            ryy_k1l = ryy_mats[3]; // after RXX(b), qubit 1
 
-            ryy_k2r = ryy_k2r * SDGGATE * rxx_k1r; // between RXX(a) and RYY(b), qubit 0
-            ryy_k2l = ryy_k2l * SDGGATE * rxx_k1l; // between RXX(a) and RYY(b), qubit 1
-            ryy_k1r = SGATE * ryy_k1r; // between RYY(b) and RZZ(c), qubit 0
-            ryy_k1l = SGATE * ryy_k1l; // between RYY(b) and RZZ(c), qubit 1
+            ryy_k2r = ryy_k2r * SDGGATE * rxx_k1r; // between RXX(a) and RXX(b), qubit 0
+            ryy_k2l = ryy_k2l * SDGGATE * rxx_k1l; // between RXX(a) and RXX(b), qubit 1
+            ryy_k1r = SGATE * ryy_k1r; // between RXX(b) and RXX(c), qubit 0
+            ryy_k1l = SGATE * ryy_k1l; // between RXX(b) and RXX(c), qubit 1
 
             self.append_1q_sequence(
                 &mut circ.gates,
@@ -340,15 +396,15 @@ impl TwoQubitControlledUDecomposer {
                     self.to_rxx_gate(gamma, false)?;
                 global_phase += global_phase_c;
 
-                rzz_k2r = rzz_mats[0]; // before RZZ(c), qubit 0
-                rzz_k2l = rzz_mats[1]; // before RZZ(c), qubit 1
-                rzz_k1r = rzz_mats[2]; // after RZZ(c), qubit 0
-                rzz_k1l = rzz_mats[3]; // after RZZ(c), qubit 1
+                rzz_k2r = rzz_mats[0]; // before RXX(c), qubit 0
+                rzz_k2l = rzz_mats[1]; // before RXX(c), qubit 1
+                rzz_k1r = rzz_mats[2]; // after RXX(c), qubit 0
+                rzz_k1l = rzz_mats[3]; // after RXX(c), qubit 1
 
-                rzz_k2r = rzz_k2r * HGATE * ryy_k1r; // between RYY(b) and RZZ(c), qubit 0
-                rzz_k2l = rzz_k2l * HGATE * ryy_k1l; // between RYY(b) and RZZ(c), qubit 1
-                rzz_k1r = HGATE * rzz_k1r; // after RZZ(c), qubit 0
-                rzz_k1l = HGATE * rzz_k1l; // after RZZ(c), qubit 1
+                rzz_k2r = rzz_k2r * HGATE * ryy_k1r; // between RXX(b) and RXX(c), qubit 0
+                rzz_k2l = rzz_k2l * HGATE * ryy_k1l; // between RXX(b) and RXX(c), qubit 1
+                rzz_k1r = HGATE * rzz_k1r; // after RXX(c), qubit 0
+                rzz_k1l = HGATE * rzz_k1l; // after RXX(c), qubit 1
 
                 self.append_1q_sequence(
                     &mut circ.gates,
@@ -375,15 +431,15 @@ impl TwoQubitControlledUDecomposer {
                 global_phase -= global_phase_c;
 
                 // the inverted 1-qubit matrices
-                rzz_k2r = rzz_mats[0]; // before RZZ(c), qubit 0
-                rzz_k2l = rzz_mats[1]; // before RZZ(c), qubit 1
-                rzz_k1r = rzz_mats[2]; // after RZZ(c), qubit 0
-                rzz_k1l = rzz_mats[3]; // after RZZ(c), qubit 1
+                rzz_k2r = rzz_mats[0]; // before RXX(c), qubit 0
+                rzz_k2l = rzz_mats[1]; // before RXX(c), qubit 1
+                rzz_k1r = rzz_mats[2]; // after RXX(c), qubit 0
+                rzz_k1l = rzz_mats[3]; // after RXX(c), qubit 1
 
-                rzz_k2r = rzz_k2r * HGATE * ryy_k1r; // between RYY(b) and RZZ(c), qubit 0
-                rzz_k2l = rzz_k2l * HGATE * ryy_k1l; // between RYY(b) and RZZ(c), qubit 1
-                rzz_k1r = HGATE * rzz_k1r; // after RZZ(c), qubit 0
-                rzz_k1l = HGATE * rzz_k1l; // after RZZ(c), qubit 1
+                rzz_k2r = rzz_k2r * HGATE * ryy_k1r; // between RXX(b) and RXX(c), qubit 0
+                rzz_k2l = rzz_k2l * HGATE * ryy_k1l; // between RXX(b) and RXX(c), qubit 1
+                rzz_k1r = HGATE * rzz_k1r; // after RXX(c), qubit 0
+                rzz_k1l = HGATE * rzz_k1l; // after RXX(c), qubit 1
 
                 self.append_1q_sequence(
                     &mut circ.gates,
@@ -580,8 +636,8 @@ impl TwoQubitControlledUDecomposer {
     ///  Args:
     ///      rxx_equivalent_gate: Gate that is locally equivalent to an :class:`.RXXGate`:
     ///      :math:`U \sim U_d(\alpha, 0, 0) \sim \text{Ctrl-U}` gate.
-    ///     euler_basis: Basis string to be provided to :class:`.OneQubitEulerDecomposer`
-    ///     for 1Q synthesis.
+    ///      euler_basis: Basis string to be provided to :class:`.OneQubitEulerDecomposer`
+    ///      for 1Q synthesis.
     ///  Raises:
     ///      QiskitError: If the gate is not locally equivalent to an :class:`.RXXGate`.
     #[new]

--- a/releasenotes/notes/improve_two_qubit_controlled_u_decomposer_1q_gate_count-2d3fe2e4c84f78df.yaml
+++ b/releasenotes/notes/improve_two_qubit_controlled_u_decomposer_1q_gate_count-2d3fe2e4c84f78df.yaml
@@ -1,0 +1,6 @@
+---
+features_synthesis:
+  - Improve the single-qubit gate count in the :class:`.TwoQubitControlledUDecomposer`.
+    A general two-qubit unitary is now decomposed into a circuit with 3 two-qubit gates 
+    and only 8 single-qubit unitary gates, improving on the previous decomposition 
+    which required 24 single-qubit unitary gates.

--- a/test/python/synthesis/test_synthesis.py
+++ b/test/python/synthesis/test_synthesis.py
@@ -1458,6 +1458,17 @@ class TestTwoQubitControlledUDecompose(CheckDecompositions):
         circ = decomposer(unitary)
         self.assertEqual(Operator(unitary), Operator(circ))
 
+        # bound on the number of 2-qubit gates
+        num2q = circ.size(filter_function=lambda x: x.operation.num_qubits == 2)
+        self.assertLessEqual(num2q, 3)
+
+        # bound on the number of 1-qubit gates
+        self.assertLessEqual(circ.count_ops().get("u", 0), 8)
+        self.assertLessEqual(circ.count_ops().get("sx", 0), 14)
+        self.assertLessEqual(circ.count_ops().get("rx", 0), 14)
+        self.assertLessEqual(circ.count_ops().get("ry", 0), 8)
+        self.assertLessEqual(circ.count_ops().get("rz", 0), 22)
+
     def test_not_rxx_equivalent(self):
         """Test that an exception is raised if the gate is not equivalent to an RXXGate"""
         gate = SwapGate

--- a/test/python/synthesis/test_synthesis.py
+++ b/test/python/synthesis/test_synthesis.py
@@ -1469,6 +1469,22 @@ class TestTwoQubitControlledUDecompose(CheckDecompositions):
         self.assertLessEqual(circ.count_ops().get("ry", 0), 8)
         self.assertLessEqual(circ.count_ops().get("rz", 0), 22)
 
+    @combine(gate=[RXXGate, RYYGate, RZZGate, RZXGate, CPhaseGate, CRZGate, CRXGate, CRYGate])
+    def test_one_controlled_u_gate_in_unitary(self, gate):
+        """Verify a unitary with one controlled-u gate for different gates in the decomposition"""
+        unitary = RZZGate(0.3).to_matrix()
+
+        decomposer = TwoQubitControlledUDecomposer(gate, euler_basis="U")
+        circ = decomposer(unitary)
+        self.assertEqual(Operator(unitary), Operator(circ))
+
+        # bound on the number of 2-qubit gates
+        num2q = circ.size(filter_function=lambda x: x.operation.num_qubits == 2)
+        self.assertEqual(num2q, 1)
+
+        # bound on the number of 1-qubit gates
+        self.assertLessEqual(circ.count_ops().get("u", 0), 4)
+
     def test_not_rxx_equivalent(self):
         """Test that an exception is raised if the gate is not equivalent to an RXXGate"""
         gate = SwapGate

--- a/test/python/synthesis/test_synthesis.py
+++ b/test/python/synthesis/test_synthesis.py
@@ -1472,7 +1472,7 @@ class TestTwoQubitControlledUDecompose(CheckDecompositions):
     @combine(gate=[RXXGate, RYYGate, RZZGate, RZXGate, CPhaseGate, CRZGate, CRXGate, CRYGate])
     def test_one_controlled_u_gate_in_unitary(self, gate):
         """Verify a unitary with one controlled-u gate for different gates in the decomposition"""
-        unitary = RZZGate(0.3).to_matrix()
+        unitary = RZZGate(-0.3).to_matrix()
 
         decomposer = TwoQubitControlledUDecomposer(gate, euler_basis="U")
         circ = decomposer(unitary)
@@ -1484,6 +1484,8 @@ class TestTwoQubitControlledUDecompose(CheckDecompositions):
 
         # bound on the number of 1-qubit gates
         self.assertLessEqual(circ.count_ops().get("u", 0), 4)
+        if gate(0.1).name == "rzz":
+            self.assertEqual(circ.size(), 1)
 
     def test_not_rxx_equivalent(self):
         """Test that an exception is raised if the gate is not equivalent to an RXXGate"""


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->
close #16036 

This PR reduces the total number of 1-qubit unitaries needed to synthesize a general 2-qubit unitary using `TwoQubitControlledUDecomposer` from 24 to 8.

This is in particular useful for the peephole optimization in #13419.

**Details:**

The `TwoQubitControlledUDecomposer` consists of the following steps.

1. We start from a general 4x4 unitary U.

2. Then we find a cannonical gate W (Weyl gate) s.t.
`U(0,1) = c2r(0) c2l(1) W(0,1) c1r(0) c1l(1) `
this yields 4 1-qubit unitary gates.

```
     ┌─────┐┌───────┐┌─────┐
q_0: ┤ c2r ├┤0      ├┤ c1r ├
     ├─────┤│  Weyl │├─────┤
q_1: ┤ c2l ├┤1      ├┤ c1l ├
     └─────┘└───────┘└─────┘
```

3. Then, we write the Weyl gate W as:
`W(0,1) = RXX(0,1) RYY(0,1) RZZ(0,1)`
```
     ┌─────────┐┌─────────┐        
q_0: ┤0        ├┤0        ├─■──────
     │  Rxx(a) ││  Ryy(b) │ │ZZ(c) 
q_1: ┤1        ├┤1        ├─■──────
     └─────────┘└─────────┘        
```
4. Now, we rewrite RYY(0,1) and RZZ(0,1) as:
`RYY(0,1) = sdg(0) sdg(0,1) RXX(0,1) s(0,1) s(0,1)`
`RZZ(0,1) = h(0) h(0,1) h(0,1) h(0,1) h(0,1)`
yielding 8 additional 1-qubit unitary gates.

```
     ┌─────┐┌─────────┐┌───┐
q_0: ┤ Sdg ├┤0        ├┤ S ├
     ├─────┤│  Rxx(b) │├───┤
q_1: ┤ Sdg ├┤1        ├┤ S ├
     └─────┘└─────────┘└───┘
     ┌───┐┌─────────┐┌───┐
q_0: ┤ H ├┤0        ├┤ H ├
     ├───┤│  Rxx(c) │├───┤
q_1: ┤ H ├┤1        ├┤ H ├
     └───┘└─────────┘└───┘
```

5. If Equiv is the target controlled-U gate (which is locally equivalent to RXX), then we rewrite RXX using Equiv:
`RXX(0,1) = k2r(0) k2l(1) Equiv(0,1) k1r(0) k1l(1)`
yielding 3*4 1-qubit unitary gates.
```
     ┌─────┐┌────────┐┌─────┐
q_0: ┤ k2r ├┤0       ├┤ k1r ├
     ├─────┤│  Equiv │├─────┤
q_1: ┤ k2l ├┤1       ├┤ k1l ├
     └─────┘└────────┘└─────┘
```

This gives a total of:
3*4 + 8 + 4 = 24 1-qubit unitary gates.
```
     ┌─────┐┌─────────┐┌───────────┐┌─────────┐┌─────┐┌─────────┐┌───────────┐»
q_0: ┤ c2r ├┤ rxx_k2r ├┤0          ├┤ rxx_k1r ├┤ Sdg ├┤ ryy_k2r ├┤0          ├»
     ├─────┤├─────────┤│  Equiv(a) │├─────────┤├─────┤├─────────┤│  Equiv(b) │»
q_1: ┤ c2l ├┤ rxx_k2l ├┤1          ├┤ rxx_k1l ├┤ Sdg ├┤ ryy_k2l ├┤1          ├»
     └─────┘└─────────┘└───────────┘└─────────┘└─────┘└─────────┘└───────────┘»
«     ┌─────────┐┌───┐┌───┐┌─────────┐┌───────────┐┌─────────┐┌───┐┌─────┐
«q_0: ┤ ryy_k1r ├┤ S ├┤ H ├┤ rzz_k2r ├┤0          ├┤ rzz_k1r ├┤ H ├┤ c1r ├
«     ├─────────┤├───┤├───┤├─────────┤│  Equiv(c) │├─────────┤├───┤├─────┤
«q_1: ┤ ryy_k1l ├┤ S ├┤ H ├┤ rzz_k2l ├┤1          ├┤ rzz_k1l ├┤ H ├┤ c1l ├
«     └─────────┘└───┘└───┘└─────────┘└───────────┘└─────────┘└───┘└─────┘
```

In this PR we multiply the 1-qubit unitary matrices betwen the 2-qubit gates, to get at most 8 1-qubit unitary gates (in the general case where 3 2-qubit gates are needed).


### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
