### PR TITLE
Add `LinearFunction.inverse` method

### DIFF
--- a/qiskit/circuit/library/generalized_gates/linear_function.py
+++ b/qiskit/circuit/library/generalized_gates/linear_function.py
@@ -19,7 +19,6 @@ from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit.library.generalized_gates.permutation import PermutationGate
 from qiskit.utils.deprecation import deprecate_func
 
-
 from qiskit.quantum_info import Clifford
 
 
@@ -149,6 +148,19 @@ class LinearFunction(Gate):
         super().__init__(
             name="linear_function", num_qubits=len(linear), params=[linear, original_circuit]
         )
+
+    def inverse(self, annotated: bool = False) -> LinearFunction:
+        """Returns the inverse of this linear function.
+
+        Args:
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.LinearFunction`.
+        """
+        from qiskit.synthesis.linear import calc_inverse_matrix
+
+        return LinearFunction(linear=calc_inverse_matrix(self.linear))
 
     @staticmethod
     def _circuit_to_mat(qc: QuantumCircuit):

--- a/releasenotes/notes/add-linear-function-inverse-0a0db84d48ac1195.yaml
+++ b/releasenotes/notes/add-linear-function-inverse-0a0db84d48ac1195.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Previously, calling ``inverse`` on a :class:`.LinearFunction` raised an error;
+    this is no longer the case.
+    See `#16184 <https://github.com/Qiskit/qiskit/issues/16184>`__.
+
+features_circuits:
+  - |
+    Added a :meth:`.LinearFunction.inverse` method that returns a 
+    :class:`.LinearFunction` representing the inverse transformation.

--- a/test/python/circuit/library/test_linear_function.py
+++ b/test/python/circuit/library/test_linear_function.py
@@ -515,6 +515,16 @@ class TestLinearFunctions(QiskitTestCase):
             linear_function = LinearFunction(linear_circuit)
             self.assertTrue(Operator(linear_function.repeat(2)), operator @ operator)
 
+    def test_inverse(self):
+        """Test correctness of the ``inverse`` method."""
+        mat = [[1, 0, 0], [1, 1, 0], [1, 1, 1]]
+        inverse_mat = [[1, 0, 0], [1, 1, 0], [0, 1, 1]]
+
+        linear_function = LinearFunction(mat)
+        inverse_linear_function = linear_function.inverse()
+        expected_inverse_linear_function = LinearFunction(inverse_mat)
+        self.assertTrue(np.array_equal(inverse_linear_function, expected_inverse_linear_function))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds `LinearFunction.inverse` method that returns a linear function representing the inverse transformation (with the inverse matrix).

Fixes #16184.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
