### PR TITLE
Fix MPL drawer crash with cregbundle=True and compose-style control flow

### DIFF
--- a/qiskit/visualization/circuit/matplotlib.py
+++ b/qiskit/visualization/circuit/matplotlib.py
@@ -579,11 +579,12 @@ class MatplotlibDrawer:
                             }
                         )
                         for outer, inner in zip(node.cargs, circuit.clbits):
-                            if self._cregbundle and (
-                                (in_reg := get_bit_register(outer_circuit, inner)) is not None
-                            ):
+                            if self._cregbundle:
+                                in_reg = get_bit_register(circuit, inner)
                                 out_reg = get_bit_register(outer_circuit, outer)
-                                flow_wire_map.update({in_reg: wire_map[out_reg]})
+                                inner_key = in_reg if in_reg is not None else inner
+                                outer_key = out_reg if out_reg is not None else outer
+                                flow_wire_map.update({inner_key: wire_map[outer_key]})
                             else:
                                 flow_wire_map.update({inner: wire_map[outer]})
 
@@ -617,6 +618,7 @@ class MatplotlibDrawer:
                         for flow_layer in flow_nodes:
                             for flow_node in flow_layer:
                                 node_data[flow_node].circ_num = circ_num
+                                node_data[flow_node].node_circuit = circuit
 
                         # Add up the width values of the same flow_parent that are not -1
                         # to get the raw_gate_width
@@ -645,7 +647,7 @@ class MatplotlibDrawer:
                 # based on the width of register_bit and puts it into the param_width. If the
                 # register_bit is small enough, the gate will just use the WID width.
                 elif not self._measure_arrows and isinstance(op, Measure):
-                    register, _, reg_index = get_bit_reg_index(outer_circuit, node.cargs[0])
+                    register, _, reg_index = get_bit_reg_index(self._circuit, node.cargs[0])
                     if register is not None:
                         param_text = f"{register.name}_{reg_index}"
                     else:
@@ -802,7 +804,7 @@ class MatplotlibDrawer:
                 for carg in node.cargs:
                     if carg in self._clbits:
                         if self._cregbundle:
-                            register = get_bit_register(outer_circuit, carg)
+                            register = get_bit_register(self._circuit, carg)
                             if register is not None:
                                 c_indxs.append(wire_map[register])
                             else:
@@ -1336,7 +1338,8 @@ class MatplotlibDrawer:
         """Draw the measure symbol and the line to the clbit"""
         qx, qy = node_data[node].q_xy[0]
         cx, cy = node_data[node].c_xy[0]
-        register, _, reg_index = get_bit_reg_index(outer_circuit, node.cargs[0])
+        node_circuit = node_data[node].node_circuit or outer_circuit
+        register, _, reg_index = get_bit_reg_index(node_circuit, node.cargs[0])
 
         # draw gate box
         self._gate(node, node_data, glob_data)
@@ -2079,3 +2082,4 @@ class NodeData:
         self.indexset = ()  # List of indices used for ForLoopOp
         self.jump_values = []  # List of jump values used for SwitchCaseOp
         self.circ_num = 0  # Which block is it in op.blocks
+        self.node_circuit = None  # The circuit this node belongs to (set for flow-op inner nodes)

--- a/releasenotes/notes/fix-mpl-cregbundle-compose-control-flow-f4471e3aa3787675.yaml
+++ b/releasenotes/notes/fix-mpl-cregbundle-compose-control-flow-f4471e3aa3787675.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed a :exc:`.CircuitError` raised by the Matplotlib circuit drawer when
+    ``cregbundle=True`` and the circuit contains control-flow blocks created via
+    :meth:`.QuantumCircuit.compose` rather than the builder interface.  For
+    compose-style control flow the inner block's classical bits are different
+    Python objects from the outer circuit's bits; the drawer was incorrectly
+    looking them up in the outer circuit.
+    See `#15823 <https://github.com/Qiskit/qiskit/issues/15823>`__.

