### PR TITLE
Add parallel threshold to commutation analysis pass

### DIFF
--- a/crates/transpiler/src/passes/commutation_analysis.rs
+++ b/crates/transpiler/src/passes/commutation_analysis.rs
@@ -31,6 +31,10 @@ type NodeIndices = Vec<IndexMap<NodeIndex, usize, ::foldhash::fast::RandomState>
 // the maximum number of qubits we check commutativity for
 const MAX_NUM_QUBITS: u32 = 3;
 
+// This value was found experimentally by testing the scaling. For more details see:
+// https://github.com/Qiskit/qiskit/pull/16171#issuecomment-4432863092
+const PARALLEL_THRESHOLD: usize = 3000;
+
 /// Compute the commutation sets for a given DAG.
 ///
 /// We return two HashMaps:
@@ -137,7 +141,7 @@ pub fn analyze_commutations(
             Ok(())
         };
 
-    if qiskit_util::getenv_use_multiple_threads() {
+    if qiskit_util::getenv_use_multiple_threads() && dag.num_ops() >= PARALLEL_THRESHOLD {
         commutation_set
             .par_iter_mut()
             .zip(node_indices.par_iter_mut())


### PR DESCRIPTION
In the recently merged #16014 we made the implementation of the commutation analysis done in the CommutationAnalysis and the CommutativeCancellation pass multithreaded. In general this greatly improved the runtime performance and scaling of the pass as circuit size grows. But for small circuits the overhead of working with the parallelism is more than the runtime of the pass otherwise. In #16014 we always ran the analysis in parallel unless we were in a Python multiprocessing context which mean we introduced this regression for the small circuits. This addresses this limitation by adding a parallel threshold based on the number of gates in the circuit. This value was found experimentally via testing.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
