### PR TITLE
Remove unused dependencies from qasm2 and qpy crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2409,7 +2409,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "num-bigint",
  "pyo3",
- "qiskit-circuit",
 ]
 
 [[package]]
@@ -2441,7 +2440,6 @@ dependencies = [
  "num-complex",
  "num-traits",
  "numpy",
- "oq3_semantics",
  "pyo3",
  "qiskit-circuit",
  "qiskit-quantum-info",

--- a/crates/qasm2/Cargo.toml
+++ b/crates/qasm2/Cargo.toml
@@ -16,4 +16,3 @@ workspace = true
 num-bigint.workspace = true
 hashbrown.workspace = true
 pyo3.workspace = true
-qiskit-circuit.workspace = true

--- a/crates/qasm2/Cargo.toml
+++ b/crates/qasm2/Cargo.toml
@@ -15,4 +15,7 @@ workspace = true
 [dependencies]
 num-bigint.workspace = true
 hashbrown.workspace = true
-pyo3.workspace = true
+
+[dependencies.pyo3]
+workspace = true
+features = ["py-clone", "num-bigint"]

--- a/crates/qpy/Cargo.toml
+++ b/crates/qpy/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 [dependencies]
 indexmap.workspace = true
 hashbrown.workspace = true
-oq3_semantics = "0.7.0"
 foldhash.workspace = true
 qiskit-circuit.workspace = true
 qiskit-quantum-info.workspace = true


### PR DESCRIPTION
There were two unused dependencies in rust crates. The qiskit-qasm2 crate had an unused dependency on the qiskit-circuit crate. In an ideal world the qasm2 parser would go directly from the qasm2 ast (or equivalent) to the internal circuit api to build a circuit. But right now it doesn't do that and exposes a bytecode to python which then constructs the circuit. The qiskit-qpy crate was depending on the oq3_semantics crate for some reason. Since this is a parser crate for qasm3 which is independent from qpy I'm not sure why this was listed. But it's not used anywhere in the qpy crate so it's safe to remove.

This removes both of these unused dependencies, unfortunately it doesn't remove anything from the qiskit-pyext build as the removed dependencies are still part of the overall build. But it at least cleans up the tree a bit to better reflect. For the case of oq3_semantics it also removes a place with a hardcoded version as it wasn't using a workspace specified version which could have caused multiple versions if we bumped the requirement in the future (assuming a future oq3_semantics release).

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
