### PR TITLE
Fix ConstrainedReschedule raising on barrier and other directives

### DIFF
--- a/crates/transpiler/src/passes/constrained_reschedule.rs
+++ b/crates/transpiler/src/passes/constrained_reschedule.rs
@@ -80,7 +80,10 @@ fn push_node_back(
         | OperationRef::StandardInstruction(StandardInstruction::Measure) => Some(acquire_align),
         OperationRef::StandardInstruction(StandardInstruction::Delay(_)) => None,
         _ => {
-            if !op_view.directive() {
+            if op_view.directive() {
+                // Compiler directives (e.g. `barrier`) have no hardware duration and
+                // therefore no alignment to enforce; they should still be visited so
+                // that successor overlap is computed, but skip the alignment step.
                 None
             } else {
                 return Err(TranspilerError::new_err(format!(

--- a/releasenotes/notes/fix-constrained-reschedule-barrier-57d38f5d131bc2bf.yaml
+++ b/releasenotes/notes/fix-constrained-reschedule-barrier-57d38f5d131bc2bf.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    Fixed :class:`.ConstrainedReschedule` raising
+    ``TranspilerError("Unknown operation type for 'barrier'.")`` when a
+    circuit contained any compiler directive such as :meth:`.QuantumCircuit.barrier`.
+    The Rust port of the pass in Qiskit 2.4 inverted the branch that handled
+    directives, so the directive case raised an error while unknown non-directive
+    operations were silently treated as having no alignment.  The behaviour now
+    matches the original Python implementation: directives are still visited so
+    that successor overlap is computed, but no alignment is enforced on them.
+    See `#16135 <https://github.com/Qiskit/qiskit/issues/16135>`__.

--- a/test/python/transpiler/test_constrained_reschedule.py
+++ b/test/python/transpiler/test_constrained_reschedule.py
@@ -1,0 +1,58 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test the ConstrainedReschedule pass."""
+
+import unittest
+
+from qiskit import QuantumCircuit
+from qiskit.circuit.library import CXGate
+from qiskit.transpiler.passes import ALAPScheduleAnalysis, ConstrainedReschedule
+from qiskit.transpiler.passmanager import PassManager
+from qiskit.transpiler.target import InstructionProperties, Target
+
+from test import QiskitTestCase
+
+
+class TestConstrainedReschedule(QiskitTestCase):
+    """Tests for the :class:`.ConstrainedReschedule` pass."""
+
+    def _make_target(self):
+        """Build a tiny 2-qubit target with one CX gate and alignment constraints."""
+        dt = 2.22e-10
+        target = Target(dt=dt, num_qubits=2, acquire_alignment=16, pulse_alignment=1)
+        target.add_instruction(CXGate(), {(0, 1): InstructionProperties(duration=100 * dt)})
+        return target
+
+    def test_reschedule_with_barrier(self):
+        """Regression test for #16135: a directive such as ``barrier`` must not
+        raise ``"Unknown operation type"`` in :class:`.ConstrainedReschedule`.
+
+        The original Python implementation treated compiler directives the same
+        as :class:`.Delay`: no alignment is enforced (they have no hardware
+        duration), but they are still visited so that successor overlap is
+        computed.  The 2.4 Rust port inverted that branch.
+        """
+        target = self._make_target()
+
+        qc = QuantumCircuit(2)
+        qc.cx(0, 1)
+        qc.barrier(0)
+
+        pm = PassManager(
+            [ALAPScheduleAnalysis(target=target), ConstrainedReschedule(target=target)]
+        )
+        pm.run(qc)  # would raise TranspilerError on the buggy code path
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #16135.

The Rust port of `ConstrainedReschedule` in Qiskit 2.4 inverted the branch that handles compiler directives. The pre-port Python implementation treated any `Delay` *or* directive as `alignment = None` (no alignment to enforce on these, but successor overlap is still computed) and raised only for genuinely unknown operations. The Rust port reversed it, so any directive — most commonly `barrier` — now raises:

```
TranspilerError: "Unknown operation type for 'barrier'."
```

while an unknown non-directive operation is silently treated as having no alignment.

## What changed

`crates/transpiler/src/passes/constrained_reschedule.rs`:

```diff
         _ => {
-            if !op_view.directive() {
+            if op_view.directive() {
+                // Compiler directives (e.g. `barrier`) have no hardware duration and
+                // therefore no alignment to enforce; they should still be visited so
+                // that successor overlap is computed, but skip the alignment step.
                 None
             } else {
                 return Err(TranspilerError::new_err(format!(
```

This restores the semantics of the original Python implementation:

```python
elif isinstance(node.op, Delay) or getattr(node.op, "_directive", False):
    # Directive or delay. These can start at arbitrary time.
    alignment = None
else:
    raise TranspilerError(f"Unknown operation type for {node!r}.")
```

(from `qiskit/transpiler/passes/scheduling/alignments/reschedule.py` prior to PR #14883, the Rust port).

## Reproduction (from the issue, with the external `qiskit_ibm_runtime` dependency removed)

```python
from qiskit import QuantumCircuit
from qiskit.circuit.library import CXGate
from qiskit.transpiler import PassManager
from qiskit.transpiler.passes import ALAPScheduleAnalysis, ConstrainedReschedule
from qiskit.transpiler.target import InstructionProperties, Target

dt = 2.22e-10
target = Target(dt=dt, num_qubits=2, acquire_alignment=16, pulse_alignment=1)
target.add_instruction(CXGate(), {(0, 1): InstructionProperties(duration=100 * dt)})

qc = QuantumCircuit(2)
qc.cx(0, 1)
qc.barrier(0)

PassManager(
    [ALAPScheduleAnalysis(target=target), ConstrainedReschedule(target=target)]
).run(qc)  # before: TranspilerError;  after: succeeds
```

## Test plan

- [x] New `test/python/transpiler/test_constrained_reschedule.py::TestConstrainedReschedule::test_reschedule_with_barrier` exercises the failing path and passes.
- [x] Bug reproduced locally against the original code; resolved after the fix.
- [x] Full `test/python/transpiler/test_scheduling_padding_pass.py` (14 tests) still passes — no regression in adjacent scheduling behaviour.
- [x] `cargo check`, `cargo clippy -p qiskit-transpiler -- -D warnings`, and `cargo fmt --check` are clean.
- [x] `ruff check` and `black --check` (project-pinned `black~=25.1`) on the new test file are clean.

## Note on a separate latent bug

While reproducing this, I noticed that `ConstrainedReschedule(acquire_alignment=..., pulse_alignment=...)` (i.e., constructed without a `target=`) raises `AttributeError: 'ConstrainedReschedule' object has no attribute 'target'` because `self.target` is only assigned in the `if target is not None` branch of `__init__`. That looks like a separate regression and I haven't touched it here to keep this PR focused on #16135; happy to file a follow-up issue / PR if maintainers would like.

## AI tool disclosure

Per the Qiskit contribution policy: this change was prepared with assistance from Claude Opus 4.7 (1M context, via Claude Code). I reviewed every diff and verified all results locally; the model did not introduce any change I did not validate.