### PR TITLE
Fix file leak from tests

### DIFF
--- a/test/python/circuit/library/test_phase_and_bitflip_oracles.py
+++ b/test/python/circuit/library/test_phase_and_bitflip_oracles.py
@@ -12,6 +12,7 @@
 
 """Test the phase and bit-flip oracle circuits."""
 
+import os
 import unittest
 import tempfile
 from ddt import ddt, data, unpack
@@ -122,6 +123,7 @@ class TestPhaseOracleAndGate(QiskitTestCase):
         -1 2 3 0
         """
         filename = tempfile.mkstemp(suffix=".dimacs")[1]
+        self.addCleanup(os.remove, filename)
         with open(filename, "w") as file:
             file.write(input_3sat_instance)
         for use_gate in [True, False]:
@@ -215,6 +217,7 @@ class TestBitFlipOracleGate(QiskitTestCase):
         -1 2 3 0
         """
         filename = tempfile.mkstemp(suffix=".dimacs")[1]
+        self.addCleanup(os.remove, filename)
         with open(filename, "w") as file:
             file.write(input_3sat_instance)
         oracle = BitFlipOracleGate.from_dimacs_file(filename)

--- a/test/python/circuit/library/test_phase_and_bitflip_oracles.py
+++ b/test/python/circuit/library/test_phase_and_bitflip_oracles.py
@@ -122,16 +122,15 @@ class TestPhaseOracleAndGate(QiskitTestCase):
         1 -2 -3 0
         -1 2 3 0
         """
-        filename = tempfile.mkstemp(suffix=".dimacs")[1]
-        self.addCleanup(os.remove, filename)
-        with open(filename, "w") as file:
+        with tempfile.NamedTemporaryFile("wt", suffix=".dimacs", delete=False) as file:
             file.write(input_3sat_instance)
+        self.addCleanup(os.remove, file.name)
         for use_gate in [True, False]:
             if use_gate:
-                oracle = PhaseOracleGate.from_dimacs_file(filename)
+                oracle = PhaseOracleGate.from_dimacs_file(file.name)
             else:
                 with self.assertWarns(DeprecationWarning):
-                    oracle = PhaseOracle.from_dimacs_file(filename)
+                    oracle = PhaseOracle.from_dimacs_file(file.name)
             self.assertEqual(oracle.num_qubits, 3)
 
 
@@ -216,11 +215,10 @@ class TestBitFlipOracleGate(QiskitTestCase):
         1 -2 -3 0
         -1 2 3 0
         """
-        filename = tempfile.mkstemp(suffix=".dimacs")[1]
-        self.addCleanup(os.remove, filename)
-        with open(filename, "w") as file:
+        with tempfile.NamedTemporaryFile("wt", suffix=".dimacs", delete=False) as file:
             file.write(input_3sat_instance)
-        oracle = BitFlipOracleGate.from_dimacs_file(filename)
+        self.addCleanup(os.remove, file.name)
+        oracle = BitFlipOracleGate.from_dimacs_file(file.name)
         self.assertEqual(oracle.num_qubits, 4)
 
 


### PR DESCRIPTION
In the the phase oracle tests two tests were creating temporary files in the unit tests to write out a dimacs file to use as an input to the phase oracle's .from_dimacs() file method. This temporary file was created with mkstemp, but then nothing would cleanup that created file. This meant that every time you ran the unit tests a new pair of temporary files were created and remained on the filesystem. This fixes this oversight and adds an .addCleanup() call to remove the file after the test methods exit.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
