### PR TITLE
Add safe shape checking to `synth_cz_depth_line_mr`

### DIFF
--- a/crates/synthesis/src/linear_phase/cz_depth_lnn.rs
+++ b/crates/synthesis/src/linear_phase/cz_depth_lnn.rs
@@ -115,6 +115,10 @@ fn _append_phase_gate(pat_val: usize, gates: &mut LnnGatesVec, qubit: usize) {
 
 /// Synthesis of a CZ circuit for linear nearest neighbor (LNN) connectivity,
 /// based on Maslov and Roetteler.
+///
+/// # Panics
+///
+/// If `matrix` is not square.
 pub(super) fn synth_cz_depth_line_mr_inner(matrix: ArrayView2<bool>) -> (usize, LnnGatesVec) {
     let num_qubits = matrix.raw_dim()[0];
     let pats = _create_patterns(num_qubits);

--- a/crates/synthesis/src/linear_phase/mod.rs
+++ b/crates/synthesis/src/linear_phase/mod.rs
@@ -12,7 +12,9 @@
 
 use numpy::PyReadonlyArray2;
 use pyo3::{
-    Bound, PyResult, pyfunction,
+    Bound, PyResult,
+    exceptions::PyValueError,
+    pyfunction,
     types::{PyModule, PyModuleMethods},
     wrap_pyfunction,
 };
@@ -36,6 +38,13 @@ pub(crate) mod cz_depth_lnn;
 #[pyo3(signature = (mat))]
 fn synth_cz_depth_line_mr(mat: PyReadonlyArray2<bool>) -> PyResult<PyCircuitData> {
     let view = mat.as_array();
+    let dim = view.raw_dim();
+    if dim[0] != dim[1] {
+        return Err(PyValueError::new_err(format!(
+            "matrix must be square, but has dimensions ({}, {})",
+            dim[0], dim[1]
+        )));
+    }
     let (num_qubits, lnn_gates) = cz_depth_lnn::synth_cz_depth_line_mr_inner(view);
     Ok(CircuitData::from_standard_gates(num_qubits as u32, lnn_gates, Param::Float(0.0))?.into())
 }

--- a/qiskit/synthesis/linear_phase/cz_depth_lnn.py
+++ b/qiskit/synthesis/linear_phase/cz_depth_lnn.py
@@ -39,8 +39,9 @@ def synth_cz_depth_line_mr(mat: np.ndarray) -> QuantumCircuit:
     (:class:`.SGate`, :class:`.SdgGate` or :class:`.ZGate`).
 
     Args:
-        mat: an upper-diagonal matrix representing the CZ circuit.
-            ``mat[i][j]=1 for i<j`` represents a ``cz(i,j)`` gate
+        mat: an square upper-diagonal matrix of `bool` representing the CZ circuit.
+            ``mat[i][j]=1 for i<j`` represents a ``cz(i,j)`` gate.  Only the upper triangle is read
+            from; the diagonal and lower triangle have no effect.
 
     Returns:
         A circuit implementation of the CZ circuit of depth :math:`2n+2` for LNN

--- a/qiskit/synthesis/linear_phase/cz_depth_lnn.py
+++ b/qiskit/synthesis/linear_phase/cz_depth_lnn.py
@@ -39,7 +39,7 @@ def synth_cz_depth_line_mr(mat: np.ndarray) -> QuantumCircuit:
     (:class:`.SGate`, :class:`.SdgGate` or :class:`.ZGate`).
 
     Args:
-        mat: an square upper-diagonal matrix of `bool` representing the CZ circuit.
+        mat: a square upper-diagonal matrix of `bool` representing the CZ circuit.
             ``mat[i][j]=1 for i<j`` represents a ``cz(i,j)`` gate.  Only the upper triangle is read
             from; the diagonal and lower triangle have no effect.
 

--- a/releasenotes/notes/cz_synth_lnn-shape-checks-af7146b406e9ed07.yaml
+++ b/releasenotes/notes/cz_synth_lnn-shape-checks-af7146b406e9ed07.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    :func:`.synth_cz_depth_line_mr` will now raise a Python-space :exc:`ValueError` on mis-shaped
+    inputs, instead of a Rust-space panic.  Fixed `#16152
+    <https://github.com/Qiskit/qiskit/issues/16152>`__.

--- a/test/python/synthesis/test_cz_synthesis.py
+++ b/test/python/synthesis/test_cz_synthesis.py
@@ -64,6 +64,25 @@ class TestCZSynth(QiskitTestCase):
             qctest = qctest.compose(perm)
             self.assertEqual(Clifford(qc), Clifford(qctest))
 
+    def test_cz_synth_lnn_accepts_trivial_inputs(self):
+        zero = np.zeros((0, 0), dtype=bool)
+        empty = QuantumCircuit(0)
+        empty.ensure_physical()
+        self.assertEqual(synth_cz_depth_line_mr(zero), empty)
+
+        one = np.zeros((1, 1), dtype=bool)
+        self.assertEqual(synth_cz_depth_line_mr(one), QuantumCircuit(1))
+        one = np.eye(1, dtype=bool)
+        self.assertEqual(synth_cz_depth_line_mr(one), QuantumCircuit(1))
+
+    def test_cz_synth_lnn_rejects_nonsquare(self):
+        wide = np.zeros((2, 3))
+        with self.assertRaisesRegex(ValueError, "matrix must be square"):
+            synth_cz_depth_line_mr(wide)
+        tall = np.zeros((5, 2))
+        with self.assertRaisesRegex(ValueError, "matrix must be square"):
+            synth_cz_depth_line_mr(tall)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This was previously unverified, which could lead to Rust panicking if the matrix was taller than it was wide.

Fix #16152
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
