### PR TITLE
Enable clippy on rust tests too

### DIFF
--- a/crates/circuit/src/circuit_drawer.rs
+++ b/crates/circuit/src/circuit_drawer.rs
@@ -1271,7 +1271,7 @@ impl TextDrawer {
 ///     f : Number to check.
 ///
 /// Returns:
-///     The string representation of output. None if no Pi formatting is found.  
+///     The string representation of output. None if no Pi formatting is found.
 pub fn format_float_pi(f: f64) -> Option<String> {
     const DENOMINATOR: i64 = 16;
     // epsilon value defines the threshold to detect pi.
@@ -1364,6 +1364,9 @@ mod tests {
     };
     use crate::parameter::parameter_expression::ParameterExpression;
     use crate::parameter::symbol_expr::Symbol;
+
+    #[cfg(feature = "cache_pygates")]
+    use std::sync::OnceLock;
 
     fn basic_circuit() -> CircuitData {
         let qreg = QuantumRegister::new_owning("q", 2);
@@ -1471,6 +1474,8 @@ c2_1: ══════════
             clbits: circuit.add_cargs(&[Clbit::new(0)]),
             params: None,
             label: None,
+            #[cfg(feature = "cache_pygates")]
+            py_op: OnceLock::new(),
         };
         circuit.push(inst).unwrap();
 
@@ -1651,6 +1656,8 @@ q_1: ┤ H ├┤1            ├┤1               ├┤ my_ch ├
             clbits: circuit.cargs_interner().get_default(),
             params: None,
             label: None,
+            #[cfg(feature = "cache_pygates")]
+            py_op: OnceLock::new(),
         };
         circuit.push(inst).unwrap();
         let inst = PackedInstruction {
@@ -1662,6 +1669,8 @@ q_1: ┤ H ├┤1            ├┤1               ├┤ my_ch ├
             clbits: circuit.cargs_interner().get_default(),
             params: None,
             label: Some(Box::new("my little identity".to_string())),
+            #[cfg(feature = "cache_pygates")]
+            py_op: OnceLock::new(),
         };
         circuit.push(inst).unwrap();
         let inst = PackedInstruction {
@@ -1673,6 +1682,8 @@ q_1: ┤ H ├┤1            ├┤1               ├┤ my_ch ├
             clbits: circuit.cargs_interner().get_default(),
             params: None,
             label: None,
+            #[cfg(feature = "cache_pygates")]
+            py_op: OnceLock::new(),
         };
         circuit.push(inst).unwrap();
         let inst = PackedInstruction {
@@ -1684,6 +1695,8 @@ q_1: ┤ H ├┤1            ├┤1               ├┤ my_ch ├
             clbits: circuit.cargs_interner().get_default(),
             params: None,
             label: Some(Box::new("my small identity".to_string())),
+            #[cfg(feature = "cache_pygates")]
+            py_op: OnceLock::new(),
         };
         circuit.push(inst).unwrap();
         let inst = PackedInstruction {
@@ -1695,6 +1708,8 @@ q_1: ┤ H ├┤1            ├┤1               ├┤ my_ch ├
             clbits: circuit.cargs_interner().get_default(),
             params: None,
             label: None,
+            #[cfg(feature = "cache_pygates")]
+            py_op: OnceLock::new(),
         };
         circuit.push(inst).unwrap();
         let inst = PackedInstruction {
@@ -1706,6 +1721,8 @@ q_1: ┤ H ├┤1            ├┤1               ├┤ my_ch ├
             clbits: circuit.cargs_interner().get_default(),
             params: None,
             label: Some(Box::new("my medium identity".to_string())),
+            #[cfg(feature = "cache_pygates")]
+            py_op: OnceLock::new(),
         };
         circuit.push(inst).unwrap();
         let inst = PackedInstruction {
@@ -1717,6 +1734,8 @@ q_1: ┤ H ├┤1            ├┤1               ├┤ my_ch ├
             clbits: circuit.cargs_interner().get_default(),
             params: None,
             label: None,
+            #[cfg(feature = "cache_pygates")]
+            py_op: OnceLock::new(),
         };
         circuit.push(inst).unwrap();
         let inst = PackedInstruction {
@@ -1728,6 +1747,8 @@ q_1: ┤ H ├┤1            ├┤1               ├┤ my_ch ├
             clbits: circuit.cargs_interner().get_default(),
             params: None,
             label: Some(Box::new("my bigger identity".to_string())),
+            #[cfg(feature = "cache_pygates")]
+            py_op: OnceLock::new(),
         };
         circuit.push(inst).unwrap();
         let result = draw_circuit(&circuit, false, false, Some(80)).unwrap();
@@ -1975,6 +1996,8 @@ q_1: ┤1         ├┤1            ├┤1         ├
                 clbits: circuit.cargs_interner().get_default(),
                 params: None,
                 label: None,
+                #[cfg(feature = "cache_pygates")]
+                py_op: OnceLock::new(),
             };
             circuit.push(inst).unwrap();
         }
