### PR TITLE
Add details on the C API to the project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 This library is the core component of Qiskit, which contains the building blocks for creating and working with quantum circuits, quantum operators, and primitive functions (Sampler and Estimator).
 It also contains a transpiler that supports optimizing quantum circuits, and a quantum information toolbox for creating advanced operators.
 
-Qiskit provides two public APIs: a Python API and a C API. The Python API is the primary interface and prior to Qiskit 2.0.0 was the only public API available
+Qiskit provides two public APIs: a Python API and a C API. The Python API is the primary interface and prior to Qiskit 2.0 was the only public API available
 for Qiskit. The C API is designed to provide direct access to Qiskit's internal data model (which is written in Rust). The C API can be consumed as either a
 shared library (`libqiskit.so`) for standalone use, or from its embedding in the `qiskit` Python package [for writing Python extension modules](https://quantum.cloud.ibm.com/docs/guides/c-extension-for-python).
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ use the built library.
 
 ## Create your first quantum program in Qiskit
 
-Now that Qiskit is installed, it's time to begin working with Qiskit. The essential parts of a quantum program are:
+Now that Qiskit is installed, it's time to begin working with Qiskit. We will use the Python interface to demonstrate creating a quantum program.
+The essential parts of a quantum program are:
 1. Define and build a quantum circuit that represents the quantum state
 2. Define the classical output by measurements or a set of observable operators
 3. Depending on the output, use the Sampler primitive to sample outcomes or the Estimator primitive to estimate expectation values.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ It also contains a transpiler that supports optimizing quantum circuits, and a q
 
 Qiskit provides two public APIs: a Python API and a C API. The Python API is the primary interface and prior to Qiskit 2.0.0 was the only public API available
 for Qiskit. The C API is designed to provide direct access to Qiskit's internal data model (which is written in Rust). The C API can be consumed as either a
-standalone shared library (`libqiskit.so`) or embedded as part of the Python package (for consumption in Python extensions, see the
-[documentation](https://quantum.cloud.ibm.com/docs/guides/c-extension-for-python) on this for more details on using Qiskit from a compiled extension).
+shared library (`libqiskit.so`) for standalone use, or from its embedding in the `qiskit` Python package [for writing Python extension modules](https://quantum.cloud.ibm.com/docs/guides/c-extension-for-python).
 
 For more details on how to use Qiskit, refer to the documentation located here:
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ make c
 Which will compile the C library and put the `dist/c` directory in the root of the repository which will contain the shared library and C headers for
 library.
 
-You can refer to the [documentation](https://quantum.cloud.ibm.com/docs/en/guides/install-c-api) on installing the C API for more details and how to
+You can refer to the [documentation](https://quantum.cloud.ibm.com/docs/guides/install-c-api) on installing the C API for more details and how to
 use the built library.
 
 ## Create your first quantum program in Qiskit

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@
 This library is the core component of Qiskit, which contains the building blocks for creating and working with quantum circuits, quantum operators, and primitive functions (Sampler and Estimator).
 It also contains a transpiler that supports optimizing quantum circuits, and a quantum information toolbox for creating advanced operators.
 
+Qiskit provides two public APIs: a Python API and a C API. The Python API is the primary interface and prior to Qiskit 2.0.0 was the only public API available
+for Qiskit. The C API is designed to provide direct access to Qiskit's internal data model (which is written in Rust). The C API can be consumed as either a
+standalone shared library (`libqiskit.so`) or embedded as part of the Python package (for consumption in Python extensions, see the
+[documentation](https://quantum.cloud.ibm.com/docs/en/guides/c-extension-for-python) on this for more details on using Qiskit from a compiled extension).
+
 For more details on how to use Qiskit, refer to the documentation located here:
 
 <https://quantum.cloud.ibm.com/docs/>
@@ -22,7 +27,9 @@ For more details on how to use Qiskit, refer to the documentation located here:
 
 ## Installation
 
-We encourage installing Qiskit via ``pip``:
+### Python
+
+For running Qiskit on Python we recommend installing Qiskit via ``pip``:
 
 ```bash
 pip install qiskit
@@ -31,6 +38,22 @@ pip install qiskit
 Pip will handle all dependencies automatically and you will always install the latest (and well-tested) version.
 
 To install from source, follow the instructions in the [documentation](https://quantum.cloud.ibm.com/docs/guides/install-qiskit-source).
+
+### Standalone C library
+
+To install Qiskit as a standalone C library the only option is currently to build Qiskit from source. This requires having the
+[Rust](https://rust-lang.org/) compiler installed. To simplify building having [GNU Make](https://www.gnu.org/software/make/) installed
+is recommended. With these requirements installed you can run:
+
+```bash
+make c
+```
+
+Which will compile the C library and put the `dist/c` directory in the root of the repository which will contain the shared library and C headers for
+library.
+
+You can refer to the [documentation](https://quantum.cloud.ibm.com/docs/en/guides/install-c-api) on installing the C API for more details and how to
+use the built library.
 
 ## Create your first quantum program in Qiskit
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It also contains a transpiler that supports optimizing quantum circuits, and a q
 Qiskit provides two public APIs: a Python API and a C API. The Python API is the primary interface and prior to Qiskit 2.0.0 was the only public API available
 for Qiskit. The C API is designed to provide direct access to Qiskit's internal data model (which is written in Rust). The C API can be consumed as either a
 standalone shared library (`libqiskit.so`) or embedded as part of the Python package (for consumption in Python extensions, see the
-[documentation](https://quantum.cloud.ibm.com/docs/en/guides/c-extension-for-python) on this for more details on using Qiskit from a compiled extension).
+[documentation](https://quantum.cloud.ibm.com/docs/guides/c-extension-for-python) on this for more details on using Qiskit from a compiled extension).
 
 For more details on how to use Qiskit, refer to the documentation located here:
 


### PR DESCRIPTION
Arguably the largest development in Qiskit since the 2.0.0 release was the introduction of the C API. This changed how Qiskit is consumable from solely via Python to any environment that can use a C shared library. This expanded the scope and potential user base of Qiskit quite substantially. However, a clear oversight was that the C API is not at all mentioned in the README. This corrects the oversight and adds an explanation that the two public APIs are for Python and C and also installation instructions for the standalone C API.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
