### PR TITLE
Fix `InverseCancellation` for symmetric pairs

### DIFF
--- a/crates/transpiler/src/passes/inverse_cancellation.rs
+++ b/crates/transpiler/src/passes/inverse_cancellation.rs
@@ -174,17 +174,32 @@ static SELF_INVERSE_GATES_FOR_CANCELLATION: [StandardGate; 15] = [
     StandardGate::C3X,
 ];
 
-// Inverse cancellation pairs, plus a static array indicating
-// whether the gates are symmetric and the qubit order does not matter.
-// For CS-CSdg, for example, the qubit order is irrelevant since the
-// gates are symmetric.
-static INVERSE_PAIRS_FOR_CANCELLATION: [[StandardGate; 2]; 4] = [
-    [StandardGate::T, StandardGate::Tdg],
-    [StandardGate::S, StandardGate::Sdg],
-    [StandardGate::SX, StandardGate::SXdg],
-    [StandardGate::CS, StandardGate::CSdg],
+// Inverse cancellation pairs. We store pairs, plus additional info
+// if the gates are symmetric and cancel irrespective of qubit order.
+struct InversePair {
+    gates: [StandardGate; 2],
+    symmetric: bool,
+}
+static INVERSE_PAIRS_FOR_CANCELLATION: [InversePair; 4] = [
+    // for 1-q gates, the symmetric flag does not matter -- it is slightly more efficient
+    // to set it to `false` in this case to avoid more involved qubit equality checks
+    InversePair {
+        gates: [StandardGate::T, StandardGate::Tdg],
+        symmetric: false,
+    },
+    InversePair {
+        gates: [StandardGate::S, StandardGate::Sdg],
+        symmetric: false,
+    },
+    InversePair {
+        gates: [StandardGate::SX, StandardGate::SXdg],
+        symmetric: false,
+    },
+    InversePair {
+        gates: [StandardGate::CS, StandardGate::CSdg],
+        symmetric: true,
+    },
 ];
-static INVERSE_PAIRS_SYMMETRIC: [bool; 4] = [false, false, false, true];
 
 fn std_self_inverse(dag: &mut DAGCircuit) {
     if !SELF_INVERSE_GATES_FOR_CANCELLATION
@@ -240,22 +255,22 @@ fn std_self_inverse(dag: &mut DAGCircuit) {
 }
 
 fn std_inverse_pairs(dag: &mut DAGCircuit) {
-    if !INVERSE_PAIRS_FOR_CANCELLATION.iter().any(|gate| {
-        dag.get_op_counts().contains_key(gate[0].name())
-            && dag.get_op_counts().contains_key(gate[1].name())
+    if !INVERSE_PAIRS_FOR_CANCELLATION.iter().any(|pair| {
+        dag.get_op_counts().contains_key(pair.gates[0].name())
+            && dag.get_op_counts().contains_key(pair.gates[1].name())
     }) {
         return;
     }
     // Handle inverse pairs
-    for (pair_idx, [gate_0, gate_1]) in INVERSE_PAIRS_FOR_CANCELLATION.iter().enumerate() {
-        if !dag.get_op_counts().contains_key(gate_0.name())
-            || !dag.get_op_counts().contains_key(gate_1.name())
+    for pair in INVERSE_PAIRS_FOR_CANCELLATION.iter() {
+        if !dag.get_op_counts().contains_key(pair.gates[0].name())
+            || !dag.get_op_counts().contains_key(pair.gates[1].name())
         {
             continue;
         }
         let filter = |inst: &PackedInstruction| -> bool {
             match inst.op.view() {
-                OperationRef::StandardGate(gate) => gate == *gate_0 || gate == *gate_1,
+                OperationRef::StandardGate(gate) => gate == pair.gates[0] || gate == pair.gates[1],
                 _ => false,
             }
         };
@@ -271,7 +286,7 @@ fn std_inverse_pairs(dag: &mut DAGCircuit) {
                 };
 
                 // For symmetric gates, check if the qubits match irrespective of the order
-                let qubits_match = if INVERSE_PAIRS_SYMMETRIC[pair_idx] {
+                let qubits_match = if pair.symmetric {
                     let inst_qubits = dag.get_qargs(inst.qubits);
                     let next_inst_qubits = dag.get_qargs(next_inst.qubits);
 
@@ -284,10 +299,10 @@ fn std_inverse_pairs(dag: &mut DAGCircuit) {
                     inst.qubits == next_inst.qubits
                 };
                 if qubits_match
-                    && ((inst.op.try_standard_gate() == Some(*gate_0)
-                        && next_inst.op.try_standard_gate() == Some(*gate_1))
-                        || (inst.op.try_standard_gate() == Some(*gate_1)
-                            && next_inst.op.try_standard_gate() == Some(*gate_0)))
+                    && ((inst.op.try_standard_gate() == Some(pair.gates[0])
+                        && next_inst.op.try_standard_gate() == Some(pair.gates[1]))
+                        || (inst.op.try_standard_gate() == Some(pair.gates[1])
+                            && next_inst.op.try_standard_gate() == Some(pair.gates[0])))
                 {
                     dag.remove_op_node(nodes[i]);
                     dag.remove_op_node(nodes[i + 1]);

--- a/crates/transpiler/src/passes/inverse_cancellation.rs
+++ b/crates/transpiler/src/passes/inverse_cancellation.rs
@@ -174,12 +174,17 @@ static SELF_INVERSE_GATES_FOR_CANCELLATION: [StandardGate; 15] = [
     StandardGate::C3X,
 ];
 
+// Inverse cancellation pairs, plus a static array indicating
+// whether the gates are symmetric and the qubit order does not matter.
+// For CS-CSdg, for example, the qubit order is irrelevant since the
+// gates are symmetric.
 static INVERSE_PAIRS_FOR_CANCELLATION: [[StandardGate; 2]; 4] = [
     [StandardGate::T, StandardGate::Tdg],
     [StandardGate::S, StandardGate::Sdg],
     [StandardGate::SX, StandardGate::SXdg],
     [StandardGate::CS, StandardGate::CSdg],
 ];
+static INVERSE_PAIRS_SYMMETRIC: [bool; 4] = [false, false, false, true];
 
 fn std_self_inverse(dag: &mut DAGCircuit) {
     if !SELF_INVERSE_GATES_FOR_CANCELLATION
@@ -242,7 +247,7 @@ fn std_inverse_pairs(dag: &mut DAGCircuit) {
         return;
     }
     // Handle inverse pairs
-    for [gate_0, gate_1] in INVERSE_PAIRS_FOR_CANCELLATION {
+    for (pair_idx, [gate_0, gate_1]) in INVERSE_PAIRS_FOR_CANCELLATION.iter().enumerate() {
         if !dag.get_op_counts().contains_key(gate_0.name())
             || !dag.get_op_counts().contains_key(gate_1.name())
         {
@@ -250,7 +255,7 @@ fn std_inverse_pairs(dag: &mut DAGCircuit) {
         }
         let filter = |inst: &PackedInstruction| -> bool {
             match inst.op.view() {
-                OperationRef::StandardGate(gate) => gate == gate_0 || gate == gate_1,
+                OperationRef::StandardGate(gate) => gate == *gate_0 || gate == *gate_1,
                 _ => false,
             }
         };
@@ -264,11 +269,25 @@ fn std_inverse_pairs(dag: &mut DAGCircuit) {
                 let NodeType::Operation(next_inst) = &dag[nodes[i + 1]] else {
                     unreachable!("Not an op node");
                 };
-                if inst.qubits == next_inst.qubits
-                    && (inst.op.try_standard_gate() == Some(gate_0)
-                        && next_inst.op.try_standard_gate() == Some(gate_1))
-                    || (inst.op.try_standard_gate() == Some(gate_1)
-                        && next_inst.op.try_standard_gate() == Some(gate_0))
+
+                // For symmetric gates, check if the qubits match irrespective of the order
+                let qubits_match = if INVERSE_PAIRS_SYMMETRIC[pair_idx] {
+                    let inst_qubits = dag.get_qargs(inst.qubits);
+                    let next_inst_qubits = dag.get_qargs(next_inst.qubits);
+
+                    // We know that we have only 2-qubit gates here, so we perform a brief
+                    // check based on the slice, without converting to a set. We also do not
+                    // have to check the size matches, since we later check that the gates match,
+                    // hence we know the number of qubits matches.
+                    inst_qubits.iter().all(|q| next_inst_qubits.contains(q))
+                } else {
+                    inst.qubits == next_inst.qubits
+                };
+                if qubits_match
+                    && ((inst.op.try_standard_gate() == Some(*gate_0)
+                        && next_inst.op.try_standard_gate() == Some(*gate_1))
+                        || (inst.op.try_standard_gate() == Some(*gate_1)
+                            && next_inst.op.try_standard_gate() == Some(*gate_0)))
                 {
                     dag.remove_op_node(nodes[i]);
                     dag.remove_op_node(nodes[i + 1]);

--- a/releasenotes/notes/fix-inverse-cancellation-symmetric-pairs-6739a450e53e5c84.yaml
+++ b/releasenotes/notes/fix-inverse-cancellation-symmetric-pairs-6739a450e53e5c84.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`.InverseCancellation` where pairs of symmetric gates
+    (such as :class:`.CSGate` and :class:`.CSdgGate`) were not correctly cancelled
+    if their qubit arguments were the same but in different order. Symmetric
+    gates should get cancelled irrespective of the qubit order.
+
+    Fixed `#15855 <https://github.com/Qiskit/qiskit/issues/15855>`__.

--- a/releasenotes/notes/fix-inverse-cancellation-symmetric-pairs-6739a450e53e5c84.yaml
+++ b/releasenotes/notes/fix-inverse-cancellation-symmetric-pairs-6739a450e53e5c84.yaml
@@ -1,9 +1,9 @@
 ---
 fixes:
   - |
-    Fixed a bug in :class:`.InverseCancellation` where pairs of symmetric gates
-    (such as :class:`.CSGate` and :class:`.CSdgGate`) were not correctly cancelled
-    if their qubit arguments were the same but in different order. Symmetric
-    gates should get cancelled irrespective of the qubit order.
+    Fixed a bug in :class:`.InverseCancellation` where :class:`.CSGate` and :class:`.CSdgGate` pairs
+    with reversed qubit arguments were inconsistently cancelled.  Previously, a sequence of 
+    :math:`CS-CS^\dagger` (with reversed qubit args) was cancelled, but 
+    :math:`CS^\dagger-CS` was not.  Now both are consistently cancelled.
 
     Fixed `#15855 <https://github.com/Qiskit/qiskit/issues/15855>`__.

--- a/test/python/transpiler/test_inverse_cancellation.py
+++ b/test/python/transpiler/test_inverse_cancellation.py
@@ -34,6 +34,8 @@ from qiskit.circuit.library import (
     TdgGate,
     CZGate,
     RZGate,
+    CSGate,
+    CSdgGate,
 )
 from test import QiskitTestCase
 
@@ -739,6 +741,36 @@ class TestCXCancellation(QiskitTestCase):
         expected.if_else((clbit, True), expected_if_body, None, [0, 1, 2, 3], [0])
 
         self.assertEqual(pass_(test), expected)
+
+    def test_symmetries(self):
+        """Test cancellation of symmetric gates.
+
+        CS/CSdg should cancel if they are on the same set of qubits, irrespective of the order.
+        """
+        gates = [CSGate(), CSdgGate()]
+
+        # We're testing CS and CSdg in every possible combination and qubit order.
+        # All should cancel.
+        for i in [0, 1]:
+            for j in [0, 1]:
+                for gate_idx in [0, 1]:
+                    with self.subTest(i=i, j=j, gate_idx=gate_idx):
+                        qc = QuantumCircuit(2)
+                        qc.append(gates[gate_idx], [i, (i + 1) % 2])
+                        qc.append(gates[(gate_idx + 1) % 2], [j, (j + 1) % 2])
+
+                        tqc = InverseCancellation()(qc)
+                        self.assertEqual(tqc.count_ops(), {})
+
+        # sanity check: verify that CS-CSdg doesn't globally get cancelled
+        with self.subTest(msg="sanity check"):
+            qc = QuantumCircuit(3)
+            qc.cs(0, 1)
+            qc.csdg(2, 1)
+
+            tqc = InverseCancellation()(qc)
+            self.assertEqual(tqc.count_ops().get("cs", 0), 1)
+            self.assertEqual(tqc.count_ops().get("csdg", 0), 1)
 
 
 if __name__ == "__main__":

--- a/test/python/transpiler/test_inverse_cancellation.py
+++ b/test/python/transpiler/test_inverse_cancellation.py
@@ -15,6 +15,7 @@ Testing InverseCancellation
 """
 
 import unittest
+import itertools
 import numpy as np
 
 import ddt
@@ -747,20 +748,17 @@ class TestCXCancellation(QiskitTestCase):
 
         CS/CSdg should cancel if they are on the same set of qubits, irrespective of the order.
         """
-        gates = [CSGate(), CSdgGate()]
-
         # We're testing CS and CSdg in every possible combination and qubit order.
         # All should cancel.
-        for i in [0, 1]:
-            for j in [0, 1]:
-                for gate_idx in [0, 1]:
-                    with self.subTest(i=i, j=j, gate_idx=gate_idx):
-                        qc = QuantumCircuit(2)
-                        qc.append(gates[gate_idx], [i, (i + 1) % 2])
-                        qc.append(gates[(gate_idx + 1) % 2], [j, (j + 1) % 2])
+        for qargs in itertools.product([(0, 1), (1, 0)], repeat=2):
+            for gates in itertools.permutations([CSGate(), CSdgGate()]):
+                qc = QuantumCircuit(2)
+                qc.append(gates[0], qargs[0])
+                qc.append(gates[1], qargs[1])
 
-                        tqc = InverseCancellation()(qc)
-                        self.assertEqual(tqc.count_ops(), {})
+                with self.subTest(gates=gates, qargs=qargs):
+                    tqc = InverseCancellation()(qc)
+                    self.assertEqual(tqc.count_ops(), {})
 
         # sanity check: verify that CS-CSdg doesn't globally get cancelled
         with self.subTest(msg="sanity check"):


### PR DESCRIPTION
Symmetric gates should get cancelled irrespective of the qubit order. This did not happen in InverseCancellation, which didn't consistently cancel CS and CSdg gates in the default setup since their qubit argument were out of order. Coincidentally _it did_ cancel these gates in a specific order as a by product since the boolean logic was not grouped correctly, as reported in #15855. This commit fixes this behavior.

This commit does not more generally enable handling of symmetric, user-supplied gates.

Fixes #15855. Alternative fix to #16124.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