--- a/test/python/visualization/test_circuit_drawer.py
+++ b/test/python/visualization/test_circuit_drawer.py
@@ -288,3 +288,26 @@ class TestCircuitDrawer(QiskitTestCase):
         circuit.draw("latex_source")
         if optionals.HAS_MATPLOTLIB and optionals.HAS_PYLATEX:
             circuit.draw("mpl")
+
+    @unittest.skipUnless(optionals.HAS_MATPLOTLIB, "Skipped because matplotlib is not available")
+    def test_mpl_cregbundle_non_builder_control_flow(self):
+        """MPL drawer must not raise when cregbundle=True and control flow uses compose.
+
+        For non-builder (compose-style) control flow the inner block's clbits are different
+        Python objects from the outer circuit's clbits.  The cregbundle wire-map path was
+        incorrectly looking up inner clbits in the outer circuit, causing a CircuitError.
+        Regression test for https://github.com/Qiskit/qiskit/issues/15823.
+        """
+        cell = QuantumCircuit(1, 1)
+        cell.h(0)
+        cell.measure(0, 0)
+        with cell.if_test((cell.clbits[0], 1)):
+            cell.x(0)
+
+        qc = QuantumCircuit(2, 2)
+        for i in range(2):
+            qc.compose(cell, qubits=[i], clbits=[i], inplace=True)
+
+        # Both settings must succeed without raising CircuitError.
+        self.assertIsInstance(qc.draw("mpl", cregbundle=True), figure.Figure)
+        self.assertIsInstance(qc.draw("mpl", cregbundle=False), figure.Figure)


### PR DESCRIPTION
## Summary

Fix a `CircuitError` raised by the Matplotlib circuit drawer when `cregbundle=True` is used with control-flow blocks created via `QuantumCircuit.compose()` rather than the builder interface.

## Problem

```python
from qiskit import QuantumCircuit

cell = QuantumCircuit(1, 1)
cell.h(0)
cell.measure(0, 0)
with cell.if_test((cell.clbits[0], 1)):
    cell.x(0)

qc = QuantumCircuit(2, 2)
for i in range(2):
    qc.compose(cell, qubits=[i], clbits=[i], inplace=True)

qc.draw("mpl", cregbundle=True)  # raises CircuitError
```

Output (before fix):

```
qiskit.circuit.exceptions.CircuitError: 'Could not locate provided bit: <Clbit uid=0>. Has it been added to the QuantumCircuit?'
```

## Root cause

For compose-style control flow, each inner block's clbits are different Python objects from the outer circuit's clbits.  Builder-style control flow shares the same Python objects, so the bug was hidden.

Four sites in `matplotlib.py` called `get_bit_register(outer_circuit, inner_clbit)` or `get_bit_reg_index(outer_circuit, inner_clbit)`, which fail when `inner_clbit` is not registered in `outer_circuit`.

## Fix

- **`_get_layer_widths` (wire-map build)**: look up the inner clbit's register in the inner circuit block; look up the outer clbit's register in `outer_circuit`.  Both keys fall back to the bare clbit when no register exists.
- **`_get_layer_widths` (measure-width path)**: use `self._circuit` (the flow drawer's circuit).
- **`_get_coords`**: use `self._circuit`.
- **`_measure`**: store the owning inner circuit on `NodeData.node_circuit` during flow-node population; use `node_data[node].node_circuit or outer_circuit` in `_measure`.

Builder-style control flow is unaffected.

## Tests

`test_mpl_cregbundle_non_builder_control_flow` added to `test_circuit_drawer.py` — asserts that a compose-style circuit with measurement inside control flow draws without error under both `cregbundle=True` and `cregbundle=False`.

All 262 visualization tests pass.

## Validation

```
python -m pytest test/python/visualization/ -q    # 262 passed, 2 skipped
black --check matplotlib.py test_circuit_drawer.py # All done!
ruff check matplotlib.py test_circuit_drawer.py    # All checks passed!
```

## Notes / limitations

- Does not fix the analogous text-drawer bug (issue #15822).
- For compose-style inner blocks with anonymous bits, measure labels fall back to bit index rather than outer register name — pre-existing display limitation, out of scope here.

### AI/LLM disclosure

- [x] I used the following tool to generate or modify code: Claude Code (claude-sonnet-4-6)

Fixes #15823.