### PR TITLE
Remove stale checks in `Makefile` and `tox`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ ifeq ($(QISKIT_BUILD_WITH_MIMALLOC), 1)
 	MIMALLOC := --features=mimalloc
 endif
 
-.PHONY: default ruff env lint lint-incr style black test test_randomized pytest pytest_randomized test_ci coverage coverage_erase clean
+.PHONY: default env lint style black test test_randomized pytest pytest_randomized test_ci coverage coverage_erase clean
 
-default: style lint-incr test ;
+default: style lint test ;
 
 # Dependencies need to be installed on the Anaconda virtual environment.
 env:
@@ -37,15 +37,6 @@ lint:
 	tools/find_optional_imports.py
 	tools/find_stray_release_notes.py
 	tools/verify_images.py
-
-lint-incr:
-	ruff check qiskit test tools setup.py
-	tools/verify_headers.py qiskit test tools
-	tools/find_optional_imports.py
-	tools/verify_images.py
-
-ruff:
-	ruff qiskit test tools setup.py
 
 style:
 	black --check qiskit test tools setup.py docs/conf.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 4.28.0
-envlist = py310, py311, py312, py313, lint-incr
+envlist = py310, py311, py312, py313, lint
 isolated_build = true
 
 [testenv]
@@ -55,21 +55,6 @@ commands =
   cargo fmt --check
   ruff check qiskit test tools setup.py
   cargo clippy --all-targets -- -D warnings
-  python {toxinidir}/tools/verify_headers.py qiskit test tools crates
-  python {toxinidir}/tools/find_optional_imports.py
-  python {toxinidir}/tools/find_stray_release_notes.py
-  python {toxinidir}/tools/verify_images.py
-  reno -q lint
-
-[testenv:lint-incr]
-basepython = python3
-allowlist_externals = git
-dependency_groups =
-  lint
-commands =
-  black --check {posargs} qiskit test tools setup.py docs/conf.py
-  ruff check qiskit test tools setup.py
-  -git fetch -q https://github.com/Qiskit/qiskit.git :lint_incr_latest
   python {toxinidir}/tools/verify_headers.py qiskit test tools crates
   python {toxinidir}/tools/find_optional_imports.py
   python {toxinidir}/tools/find_stray_release_notes.py


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

`ruff` has superseded `pylint` as our default linter, so there's no need for a specific `make ruff` command anymore alongside of `make lint`. (Also `make ruff` was broken since a long time and no one complained).
Since ruff is very fast there's also no need for an incremental lint check anymore; in fact, it was not even running incrementally anymore. Hence `make lint-incr` is also removed both in `Makefile` and `tox`.

There is some potential danger of removing jobs that people are relying on in their automated (or mechanical memory) workflows, but I would argue that cleaning up and ensuring we don't have broken commands outweighs these downsides.

Question: Does this warrant an `Removed` release note to document these commands no longer exist?

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
