### PR TITLE
Fix Commuting2qGateRouter global phase handling

### DIFF
--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_gate_router.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_gate_router.py
@@ -174,6 +174,7 @@ class Commuting2qGateRouter(TransformationPass):
 
         # Used to keep track of nodes that do not decompose using swap strategies.
         accumulator = new_dag.copy_empty_like()
+        accumulator.global_phase = 0
 
         for node in dag.topological_op_nodes():
             if isinstance(node.op, Commuting2qBlock):
@@ -220,7 +221,9 @@ class Commuting2qGateRouter(TransformationPass):
         new_dag.compose(accumulator, qubits=order_bits)
 
         # Re-initialize the node accumulator
-        return new_dag.copy_empty_like()
+        accumulator = new_dag.copy_empty_like()
+        accumulator.global_phase = 0
+        return accumulator
 
     def _position_in_cmap(self, dag: DAGCircuit, j: int, k: int, layout: Layout) -> tuple[int, ...]:
         """A helper function to track the movement of virtual qubits through the swaps.

--- a/releasenotes/notes/fix-commuting-router-global-phase-16205.yaml
+++ b/releasenotes/notes/fix-commuting-router-global-phase-16205.yaml
@@ -1,0 +1,6 @@
+fixes:
+  - |
+    Fixed :class:`.Commuting2qGateRouter` so it preserves the input circuit's
+    global phase instead of adding it again when composing accumulated
+    non-routed operations.
+    Fixed `#16205 <https://github.com/Qiskit/qiskit/issues/16205>`__.

--- a/test/python/transpiler/test_swap_strategy_router.py
+++ b/test/python/transpiler/test_swap_strategy_router.py
@@ -21,7 +21,7 @@ from qiskit.circuit.library import PauliEvolutionGate, CXGate
 from qiskit.circuit.library.n_local import QAOAAnsatz
 from qiskit.converters import circuit_to_dag
 from qiskit.exceptions import QiskitError
-from qiskit.quantum_info import Pauli, SparsePauliOp
+from qiskit.quantum_info import Operator, Pauli, SparsePauliOp
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit.transpiler.passes import FullAncillaAllocation
 from qiskit.transpiler.passes import EnlargeWithAncilla
@@ -91,6 +91,18 @@ class TestPauliEvolutionSwapStrategies(QiskitTestCase):
         expected.append(PauliEvolutionGate(Pauli("ZZ"), 3), (0, 1))
 
         self.assertEqual(swapped, expected)
+
+    def test_global_phase_preserved_without_commuting_blocks(self):
+        """Test routing a circuit with no commuting blocks preserves its global phase."""
+        circ = QuantumCircuit(4, global_phase=0.3)
+        circ.h(0)
+        circ.cx(0, 1)
+
+        swap_strat = SwapStrategy.from_line([0, 1, 2, 3])
+        routed = PassManager([Commuting2qGateRouter(swap_strat)]).run(circ)
+
+        self.assertEqual(routed.global_phase, circ.global_phase)
+        self.assertEqual(Operator(routed), Operator(circ))
 
     def test_basic_xx(self):
         """Test to route an XX-based evolution op.


### PR DESCRIPTION
## Summary

Fixes #16205.

`Commuting2qGateRouter` now preserves the input circuit's global phase when composing accumulated non-routed operations.

## Details

The output DAG still starts from `dag.copy_empty_like()`. The temporary accumulator DAGs now clear `global_phase` before they are composed back into the output.

## Tests

See CI.

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description: ChatGPT (GPT-5) and OpenAI Codex (GPT-5)
- [x] I used the following tool to generate or modify code: ChatGPT (GPT-5) and OpenAI Codex (GPT-5)