### PR TITLE
Revert QV circuit size change from PGO scripts

### DIFF
--- a/tools/pgo_scripts/test_utility_scale.py
+++ b/tools/pgo_scripts/test_utility_scale.py
@@ -80,9 +80,9 @@ def _main():
         strict=False,
     )
     qaoa_circ.name = "qaoa_barabasi_albert_N100_3reps"
-    qv_circ = quantum_volume(cmap.size(), seed=123456789)
+    qv_circ = quantum_volume(100, seed=123456789)
     qv_circ.measure_all()
-    qv_circ.name = "QV12554203470773361527671578846415332832204710888928069025792"
+    qv_circ.name = "QV1267650600228229401496703205376"
     hwb_circ = qasm2.load(
         os.path.join(QASM_DIR, "hwb12.qasm"),
         include_path=qasm2.LEGACY_INCLUDE_PATH,


### PR DESCRIPTION
In #15931 we updated the qv circuit used for the PGO scripts to use the quantum_volume() function instead of the deprecated QuantumVolume class. However at the same time that also increased the circuit from a 100 qubit quantum volume circuit to a 193 qubit quantum volume circuit. This is a significantly deeper circuit and running the transpiler for profile collection is significantly slower, taking several minutes locally in my environment. 100 qubits was not nearly as slow to run so this opts to revert this part of the change back to use the 100 qubit quantum volume to limit the runtime of the pgo profile collection.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
