### PR TITLE
Make `uuid` public on `ParameterVector`

### DIFF
--- a/qiskit/circuit/parametervector.py
+++ b/qiskit/circuit/parametervector.py
@@ -29,13 +29,31 @@ class ParameterVector:
     index.
 
     This class fulfills the :class:`collections.abc.Sequence` interface.
+
+    .. note::
+        This class does not implement regular equality, but has historically been allowed to be used
+        as a dictionary key for :meth:`.QuantumCircuit.assign_parameters`.  The class is mutable via
+        :meth:`resize`, so it generally cannot implement regular equality; for two
+        :class:`.ParameterVector` objects to compare equal, they must be literally the same Python
+        instance.
+
+        This restriction does not apply to the individual :class:`.ParameterVectorElement`
+        instances; these must only match on name, index and UUID.
     """
 
     __slots__ = ("_name", "_params", "_root_uuid")
 
-    def __init__(self, name, length=0):
+    def __init__(self, name: str, length: int = 0, uuid: UUID | None = None):
+        """
+        Args:
+            name: the base name of the vector
+            length: the number of elements in the vector
+            uuid: (optional) the root UUID to use for the vector.  This can be used to create a new
+                vector whose elements will compare equal to a previous vector (such as in a
+                deserialization process).
+        """
         self._name = name
-        self._root_uuid = uuid4()
+        self._root_uuid = uuid or uuid4()
         root_uuid_int = self._root_uuid.int
         self._params = [
             ParameterVectorElement(self, i, UUID(int=root_uuid_int + i)) for i in range(length)
@@ -52,6 +70,11 @@ class ParameterVector:
 
         It is not safe to mutate this list."""
         return self._params
+
+    @property
+    def uuid(self) -> UUID:
+        """Get the root UUID of this vector."""
+        return self._root_uuid
 
     def index(self, value):
         """Find the index of a :class:`ParameterVectorElement` within the list.

--- a/releasenotes/notes/pv-uuid-b87799cfced05282.yaml
+++ b/releasenotes/notes/pv-uuid-b87799cfced05282.yaml
@@ -1,0 +1,5 @@
+---
+features_circuits:
+  - :class:`.ParameterVector` now accepts an optional ``uuid`` constructor argument, and exposes
+    its base :class:`~uuid.UUID` through its :attr:`~.ParameterVector.uuid` attribute.  This can
+    be used to reconstruct vectors whose elements compare equal.

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -949,6 +949,17 @@ class TestParameters(QiskitTestCase):
         self.assertEqual(hash(x1), hash(x1_expr))
         self.assertEqual(hash(x2), hash(x2_expr))
 
+    def test_parameter_vector_elements_can_be_recreated(self):
+        left = ParameterVector("a", 5)
+        right = ParameterVector("a", 5, uuid=left.uuid)
+        # We can't compare the two vectors directly because `ParameterVector` only implements
+        # identity-based equality, since it's internally mutable.
+        self.assertEqual(list(left), list(right))
+
+        # UUIDs don't match.
+        other = ParameterVector("a", 5)
+        self.assertNotEqual(list(left), list(other))
+
     def test_binding_parameterized_circuits_built_in_multiproc(self):
         """Verify subcircuits built in a subprocess can still be bound."""
         # ref: https://github.com/Qiskit/qiskit-terra/issues/2429


### PR DESCRIPTION
Currently, there's no way to control the UUID of `ParameterVector`, which is at odds with `Parameter` itself.  QPY has to jump through several non-public hoops to influence the UUIDs of created elements, though this is an interface we natively support elsewhere.

This commit is just the new feature.  A follow up with switch QPY over to using it; that is a more involved change that needs separate review because it may lead to a relaxing of the "vector was not constructed equally" warning at the same time.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
