### PR TITLE
Use `ParameterVector(uuid=...)` in QPY deserialisation

### DIFF
--- a/crates/qpy/src/params.rs
+++ b/crates/qpy/src/params.rs
@@ -12,6 +12,7 @@
 use binrw::Endian;
 use num_complex::Complex64;
 use pyo3::prelude::*;
+use pyo3::types::IntoPyDict;
 use qiskit_circuit::imports;
 use qiskit_circuit::operations::Param;
 use qiskit_circuit::parameter::parameter_expression::{
@@ -546,33 +547,26 @@ pub(crate) fn unpack_parameter_vector(
             Some(value) => value,
             None => Python::attach(|py| -> Result<_, QpyError> {
                 // we use python-space to create a new parameter vector
+                let py_uuid = {
+                    let kwargs = [("int", root_uuid_int)].into_py_dict(py)?;
+                    py.import("uuid")?
+                        .getattr("UUID")?
+                        .call((), Some(&kwargs))?
+                };
                 let vector = imports::PARAMETER_VECTOR
                     .get_bound(py)
-                    .call1((name.clone(), parameter_vector_pack.vector_size))?
+                    .call1((name.clone(), parameter_vector_pack.vector_size, py_uuid))?
                     .unbind();
-                qpy_data.vectors.insert(root_uuid, (vector, Vec::new()));
+                qpy_data
+                    .vectors
+                    .insert(root_uuid, (vector, Default::default()));
                 qpy_data.vectors.get_mut(&root_uuid).ok_or_else(|| {
                     QpyError::MissingData("Parameter vector creation failed".to_string())
                 })
             })?,
         };
         let vector = vector_data.0.bind(py);
-        let vector_name = vector.getattr("name")?.extract::<String>()?;
-        let vector_element = vector.get_item(index)?.extract::<Symbol>()?;
-        if vector_element.uuid != uuid {
-            // we need to create a new parameter vector element and hack it into the vector
-            vector_data.1.push(index);
-            // let param_vector_element = PyParameterVectorElement::py_new(py, vector, index, parameter_vector_pack.uuid)
-            let param_vector_element = Symbol::py_new(
-                &vector_name,
-                Some(uuid.as_u128()),
-                Some(index),
-                Some(vector.clone().unbind()),
-            )?;
-            vector
-                .getattr("_params")?
-                .set_item(index, param_vector_element)?;
-        }
+        vector_data.1.insert(index);
         Ok(vector.clone().unbind())
     })?;
 

--- a/crates/qpy/src/value.rs
+++ b/crates/qpy/src/value.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use binrw::meta::{ReadEndian, WriteEndian};
 use binrw::{BinRead, BinWrite, Endian, binrw};
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 use pyo3::prelude::*;
 use pyo3::types::PyAny;
 
@@ -126,7 +126,7 @@ pub struct QPYReadData<'a> {
     pub use_symengine: bool,
     pub standalone_vars: HashMap<u16, qiskit_circuit::Var>,
     pub standalone_stretches: HashMap<u16, qiskit_circuit::Stretch>,
-    pub vectors: HashMap<Uuid, (Py<PyAny>, Vec<u32>)>, // Parameter expression vectors, which are a python-only elements for now
+    pub vectors: HashMap<Uuid, (Py<PyAny>, HashSet<u32>)>, // Parameter expression vectors, which are a python-only elements for now
     pub annotation_handler: AnnotationHandler<'a>,
 }
 

--- a/qiskit/qpy/binary_io/value.py
+++ b/qiskit/qpy/binary_io/value.py
@@ -460,14 +460,9 @@ def _read_parameter_vec(file_obj, vectors):
     name = file_obj.read(data.vector_name_size).decode(common.ENCODE)
 
     if root_uuid not in vectors:
-        vectors[root_uuid] = (ParameterVector(name, data.vector_size), set())
+        vectors[root_uuid] = (ParameterVector(name, data.vector_size, uuid=root_uuid), set())
     vector = vectors[root_uuid][0]
-
-    if vector[data.index].uuid != uuid.UUID(bytes=data.uuid):
-        vectors[root_uuid][1].add(data.index)
-        vector._params[data.index] = ParameterVectorElement(
-            vector, data.index, uuid=uuid.UUID(int=root_uuid_int + data.index)
-        )
+    vectors[root_uuid][1].add(data.index)
     return vector[data.index]
 
 

--- a/test/python/circuit/test_circuit_load_from_qpy.py
+++ b/test/python/circuit/test_circuit_load_from_qpy.py
@@ -1171,8 +1171,6 @@ class TestLoadFromQPY(QiskitTestCase):
             self.assertTrue(all(p == q for p, q in zip(params, new_params)))
             # vector[0] is part of the circuit
             self.assertTrue(vector[0] == new_vector[0])
-            # vector[1] is not part of the circuit
-            self.assertTrue(vector[1] != new_vector[1])
 
         with self.subTest("real_amplitudes"):
             qc = real_amplitudes(2, reps=1)


### PR DESCRIPTION
When QPY deserialises `ParameterVectorElement`s, it first created a dummy `ParameterVectorElement` with a random UUID, then mutated an internal Python-space cache of the elements individually, as they were encountered, to reset them to the `root_uuid + offset` form.

The idea that we *can* find the root vector during deserialisation is predicated on the assumption that the `root_uuid + offset` form *must* hold; if it doesn't, then the attempt to look up a cached version of the vector by looking at the `element_uuid - offset` would fail, so we'd never return the same vector.

When `ParameterVectorElement` serialisation was introduced in QPY v3[^1], vectors were still being looked up by name, and the elements had completely disconnected UUIDs, which motivated the original system. This is no longer the case on both counts; it is now much easier simply to generate the vector correctly from the start, and never need to mutate internal private state.

[^1]: 5c4cd2bbcf: Fix ParameterVector handling in QPY serialization (gh-7381)

Depends on #16216

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->