@@ -1993,6 +2016,8 @@ q_1: ┤1         ├┤1            ├┤1         ├
                     clbits: circuit.cargs_interner().get_default(),
                     params: Some(Box::new(Parameters::Params(smallvec![param]))),
                     label: None,
+                    #[cfg(feature = "cache_pygates")]
+                    py_op: OnceLock::new(),
                 };
                 circuit.push(inst).unwrap();
             }
@@ -2005,6 +2030,8 @@ q_1: ┤1         ├┤1            ├┤1         ├
                 clbits: circuit.cargs_interner().get_default(),
                 params: None,
                 label: None,
+                #[cfg(feature = "cache_pygates")]
+                py_op: OnceLock::new(),
             };
             circuit.push(inst).unwrap();
         }
@@ -2015,6 +2042,8 @@ q_1: ┤1         ├┤1            ├┤1         ├
                 clbits: circuit.add_cargs(&[Clbit::new(i)]),
                 params: None,
                 label: None,
+                #[cfg(feature = "cache_pygates")]
+                py_op: OnceLock::new(),
             };
             circuit.push(inst).unwrap();
         }
@@ -2119,7 +2148,7 @@ q_1: ┤1         ├┤1             ├┤1         ├
             Symbol::new("🎩", None, None),
         )));
         circuit
-            .push_standard_gate(StandardGate::RY, &[param.clone()], &[Qubit(1)])
+            .push_standard_gate(StandardGate::RY, std::slice::from_ref(&param), &[Qubit(1)])
             .unwrap();
         circuit
             .push_standard_gate(StandardGate::RXX, &[param], &[Qubit(0), Qubit(1)])

--- a/crates/transpiler/src/passes/split_2q_unitaries.rs
+++ b/crates/transpiler/src/passes/split_2q_unitaries.rs
@@ -175,7 +175,7 @@ pub fn run_split_2q_unitaries(
             inst.params.as_deref().cloned(),
             inst.label.as_ref().map(|x| x.to_string()),
             #[cfg(feature = "cache_pygates")]
-            inst.py_op.get().map(|x| x.clone()),
+            inst.py_op.get().cloned(),
         )?;
     }
     Ok(Some((new_dag.build(), mapping)))

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ commands =
   black --check {posargs} qiskit test tools setup.py docs/conf.py
   cargo fmt --check
   ruff check qiskit test tools setup.py
-  cargo clippy -- -D warnings
+  cargo clippy --all-targets -- -D warnings
   python {toxinidir}/tools/verify_headers.py qiskit test tools crates
   python {toxinidir}/tools/find_optional_imports.py
   python {toxinidir}/tools/find_stray_release_notes.py


### PR DESCRIPTION
Building off of the recently merged #16018 which ran cargo clippy with --all-targets to fix some issues flagged in our test code, this commit enables the --all-targets flag in CI. This will ensure our tests are running linting too. The --all-targets flag is often paired with the --all-features flag to ensure clippy is checking all code paths, however for Qiskit we can't use the --all-features flag because the mimalloc feature flags on qiskit-pyext and qiskit-cext are mutually exclusive so we can't run clippy on the entire workspace with every feature enabled. If we wanted this coverage we would have to run clippy per library with the --all-features flag, but this doesn't make that change because it's potentially slower than it's worth since we don't have very many features. This commit does fix the underlying issues running clippy on all-features catches (until the pyext build which fails during compilation).

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
