### PR TITLE
Set QISKIT_BUILD_WITH_MIMALLOC=1 for PGO profiling step

### DIFF
--- a/tools/build_pgo.sh
+++ b/tools/build_pgo.sh
@@ -23,7 +23,7 @@ if [[ $arch == "arm64" ]]; then
 fi
 
 # Build with instrumentation
-RUSTFLAGS="-Cprofile-generate=$work_dir" QISKIT_BUILD_PROFILE=release pip install --prefer-binary -c constraints.txt --group test -e .
+QISKIT_BUILD_WITH_MIMALLOC=1 RUSTFLAGS="-Cprofile-generate=$work_dir" QISKIT_BUILD_PROFILE=release pip install --prefer-binary -c constraints.txt --group test -e .
 
 # Run profile data generation
 QISKIT_PARALLEL=FALSE stestr run --abbreviate


### PR DESCRIPTION
In the recently merged #16024 we added optional support for building with mimalloc as the global allocator. This is an opt-in flag to limit the scope of requiring a C compiler to build the mimalloc dependency when building qiskit from source. However in that PR we overlooked setting the QISKIT_BUILD_WITH_MIMALLOC=1 environment variable when building qiskit with instrumentation enabled for PGO profile collection. The intent was to use mimalloc for our release builds and this oversight meant we were collecting profiling data without mimalloc and then building the final release output with mimalloc. It is unlikely this would cause a huge issue in practice but it is better to keep the profiling data as close to the actual final build as possible.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
