### PR TITLE
fix: Ensure there is no subtraction panic via underflow

### DIFF
--- a/crates/transpiler/src/passes/constrained_reschedule.rs
+++ b/crates/transpiler/src/passes/constrained_reschedule.rs
@@ -208,7 +208,7 @@ fn push_node_back(
 
         // Compute overlap if there is qubits overlap
         let qreg_overlap = if !this_qubits.is_disjoint(&next_qubits) {
-            new_t1q - next_t0q
+	    new_t1q.saturating_sub(next_t0q)
         } else {
             0
         };
@@ -219,7 +219,7 @@ fn push_node_back(
             && !this_clbits.is_disjoint(&next_clbits)
         {
             if let (Some(t1c), Some(t0c)) = (new_t1c, next_t0c) {
-                t1c - t0c
+		t1c.saturating_sub(t0c)
             } else {
                 0
             }

--- a/crates/transpiler/src/passes/constrained_reschedule.rs
+++ b/crates/transpiler/src/passes/constrained_reschedule.rs
@@ -208,7 +208,7 @@ fn push_node_back(
 
         // Compute overlap if there is qubits overlap
         let qreg_overlap = if !this_qubits.is_disjoint(&next_qubits) {
-	    new_t1q.saturating_sub(next_t0q)
+            new_t1q.saturating_sub(next_t0q)
         } else {
             0
         };
@@ -219,7 +219,7 @@ fn push_node_back(
             && !this_clbits.is_disjoint(&next_clbits)
         {
             if let (Some(t1c), Some(t0c)) = (new_t1c, next_t0c) {
-		t1c.saturating_sub(t0c)
+                t1c.saturating_sub(t0c)
             } else {
                 0
             }


### PR DESCRIPTION
In the Python version of `ConstrainedReschedule` when `next_t0q > new_t1q` the overlap gives a negative number, which is handled by `overlap = max(qreg_overlap, creg_overlap)` followed by the `if overlap > 0` check. 

In Rust these values are u64 so the same subtraction panics on underflow. By using `saturating_sub` we clamp to 0 so it matches the Python behavior. 

Fix #16231.

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
