### PR TITLE
Prefer node_or_instr.name to node_or_instr.operation.name

### DIFF
--- a/qiskit/circuit/library/generalized_gates/linear_function.py
+++ b/qiskit/circuit/library/generalized_gates/linear_function.py
@@ -157,16 +157,16 @@ class LinearFunction(Gate):
         mat = np.eye(nq, nq, dtype=bool)
 
         for instruction in qc.data:
-            if instruction.operation.name in ("barrier", "delay"):
+            if instruction.name in ("barrier", "delay"):
                 # can be ignored
                 continue
-            if instruction.operation.name == "cx":
+            if instruction.name == "cx":
                 # implemented directly
                 cb = qc.find_bit(instruction.qubits[0]).index
                 tb = qc.find_bit(instruction.qubits[1]).index
                 mat[tb, :] = (mat[tb, :]) ^ (mat[cb, :])
                 continue
-            if instruction.operation.name == "swap":
+            if instruction.name == "swap":
                 # implemented directly
                 cb = qc.find_bit(instruction.qubits[0]).index
                 tb = qc.find_bit(instruction.qubits[1]).index

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -4257,7 +4257,7 @@ class QuantumCircuit:
         Returns:
             list(tuple): list of (instruction, qargs, cargs).
         """
-        return [match for match in self._data if match.operation.name == name]
+        return [match for match in self._data if match.name == name]
 
     def num_connected_components(self, unitary_only: bool = False) -> int:
         """How many non-entangled subcircuits can the circuit be factored to.

--- a/qiskit/dagcircuit/dagdependency_v2.py
+++ b/qiskit/dagcircuit/dagdependency_v2.py
@@ -339,7 +339,7 @@ class _DAGDependencyV2:
         """Get the set of "op" nodes with the given name."""
         named_nodes = []
         for node in self._multi_graph.nodes():
-            if node.op.name in names:
+            if node.name in names:
                 named_nodes.append(node)
         return named_nodes
 

--- a/qiskit/primitives/statevector_sampler.py
+++ b/qiskit/primitives/statevector_sampler.py
@@ -266,7 +266,7 @@ def _final_measurement_mapping(circuit: QuantumCircuit) -> dict[tuple[ClassicalR
     # Find final measurements starting in back
     mapping = {}
     for item in circuit[::-1]:
-        if item.operation.name == "measure":
+        if item.name == "measure":
             loc = circuit.find_bit(item.clbits[0])
             cbit = loc.index
             qbit = circuit.find_bit(item.qubits[0]).index
@@ -274,7 +274,7 @@ def _final_measurement_mapping(circuit: QuantumCircuit) -> dict[tuple[ClassicalR
                 for creg in loc.registers:
                     mapping[creg] = qbit
                 active_cbits.remove(cbit)
-        elif item.operation.name not in ["barrier", "delay"]:
+        elif item.name not in ["barrier", "delay"]:
             for qq in item.qubits:
                 _temp_qubit = circuit.find_bit(qq).index
                 if _temp_qubit in active_qubits:

--- a/qiskit/providers/basic_provider/basic_simulator.py
+++ b/qiskit/providers/basic_provider/basic_simulator.py
@@ -546,7 +546,7 @@ class BasicSimulator(BackendV2):
         # Find measurement operations
         measure_ops = []
         for operation in circuit.data:
-            if operation.operation.name == "measure":
+            if operation.name == "measure":
                 qubit = circuit.find_bit(operation.qubits[0]).index
                 clbit = circuit.find_bit(operation.clbits[0]).index
                 measure_ops.append((qubit, clbit))

--- a/qiskit/synthesis/linear/linear_circuits_utils.py
+++ b/qiskit/synthesis/linear/linear_circuits_utils.py
@@ -36,7 +36,7 @@ def transpose_cx_circ(qc: QuantumCircuit):
     """
     transposed_circ = QuantumCircuit(qc.qubits, qc.clbits, name=qc.name + "_transpose")
     for instruction in reversed(qc.data):
-        if instruction.operation.name != "cx":
+        if instruction.name != "cx":
             raise CircuitError("The circuit contains non-CX gates.")
         transposed_circ._append(instruction.replace(qubits=reversed(instruction.qubits)))
     return transposed_circ

--- a/qiskit/transpiler/passes/basis/translate_parameterized.py
+++ b/qiskit/transpiler/passes/basis/translate_parameterized.py
@@ -161,9 +161,9 @@ def _is_supported(node: DAGOpNode, supported_gates: list[str], target: Target | 
     If the target is provided, check using the target, otherwise the supported_gates are used.
     """
     if target is not None:
-        return target.instruction_supported(node.op.name)
+        return target.instruction_supported(node.name)
 
-    return node.op.name in supported_gates
+    return node.name in supported_gates
 
 
 def _instruction_to_dag(op: Instruction) -> DAGCircuit:

--- a/qiskit/transpiler/passes/optimization/collect_linear_functions.py
+++ b/qiskit/transpiler/passes/optimization/collect_linear_functions.py
@@ -76,7 +76,7 @@ class CollectLinearFunctions(CollectAndCollapse):
 
 def _is_linear_gate(node):
     """Specifies whether a node holds a linear gate."""
-    return node.op.name in ("cx", "swap") and getattr(node, "condition", None) is None
+    return node.name in ("cx", "swap") and getattr(node, "condition", None) is None
 
 
 def _collapse_to_linear_function(circuit):

--- a/qiskit/transpiler/passes/scheduling/padding/context_aware_dynamical_decoupling.py
+++ b/qiskit/transpiler/passes/scheduling/padding/context_aware_dynamical_decoupling.py
@@ -261,7 +261,7 @@ class ContextAwareDynamicalDecoupling(TransformationPass):
             )
             for node, start_time in self.property_set["node_start_time"].items()
             if (
-                node.op.name == "delay"
+                node.name == "delay"
                 and not is_after_reset(node)
                 and self._duration(node, qubit_map) > self._min_duration
             )

--- a/qiskit/transpiler/passes/utils/remove_final_measurements.py
+++ b/qiskit/transpiler/passes/utils/remove_final_measurements.py
@@ -35,7 +35,7 @@ def calc_final_ops(dag: DAGCircuit, final_op_names: set[str]) -> list[DAGOpNode]
         if not isinstance(node, DAGOpNode):
             continue
 
-        if node.op.name == "barrier":
+        if node.name == "barrier":
             # Barrier is final if all children are final, so we track
             # how many times we still need to encounter each barrier
             # via a child node.

--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -1134,11 +1134,9 @@ class OptimizeCliffordRZPassManager(PassManagerStagePlugin):
                     # we keep the run intact if it is only diagonals or only cliffords,
                     # meaning we collect if it's non-diag and non-clifford
                     contains_non_diag = any(
-                        node.op.name not in {"rz", "t", "tdg", "s", "sdg", "z"} for node in run
+                        node.name not in {"rz", "t", "tdg", "s", "sdg", "z"} for node in run
                     )
-                    contains_non_clifford = any(
-                        node.op.name not in clifford_t_gates for node in run
-                    )
+                    contains_non_clifford = any(node.name not in clifford_t_gates for node in run)
                     return contains_non_clifford and contains_non_diag
 
                 pre_loop = [


### PR DESCRIPTION
This PR switches the Python library to prefer `CircuitInstruction.name` over `CircuitInsruction.operation.name` in all places I could find where the operation is not used again. This avoids wastefully creating the operation as a new Python object. The same holds for nodes in DAG circuits. Therefore, this PR is theoretically a performance improvement, though I'd guess a very minor one.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Claude opus 4.7

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
