### PR TITLE
Fix File Open Leaks, Improve tempfile handling in tests

### DIFF
--- a/test/python/circuit/library/test_phase_and_bitflip_oracles.py
+++ b/test/python/circuit/library/test_phase_and_bitflip_oracles.py
@@ -14,6 +14,7 @@
 
 import unittest
 import tempfile
+import os
 from ddt import ddt, data, unpack
 from numpy import sqrt, isclose
 
@@ -121,7 +122,9 @@ class TestPhaseOracleAndGate(QiskitTestCase):
         1 -2 -3 0
         -1 2 3 0
         """
-        filename = tempfile.mkstemp(suffix=".dimacs")[1]
+        fd,filename = tempfile.mkstemp(suffix=".dimacs")
+        os.close(fd)
+        self.addCleanup(os.remove, filename)
         with open(filename, "w") as file:
             file.write(input_3sat_instance)
         for use_gate in [True, False]:


### PR DESCRIPTION
Refactor tempfile usage to ensure cleanup of temporary files.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [ x ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to generate or modify code:
- [ ] I used the following tool to help write this PR description:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->


when tempfile.mkstemp is called it gives the filename but also opens the file in low level (and gives the descriptor  fd) so ignoring that leaves that file open so it needs manual closing