### PR TITLE
Use generic errors in the variable mapper and expr.

### DIFF
--- a/crates/circuit/src/classical/expr/expr.rs
+++ b/crates/circuit/src/classical/expr/expr.rs
@@ -10,6 +10,8 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use std::error::Error;
+
 use crate::classical::expr::{Binary, Cast, Index, Stretch, Unary, Value, Var};
 use crate::classical::types::Type;
 use pyo3::prelude::*;
@@ -140,16 +142,18 @@ impl Expr {
     }
 
     /// Visits all nodes by mutable reference, in a post-order traversal.
-    pub fn visit_mut<F>(&mut self, mut visitor: F) -> PyResult<()>
+    pub fn visit_mut<F, E>(&mut self, mut visitor: F) -> Result<(), E>
     where
-        F: FnMut(ExprRefMut) -> PyResult<()>,
+        F: FnMut(ExprRefMut) -> Result<(), E>,
+        E: Error,
     {
         self.visit_mut_impl(&mut visitor)
     }
 
-    fn visit_mut_impl<F>(&mut self, visitor: &mut F) -> PyResult<()>
+    fn visit_mut_impl<F, E>(&mut self, visitor: &mut F) -> Result<(), E>
     where
-        F: FnMut(ExprRefMut) -> PyResult<()>,
+        F: FnMut(ExprRefMut) -> Result<(), E>,
+        E: Error,
     {
         match self {
             Expr::Unary(u) => u.operand.visit_mut_impl(visitor)?,
@@ -481,7 +485,7 @@ mod tests {
     use crate::classical::types::Type;
     use crate::duration::Duration;
     use num_bigint::BigUint;
-    use pyo3::PyResult;
+    use pyo3::{PyErr, PyResult};
     use uuid::Uuid;
 
     #[test]
@@ -704,7 +708,7 @@ mod tests {
 
         expr.visit_mut(|x| {
             assert!(order.next().unwrap()(&x));
-            Ok(())
+            Ok::<_, PyErr>(())
         })?;
 
         assert!(order.next().is_none());
@@ -740,7 +744,7 @@ mod tests {
         expr.visit_mut(|x| match x {
             ExprRefMut::Var(Var::Standalone { name, .. }) => {
                 *name = "updated".to_string();
-                Ok(())
+                Ok::<_, PyErr>(())
             }
             _ => Ok(()),
         })?;

--- a/crates/circuit/src/variable_mapper.rs
+++ b/crates/circuit/src/variable_mapper.rs
@@ -16,9 +16,8 @@ use crate::operations::{Condition, SwitchTarget};
 use hashbrown::{HashMap, HashSet};
 use num_bigint::BigUint;
 use num_traits::Num;
-use pyo3::PyResult;
-use pyo3::prelude::*;
 use std::cell::RefCell;
+use std::error::Error;
 
 pub(crate) struct VariableMapper {
     target_cregs: Vec<ClassicalRegister>,
@@ -59,14 +58,15 @@ impl VariableMapper {
     /// [DAGCircuit::compose]; nowhere else does this, and in general this would require *far*
     /// more complex classical rewriting than Qiskit needs to worry about in the full expression
     /// era.
-    pub fn map_condition<F>(
+    pub fn map_condition<F, E>(
         &self,
         condition: &Condition,
         allow_reorder: bool,
         mut add_register: F,
-    ) -> PyResult<Condition>
+    ) -> Result<Condition, E>
     where
-        F: FnMut(&ClassicalRegister) -> PyResult<()>,
+        F: FnMut(&ClassicalRegister) -> Result<(), E>,
+        E: Error,
     {
         Ok(match condition {
             Condition::Bit(target, value) => {
@@ -99,7 +99,7 @@ impl VariableMapper {
                         mapped_bits_set == register_set
                     })
                     .cloned()
-                    .map(Ok::<_, PyErr>)
+                    .map(Ok::<_, E>)
                     .unwrap_or_else(|| {
                         let mapped_theirs =
                             ClassicalRegister::new_alias(None, mapped_bits_order.clone());
@@ -138,13 +138,14 @@ impl VariableMapper {
 
     /// Map the real-time variables in a `target` of a `SwitchCaseOp` to the new
     /// circuit.
-    pub fn map_target<F>(
+    pub fn map_target<F, E>(
         &self,
         target: &SwitchTarget,
         mut add_register: F,
-    ) -> PyResult<SwitchTarget>
+    ) -> Result<SwitchTarget, E>
     where
-        F: FnMut(&ClassicalRegister) -> PyResult<()>,
+        F: FnMut(&ClassicalRegister) -> Result<(), E>,
+        E: Error,
     {
         Ok(match target {
             SwitchTarget::Bit(bit) => SwitchTarget::Bit(self.bit_map.get(bit).cloned().unwrap()),
@@ -156,9 +157,10 @@ impl VariableMapper {
     }
 
     /// Map the variables in an [expr::Expr] node to the new circuit.
-    pub fn map_expr<F>(&self, expr: &expr::Expr, mut add_register: F) -> PyResult<expr::Expr>
+    pub fn map_expr<F, E>(&self, expr: &expr::Expr, mut add_register: F) -> Result<expr::Expr, E>
     where
-        F: FnMut(&ClassicalRegister) -> PyResult<()>,
+        F: FnMut(&ClassicalRegister) -> Result<(), E>,
+        E: Error,
     {
         let mut mapped = expr.clone();
         mapped.visit_mut(|e| match e {
@@ -194,13 +196,14 @@ impl VariableMapper {
 
     /// Map the target's registers to suitable equivalents in the destination, adding an
     /// extra one if there's no exact match."""
-    fn map_register<F>(
+    fn map_register<F, E>(
         &self,
         theirs: &ClassicalRegister,
         mut add_register: F,
-    ) -> PyResult<ClassicalRegister>
+    ) -> Result<ClassicalRegister, E>
     where
-        F: FnMut(&ClassicalRegister) -> PyResult<()>,
+        F: FnMut(&ClassicalRegister) -> Result<(), E>,
+        E: Error,
     {
         if let Some(mapped_theirs) = self.register_map.borrow().get(theirs.name()) {
             return Ok(mapped_theirs.clone());
@@ -215,7 +218,7 @@ impl VariableMapper {
                 mapped_bits == register
             })
             .cloned()
-            .map(Ok::<_, PyErr>)
+            .map(Ok::<_, E>)
             .unwrap_or_else(|| {
                 let mapped_theirs = ClassicalRegister::new_alias(None, mapped_bits.clone());
                 add_register(&mapped_theirs)?;


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->
While in the past we relied on `PyResult` to handle all of the errors as python exceptions, we can now remove some of the dependencies in parts of our system. After some evaluation, it turns out we can use generic errors in the `VariableMapper` and `Expr` which frees us from needing python in order to use these components.

This was discovered during efforts to separate `DAGCircuit`'s error messages from always using `PyErr`.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
