### PR TITLE
Fix invalid simplification of XXPlusYY gates in CommutativeOptimization

### DIFF
--- a/crates/transpiler/src/passes/commutative_optimization.rs
+++ b/crates/transpiler/src/passes/commutative_optimization.rs
@@ -142,6 +142,8 @@ fn is_special_symmetric(inst: &PackedInstruction, tol: f64) -> bool {
 /// * `dag` - The output [DAGCircuit]. We use its `qargs_interner` to store sorted
 ///   qubits for symmetric gates.
 /// * `inst` - The instruction to canonicalize.
+/// * `tol` - The tolerance used for fidelity computations (for instance, checking
+///   whether a gate is symmetric within the specified tolerance).
 ///
 /// # Returns:
 ///

--- a/crates/transpiler/src/passes/commutative_optimization.rs
+++ b/crates/transpiler/src/passes/commutative_optimization.rs
@@ -69,7 +69,7 @@ fn compare_params(params1: &[Param], params2: &[Param]) -> PyResult<bool> {
 
 /// List of symmetric gates, that is the gate remains the same under all
 /// permutations of its arguments.
-static SYMMETRIC_GATES: [StandardGate; 13] = [
+static SYMMETRIC_GATES: [StandardGate; 12] = [
     StandardGate::CZ,
     StandardGate::Swap,
     StandardGate::ISwap,
@@ -81,7 +81,6 @@ static SYMMETRIC_GATES: [StandardGate; 13] = [
     StandardGate::RYY,
     StandardGate::RZZ,
     StandardGate::XXMinusYY,
-    StandardGate::XXPlusYY,
     StandardGate::CCZ,
 ];
 

--- a/crates/transpiler/src/passes/commutative_optimization.rs
+++ b/crates/transpiler/src/passes/commutative_optimization.rs
@@ -102,6 +102,35 @@ static MERGEABLE_ROTATION_GATES: [StandardGate; 12] = [
     StandardGate::CU1,
 ];
 
+/// Check if `inst` is symmetric for some special values of its parameters,
+/// taking tolerance into account.
+fn is_special_symmetric(inst: &PackedInstruction, tol: f64) -> bool {
+    // For now, this only handles the standard XXPlusYY gate.
+    if let OperationRef::StandardGate(StandardGate::XXPlusYY) = inst.op.view() {
+        // From the matrix representation, applying XXPlusYY(theta, beta) on reversed qubits [q2, q1]
+        // is the same as applying XXPlusYY(theta, -beta) on [q1, q2].
+        // The direct computation for the average gate fidelity between XXPlusYY(theta, beta) and
+        // XXPlusYY(theta, -beta) gives the following: 1/5 + 4/5 [1-sin^(theta/2) sin^2(beta)]^2.
+        match inst.params_view() {
+            [Param::Float(theta), Param::Float(beta)] => {
+                // If both theta and beta are floating-point, we can evaluate the above condition
+                // directly.
+                let x = (1.0 - (theta / 2.0).sin().powf(2.0) * beta.sin().powf(2.0)).powf(2.0);
+                return x > 1.0 - 5. / 4. * tol;
+            }
+            [Param::ParameterExpression(_theta), Param::Float(beta)] => {
+                // If theta is parametric, we take the estimate that works for all theta.
+                let x = (1.0 - beta.sin().powf(2.0)).powf(2.0);
+                return x > 1.0 - 5. / 4. * tol;
+            }
+            _ => {
+                return false;
+            }
+        }
+    }
+    false
+}
+
 /// Computes the canonical representative of a packed instruction, and in particular:
 /// * replaces all types of Z-rotations by RZ-gates,
 /// * replaces all types of X-rotations by RX-gates,
@@ -121,6 +150,7 @@ static MERGEABLE_ROTATION_GATES: [StandardGate; 12] = [
 fn canonicalize(
     dag: &mut DAGCircuit,
     inst: &PackedInstruction,
+    tol: f64,
 ) -> Option<(PackedInstruction, Param)> {
     // ToDo: possibly consider other rotations as well (e.g. CS -> CRZ).
     let rotation = match inst.op.view() {

--- a/crates/transpiler/src/passes/commutative_optimization.rs
+++ b/crates/transpiler/src/passes/commutative_optimization.rs
@@ -208,7 +208,7 @@ fn canonicalize(
     }
 
     if let OperationRef::StandardGate(standard_gate) = inst.op.view() {
-        if SYMMETRIC_GATES.contains(&standard_gate) {
+        if SYMMETRIC_GATES.contains(&standard_gate) || is_special_symmetric(inst, tol) {
             let qargs = dag.get_qargs(inst.qubits);
             if !qargs.is_sorted() {
                 let mut sorted_qargs = qargs.to_vec();
@@ -633,7 +633,7 @@ pub fn run_commutative_optimization(
             continue;
         }
 
-        if let Some((new_instruction, phase_update)) = canonicalize(&mut new_dag, instr1) {
+        if let Some((new_instruction, phase_update)) = canonicalize(&mut new_dag, instr1, tol) {
             node_actions[idx1] = NodeAction::Canonical(new_instruction, phase_update);
         }
 

--- a/releasenotes/notes/fix-xxplusyy-in-comm-opt-7a3bc47797ac2990.yaml
+++ b/releasenotes/notes/fix-xxplusyy-in-comm-opt-7a3bc47797ac2990.yaml
@@ -3,7 +3,10 @@ fixes:
   - |
     Fixed a bug in the :class:`.CommutativeOptimization` transpiler pass
     where pairs of :class:`.XXPlusYYGate` gates acting on the same qubits
-    with reversed order were incorrectly simplified.
+    but in reversed order were incorrectly simplified. However, the
+    simplification is performed in special cases where the gate and its
+    reversed versions are inverse within the specified tolerance, for
+    instance when the argument `beta` is a multiple of `pi`.
 
     See `#16161 <https://github.com/Qiskit/qiskit/issues/16161>`__.
 

--- a/releasenotes/notes/fix-xxplusyy-in-comm-opt-7a3bc47797ac2990.yaml
+++ b/releasenotes/notes/fix-xxplusyy-in-comm-opt-7a3bc47797ac2990.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed a bug in the :class:`.CommutativeOptimization` transpiler pass
+    where pairs of :class:`.XXPlusYYGate` gates acting on the same qubits
+    with reversed order were incorrectly simplified.
+
+    See `#16161 <https://github.com/Qiskit/qiskit/issues/16161>`__.
+
+

--- a/test/python/transpiler/test_commutative_optimization.py
+++ b/test/python/transpiler/test_commutative_optimization.py
@@ -167,8 +167,7 @@ class TestCommutativeOptimization(QiskitTestCase):
         RXXGate(0.4),
         RYYGate(0.4),
         RZZGate(0.4),
-        XXMinusYYGate(0.4),
-        XXPlusYYGate(0.4),
+        XXMinusYYGate(0.4, 0.2),
     )
     def test_symmetric_gates_cancel(self, symmetric_gate):
         """Test that various symmetric gates cancel."""
@@ -182,6 +181,16 @@ class TestCommutativeOptimization(QiskitTestCase):
 
         self.assertEqual(Operator(expected), Operator(qc))
         self.assertEqual(qct, expected)
+
+    def test_nonsymmetric_gates_do_not_canel(self):
+        """Test that non-symmetric gates do not cancel."""
+        qc = QuantumCircuit(2)
+        qc.append(XXPlusYYGate(0.4, 0.2), [0, 1])
+        qc.append(XXPlusYYGate(0.4, 0.2).inverse(), [1, 0])  # note reversed order of qubits
+
+        qct = CommutativeOptimization()(qc)
+
+        self.assertEqual(qct, qc)
 
     def test_symmetric_iswap_gates_cancel(self):
         """Test that iSwap gates cancel."""

--- a/test/python/transpiler/test_commutative_optimization.py
+++ b/test/python/transpiler/test_commutative_optimization.py
@@ -167,6 +167,8 @@ class TestCommutativeOptimization(QiskitTestCase):
         RXXGate(0.4),
         RYYGate(0.4),
         RZZGate(0.4),
+        XXPlusYYGate(0.4, 0.0),
+        XXPlusYYGate(0.4, np.pi),
         XXMinusYYGate(0.4, 0.2),
     )
     def test_symmetric_gates_cancel(self, symmetric_gate):
@@ -191,6 +193,16 @@ class TestCommutativeOptimization(QiskitTestCase):
         qct = CommutativeOptimization()(qc)
 
         self.assertEqual(qct, qc)
+
+    def test_symmetric_xxplusyy_gates_cancel(self):
+        """Test for cancellation XXPlusYY gates with parametric values of theta."""
+        symmetric_gate = XXPlusYYGate(Parameter("t"), np.pi)
+        qc = QuantumCircuit(2)
+        qc.append(symmetric_gate, [0, 1])
+        qc.append(symmetric_gate.inverse(), [1, 0])  # note reversed order of qubits
+        qct = CommutativeOptimization()(qc)
+        expected = QuantumCircuit(2)
+        self.assertEqual(qct, expected)
 
     def test_symmetric_iswap_gates_cancel(self):
         """Test that iSwap gates cancel."""


### PR DESCRIPTION

The `CommutativeOptimization` transpiler pass uses the following simplification for symmetric gates: a symmetric gate followed by its inverse on the same qubits but in opposite order cancel out. However, a general two-parametric `XXPlusYYGate` is non-symmetric, and hence the above simplification should not apply to it. This PR simply removes `XXPlusYYGate` from the predefined set of symmetric gates. Note that the general two-parametric `XXMinusYYGate` is symmetric, and so is still kept as a symmetric gate.

However, this leads to the following nuance. A specialized `XXPlusYY(theta, beta=0)` is symmetric, so before this PR `CommutativeOptimization` would correctly cancel pairs such as `XXPlusYY(theta, 0)` on `[0, 1]` and `XXPlusYY(-theta, 0)` on `[1, 0]`. If this behavior needs to be preserved for backwards compatibility, a slightly more involved fix would be required.

Fixed #16161.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
