### PR TITLE
Expose ``n_local`` to C API

### DIFF
--- a/crates/cext-vtable/src/lib.rs
+++ b/crates/cext-vtable/src/lib.rs
@@ -157,6 +157,17 @@ mod circuit_library {
             export_fn!(suzuki_trotter::qk_circuit_library_suzuki_trotter),
             export_fn!(pbc::qk_pauli_product_rotation_clear),
             export_fn!(pbc::qk_pauli_product_measurement_clear),
+            export_fn!(n_local::qk_n_local),
+            export_fn!(n_local::qk_qubit_connection_new),
+            export_fn!(n_local::qk_qubit_connection_equal),
+            export_fn!(n_local::qk_qubit_connection_free),
+            export_fn!(n_local::qk_entanglement_free),
+            export_fn!(n_local::qk_get_entanglement_layers_quantity),
+            export_fn!(n_local::qk_get_entanglement_layer_blocks_quantity),
+            export_fn!(n_local::qk_get_entanglement_qubit_connections_quantity),
+            export_fn!(n_local::qk_get_entanglement_qubit_connections),
+            export_fn!(n_local::qk_get_entanglement_with_multiple_strategy),
+            export_fn!(n_local::qk_get_entanglement_with_strategy),
         ]
     });
 }

--- a/crates/cext-vtable/src/lib.rs
+++ b/crates/cext-vtable/src/lib.rs
@@ -157,17 +157,8 @@ mod circuit_library {
             export_fn!(suzuki_trotter::qk_circuit_library_suzuki_trotter),
             export_fn!(pbc::qk_pauli_product_rotation_clear),
             export_fn!(pbc::qk_pauli_product_measurement_clear),
-            export_fn!(n_local::qk_n_local),
-            export_fn!(n_local::qk_qubit_connection_new),
-            export_fn!(n_local::qk_qubit_connection_equal),
-            export_fn!(n_local::qk_qubit_connection_free),
-            export_fn!(n_local::qk_entanglement_free),
-            export_fn!(n_local::qk_get_entanglement_layers_quantity),
-            export_fn!(n_local::qk_get_entanglement_layer_blocks_quantity),
-            export_fn!(n_local::qk_get_entanglement_qubit_connections_quantity),
-            export_fn!(n_local::qk_get_entanglement_qubit_connections),
-            export_fn!(n_local::qk_get_entanglement_with_multiple_strategy),
-            export_fn!(n_local::qk_get_entanglement_with_strategy),
+            export_fn!(n_local::qk_circuit_library_n_local),
+            export_fn!(n_local::qk_circuit_library_n_local_settings_default),
         ]
     });
 }

--- a/crates/cext/src/circuit_library/mod.rs
+++ b/crates/cext/src/circuit_library/mod.rs
@@ -14,3 +14,4 @@ pub mod iqp;
 pub mod pbc;
 pub mod quantum_volume;
 pub mod suzuki_trotter;
+pub mod n_local;

--- a/crates/cext/src/circuit_library/mod.rs
+++ b/crates/cext/src/circuit_library/mod.rs
@@ -11,7 +11,7 @@
 // that they have been altered from the originals.
 
 pub mod iqp;
+pub mod n_local;
 pub mod pbc;
 pub mod quantum_volume;
 pub mod suzuki_trotter;
-pub mod n_local;

--- a/crates/cext/src/circuit_library/n_local.rs
+++ b/crates/cext/src/circuit_library/n_local.rs
@@ -116,6 +116,7 @@ pub enum EntanglementStrategy {
 /// @param parameter_prefix The prefix used for the default parameters generated.
 /// @param insert_barriers If ``true``, barriers are inserted in between each layer. If ``false``,
 ///   no barriers are inserted.
+/// @param skip_final_rotation_layer Whether a final rotation layer is added to the circuit.
 ///
 /// @return A pointer to the generated circuit.
 ///

--- a/crates/cext/src/circuit_library/n_local.rs
+++ b/crates/cext/src/circuit_library/n_local.rs
@@ -20,15 +20,19 @@ use qiskit_circuit_library::parameter_ledger::ParameterLedgerBuilder;
 use std::ffi::{CStr, c_char};
 
 // Opaque structs for FFI compatibility
+/// QubitConnection: Indices that the multi-qubit gate acts on
 #[derive(Debug, Clone)]
 pub struct QubitConnection(Vec<u32>);
 
+/// BlockQubitConnection: Entanglement for single block
 pub struct BlockQubitConnection(Vec<QubitConnection>);
 
+/// LayerEntanglement: Entanglements for all blocks in the layer
 pub struct LayerEntanglement(Vec<BlockQubitConnection>);
-
+/// Entanglement: Entanglement for every layer
 pub struct Entanglement(Vec<LayerEntanglement>);
 
+/// Enum representing all the possible strategies for n_local entanglement blocks
 #[repr(C)]
 pub enum EntanglementStrategy {
     Full,
@@ -120,6 +124,31 @@ pub unsafe extern "C" fn qk_n_local(
     }
 }
 
+/// @ingroup QkCircuitLibrary
+/// Obtain the layers count in the provided ``QkEntanglement``.
+///
+/// @param entanglement A pointer to the ``QkEntanglement`` object.
+///
+/// @return The layers count on the provided ``QkEntanglement``.
+///
+/// # Example
+///
+/// ```c
+/// int reps = 1;
+/// int num_qubits = 2;
+/// QkGate entanglement_blocks[1] = {QkGate_CRX};
+/// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
+///     num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
+///
+/// size_t layers_count = qk_get_entanglement_layers_quantity(entanglement);
+///
+/// qk_entanglement_free(entanglement);
+/// ```
+///
+///
+/// # Safety
+///
+/// Behavior is undefined if ``entanglement`` is not either null or a valid pointer to a ``QkEntanglement``.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_get_entanglement_layers_quantity(
     entanglement: *const Entanglement,
@@ -129,6 +158,32 @@ pub unsafe extern "C" fn qk_get_entanglement_layers_quantity(
     entanglement.0.len()
 }
 
+/// @ingroup QkCircuitLibrary
+/// Obtain the blocks count on a given layer in the provided ``QkEntanglement``.
+///
+/// @param entanglement A pointer to the ``QkEntanglement`` object.
+/// @param layer_index The layer index where the blocks are.
+///
+/// @return The blocks count on the given layer.
+///
+/// # Example
+///
+/// ```c
+/// int reps = 1;
+/// int num_qubits = 2;
+/// QkGate entanglement_blocks[1] = {QkGate_CRX};
+/// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
+///     num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
+///
+/// size_t blocks_count = qk_get_entanglement_layer_blocks_quantity(entanglement, 0);
+///
+/// qk_entanglement_free(entanglement);
+/// ```
+///
+///
+/// # Safety
+///
+/// Behavior is undefined if ``entanglement`` is not either null or a valid pointer to a ``QkEntanglement``.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_get_entanglement_layer_blocks_quantity(
     entanglement: *const Entanglement,
@@ -139,6 +194,33 @@ pub unsafe extern "C" fn qk_get_entanglement_layer_blocks_quantity(
     entanglement.0[layer_index].0.len()
 }
 
+/// @ingroup QkCircuitLibrary
+/// Obtain the ``QkQubitConnection`` count on a given layer and block in the provided ``QkEntanglement``.
+///
+/// @param entanglement A pointer to the ``QkEntanglement`` object.
+/// @param layer_index The layer index where the ``QkQubitConnection`` objects exist.
+/// @param block_index The block index in the layer where the ``QkQubitConnection`` objects exist.
+///
+/// @return The qubit connections count on the given layer and block.
+///
+/// # Example
+///
+/// ```c
+/// int reps = 1;
+/// int num_qubits = 2;
+/// QkGate entanglement_blocks[1] = {QkGate_CRX};
+/// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
+///     num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
+///
+/// size_t connections_count = qk_get_entanglement_qubit_connections_quantity(entanglement, 0, 0);
+///
+/// qk_entanglement_free(entanglement);
+/// ```
+///
+///
+/// # Safety
+///
+/// Behavior is undefined if ``entanglement`` is not either null or a valid pointer to a ``QkEntanglement``.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_get_entanglement_qubit_connections_quantity(
     entanglement: *const Entanglement,
@@ -150,6 +232,35 @@ pub unsafe extern "C" fn qk_get_entanglement_qubit_connections_quantity(
     entanglement.0[layer_index].0[block_index].0.len()
 }
 
+/// @ingroup QkCircuitLibrary
+/// Obtain the ``QkQubitConnection`` object at a given layer and block in the provided ``QkEntanglement``.
+///
+/// @param entanglement A pointer to the ``QkEntanglement`` object.
+/// @param layer_index The layer index where the ``QkQubitConnection`` object exists.
+/// @param block_index The block index in the layer where the ``QkQubitConnection`` object exists.
+/// @param connection_index The ``QkQubitConnection`` object index where the multi-qubit gate acts on.
+///
+/// @return A pointer to the obtained ``QkQubitConnection``.
+///
+/// # Example
+///
+/// ```c
+/// int reps = 1;
+/// int num_qubits = 2;
+/// QkGate entanglement_blocks[1] = {QkGate_CRX};
+/// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
+///     num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
+///
+/// QkQubitConnection *connection = qk_get_entanglement_qubit_connections(entanglement, 0, 0, 1);
+///
+/// qk_entanglement_free(entanglement);
+/// qk_qubit_connection_free(connection);
+/// ```
+///
+///
+/// # Safety
+///
+/// Behavior is undefined if ``entanglement`` is not either null or a valid pointer to a ``QkEntanglement``.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_get_entanglement_qubit_connections(
     entanglement: *const Entanglement,
@@ -164,6 +275,23 @@ pub unsafe extern "C" fn qk_get_entanglement_qubit_connections(
     ))
 }
 
+/// @ingroup QkCircuitLibrary
+/// Construct a new ``QkQubitConnection`` representing the entanglement between qubits where a multi-qubit gate acts on.
+///
+/// @param num_qubits The size of the qubits connections array.
+/// @param qubit_connections The qubits connections array.
+///
+/// @return A pointer to the created ``QkQubitConnection``.
+///
+/// # Example
+///
+/// ```c
+/// QkQubitConnection *qconn = qk_qubit_connection_new((uint32_t[2]){0, 1}, 2);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined ``qubit_connections`` is not a valid, non-null pointer to a ``uint32_t`` array.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_qubit_connection_new(
     num_qubits: usize,
@@ -176,6 +304,27 @@ pub unsafe extern "C" fn qk_qubit_connection_new(
     Box::into_raw(Box::new(QubitConnection(qubits)))
 }
 
+/// @ingroup QkCircuitLibrary
+/// Compare two ``QkQubitConnection`` for equality.
+///
+/// @param c1 A pointer to the left hand side ``QkQubitConnection``.
+/// @param c2 A pointer to the right hand side ``QkQubitConnection``.
+///
+/// @return ``true`` if the ``QkQubitConnection`` objects are equal, ``false`` otherwise.
+///
+/// # Example
+///
+/// ```c
+/// QkQubitConnection *qconn = qk_qubit_connection_new((uint32_t[2]){0, 1}, 2);
+/// QkQubitConnection *qconn2 = qk_qubit_connection_new((uint32_t[2]){0, 1}, 2);
+///
+/// bool equal = qk_qubit_connection_equal(qconn, qconn2);
+/// ```
+///
+/// # Safety
+///
+/// The behavior is undefined if any of ``c1`` or ``c2`` is not a valid, non-null
+/// pointer to a ``QkQubitConnection``.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_qubit_connection_equal(
     c1: *const QubitConnection,
@@ -200,12 +349,12 @@ pub unsafe extern "C" fn qk_qubit_connection_equal(
 /// @param entanglement_blocks The blocks used in the entanglement layers.
 /// @param entanglement_blocks_size Length of the list of entanglement blocks provided
 ///
+/// @return A pointer to the created ``QkEntanglement``.
 ///
 /// # Safety
 ///
 /// Behavior is undefined ``entanglement_strategy`` is not a valid, non-null pointer to a ``QkEntanglementStrategy`` array.
 /// Behavior is undefined ``entanglement_blocks`` is not a valid, non-null pointer to a ``StandardGate`` array.
-///
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_get_entanglement_with_multiple_strategy(
     num_qubits: u32,
@@ -256,12 +405,11 @@ pub unsafe extern "C" fn qk_get_entanglement_with_multiple_strategy(
 /// @param entanglement_blocks The blocks used in the entanglement layers.
 /// @param entanglement_blocks_size Length of the list of entanglement blocks provided.
 ///
-///
+/// @return A pointer to the created ``QkEntanglement``.
 ///
 /// # Safety
 ///
 /// Behavior is undefined ``entanglement_blocks`` is not a valid, non-null pointer to a ``QkGate`` array.
-///
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_get_entanglement_with_strategy(
     num_qubits: u32,
@@ -329,7 +477,7 @@ pub unsafe extern "C" fn qk_qubit_connection_free(qubit_connection: *mut QubitCo
 ///
 /// ```c
 /// int reps = 1;
-/// QkGate rotation_blocks[1] = {QkGate_H};
+/// int num_qubits = 2;
 /// QkGate entanglement_blocks[1] = {QkGate_CRX};
 /// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
 ///     num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);

--- a/crates/cext/src/circuit_library/n_local.rs
+++ b/crates/cext/src/circuit_library/n_local.rs
@@ -328,6 +328,7 @@ pub unsafe extern "C" fn qk_qubit_connection_free(qubit_connection: *mut QubitCo
 /// # Example
 ///
 /// ```c
+/// int reps = 1;
 /// QkGate rotation_blocks[1] = {QkGate_H};
 /// QkGate entanglement_blocks[1] = {QkGate_CRX};
 /// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
@@ -361,12 +362,11 @@ fn get_entanglement_with_strategy(
 ) -> Entanglement {
     Entanglement(
         (0..reps)
-            .zip(entanglement_strategy)
-            .map(|(layer, strategy)| {
+            .map(|layer| {
                 get_layer_entanglement_with_strategy(
                     num_qubits,
-                    &entanglement_blocks,
-                    strategy,
+                    entanglement_blocks,
+                    entanglement_strategy,
                     layer,
                 )
             })
@@ -377,18 +377,19 @@ fn get_entanglement_with_strategy(
 fn get_layer_entanglement_with_strategy(
     num_qubits: u32,
     entanglement_blocks: &[&StandardGate],
-    entanglement_strategy: &str,
+    entanglement_strategy: &[&str],
     layer_index: usize,
 ) -> LayerEntanglement {
     LayerEntanglement(
         entanglement_blocks
             .iter()
-            .map(|gate| {
+            .zip(entanglement_strategy.iter())
+            .map(|(gate, &strategy)| {
                 get_block_qubit_connections_with_strategy(
                     num_qubits,
                     gate,
-                    entanglement_strategy,
-                    (entanglement_strategy == "sca").then_some(layer_index),
+                    strategy,
+                    (strategy == "sca").then_some(layer_index),
                 )
             })
             .collect(),

--- a/crates/cext/src/circuit_library/n_local.rs
+++ b/crates/cext/src/circuit_library/n_local.rs
@@ -10,14 +10,14 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::pointers::{check_ptr, const_ptr_as_ref};
+use crate::pointers::const_ptr_as_ref;
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::operations::StandardGate;
 use qiskit_circuit_library::blocks::{Block, Entanglement};
 use qiskit_circuit_library::entanglement::get_entanglement_from_str;
 use qiskit_circuit_library::multi_local::n_local;
 use qiskit_circuit_library::parameter_ledger::ParameterLedgerBuilder;
-use std::ffi::{CStr, CString, c_char};
+use std::ffi::{CStr, c_char};
 
 #[repr(C)]
 pub struct NLocalSettings {
@@ -40,7 +40,7 @@ impl Default for NLocalSettings {
         Self {
             entanglement_strategy: EntanglementStrategy::Full,
             reps: 3,
-            parameter_prefix: CString::new("θ").unwrap().into_raw(),
+            parameter_prefix: std::ptr::null_mut(),
             insert_barriers: false,
             skip_final_rotation_layer: false,
         }
@@ -138,7 +138,7 @@ pub enum EntanglementStrategy {
 ///
 /// QkNLocalSettings settings = qk_circuit_library_n_local_settings_default();
 /// settings.reps = 2;
-/// // For this example we use QkEntanglementStrategy_Linear since 
+/// // For this example we use QkEntanglementStrategy_Linear since
 /// // the default is QkEntanglementStrategy_Full
 /// settings.entanglement_strategy = QkEntanglementStrategy_Linear;
 ///
@@ -185,18 +185,11 @@ pub unsafe extern "C" fn qk_circuit_library_n_local(
             .collect();
     let entanglement_blocks: Vec<&Block> = entanglement_blocks.iter().collect();
 
-    let (settings, parameter_prefix) = if settings.is_null() {
-        (&NLocalSettings::default(), "θ")
+    let settings = if settings.is_null() {
+        &NLocalSettings::default()
     } else {
         // SAFETY: Per documentation, the pointer is non-null and aligned.
-        let settings = unsafe { const_ptr_as_ref(settings) };
-        (settings, unsafe {
-            // SAFETY: Per documentation, the pointer is non-null and aligned.
-            check_ptr(settings.parameter_prefix).expect("Parameter prefix must not be null");
-            CStr::from_ptr(settings.parameter_prefix)
-                .to_str()
-                .expect("Invalid UTF-8 character")
-        })
+        unsafe { const_ptr_as_ref(settings) }
     };
 
     let entanglement = get_entanglement_strategy(&settings.entanglement_strategy);
@@ -215,7 +208,16 @@ pub unsafe extern "C" fn qk_circuit_library_n_local(
         &entanglement,
         settings.reps,
         settings.insert_barriers,
-        &parameter_prefix,
+        if settings.parameter_prefix.is_null() {
+            "θ"
+        } else {
+            // SAFETY: Per documentation, the pointer is non-null and aligned.
+            unsafe {
+                CStr::from_ptr(settings.parameter_prefix)
+                    .to_str()
+                    .expect("Invalid UTF-8 character")
+            }
+        },
         settings.skip_final_rotation_layer,
         false,
     ) {

--- a/crates/cext/src/circuit_library/n_local.rs
+++ b/crates/cext/src/circuit_library/n_local.rs
@@ -290,6 +290,69 @@ pub unsafe extern "C" fn qk_get_entanglement_with_strategy(
     )))
 }
 
+/// @ingroup QkCircuitLibrary
+/// Free the ``QkQubitConnection``.
+///
+/// @param qubit_connection A pointer to the ``QkQubitConnection`` to free.
+///
+/// # Example
+///
+/// ```c
+/// QkQubitConnection *qconn = qk_qubit_connection_new((uint32_t[2]){0, 1}, 2);
+/// qk_qubit_connection_free(qconn);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``qubit_connection`` is not either null or a valid pointer to a ``QubitConnection``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_qubit_connection_free(qubit_connection: *mut QubitConnection) {
+    if !qubit_connection.is_null() {
+        if !qubit_connection.is_aligned() {
+            panic!("Attempted to free a non-aligned pointer.")
+        }
+
+        // SAFETY: We have verified the pointer is non-null and aligned, so it should be
+        // readable by Box.
+        unsafe {
+            let _ = Box::from_raw(qubit_connection);
+        }
+    }
+}
+
+/// @ingroup QkCircuitLibrary
+/// Free the ``QkEntanglement``.
+///
+/// @param entanglement A pointer to the ``QkEntanglement`` to free.
+///
+/// # Example
+///
+/// ```c
+/// QkGate rotation_blocks[1] = {QkGate_H};
+/// QkGate entanglement_blocks[1] = {QkGate_CRX};
+/// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
+///     num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
+/// qk_entanglement_free(entanglement);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``entanglement`` is not either null or a valid pointer to a ``QkEntanglement``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_entanglement_free(entanglement: *mut Entanglement) {
+    if !entanglement.is_null() {
+        if !entanglement.is_aligned() {
+            panic!("Attempted to free a non-aligned pointer.")
+        }
+
+        // SAFETY: We have verified the pointer is non-null and aligned, so it should be
+        // readable by Box.
+        unsafe {
+            let _ = Box::from_raw(entanglement);
+        }
+    }
+}
+
 fn get_entanglement_with_strategy(
     num_qubits: u32,
     entanglement_blocks: &[&StandardGate],

--- a/crates/cext/src/circuit_library/n_local.rs
+++ b/crates/cext/src/circuit_library/n_local.rs
@@ -142,21 +142,20 @@ pub enum EntanglementStrategy {
 /// // the default is QkEntanglementStrategy_Full
 /// settings.entanglement_strategy = QkEntanglementStrategy_Linear;
 ///
-/// QkCircuit *qc = qk_circuit_library_n_local(num_qubits, rotation_blocks, 1, entanglement_blocks, 1, &settings);
+/// QkCircuit *qc = qk_circuit_library_n_local(num_qubits, rotation_blocks, 1, 
+///                                            entanglement_blocks, 1, &settings);
 ///
 /// qk_circuit_free(qc);
 /// ```
 ///
 /// # Safety
 ///
-/// Behavior is undefined if ``entanglement`` is not either null
-/// or a valid pointer to a ``QkEntanglement``.
 /// Behavior is undefined if ``rotation_blocks`` is not a valid, non-null pointer
 /// to a sequence of ``rotation_blocks_size`` consecutive elements of ``StandardGate``.
 /// Behavior is undefined if ``entanglement_blocks`` is not a valid, non-null pointer
 /// to a sequence of ``entanglement_blocks_size`` consecutive elements of ``StandardGate``.
-/// The `parameter_prefix` parameter must be a pointer to memory that contains a valid
-/// nul terminator at the end of the string. It also must be valid for reads of
+/// The `NLocalSettings.parameter_prefix` parameter must be a pointer to memory that contains
+/// a valid nul terminator at the end of the string. It also must be valid for reads of
 /// bytes up to and including the nul terminator.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_circuit_library_n_local(

--- a/crates/cext/src/circuit_library/n_local.rs
+++ b/crates/cext/src/circuit_library/n_local.rs
@@ -20,9 +20,13 @@ use qiskit_circuit_library::parameter_ledger::ParameterLedgerBuilder;
 use std::ffi::{CStr, c_char};
 
 // Opaque structs for FFI compatibility
+#[derive(Debug, Clone)]
 pub struct QubitConnection(Vec<u32>);
+
 pub struct BlockQubitConnection(Vec<QubitConnection>);
+
 pub struct LayerEntanglement(Vec<BlockQubitConnection>);
+
 pub struct Entanglement(Vec<LayerEntanglement>);
 
 #[repr(C)]
@@ -112,21 +116,91 @@ pub unsafe extern "C" fn qk_n_local(
     }
 }
 
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_get_entanglement_layers_quantity(
+    entanglement: *const Entanglement,
+) -> usize {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let entanglement = unsafe { const_ptr_as_ref(entanglement) };
+    entanglement.0.len()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_get_entanglement_layer_blocks_quantity(
+    entanglement: *const Entanglement,
+    layer_index: usize,
+) -> usize {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let entanglement = unsafe { const_ptr_as_ref(entanglement) };
+    entanglement.0[layer_index].0.len()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_get_entanglement_qubit_connections_quantity(
+    entanglement: *const Entanglement,
+    layer_index: usize,
+    block_index: usize,
+) -> usize {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let entanglement = unsafe { const_ptr_as_ref(entanglement) };
+    entanglement.0[layer_index].0[block_index].0.len()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_get_entanglement_qubit_connections(
+    entanglement: *const Entanglement,
+    layer_index: usize,
+    block_index: usize,
+    connection_index: usize,
+) -> *mut QubitConnection {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let entanglement = unsafe { const_ptr_as_ref(entanglement) };
+    Box::into_raw(Box::new(
+        entanglement.0[layer_index].0[block_index].0[connection_index].clone(),
+    ))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_qubit_connection_new(
+    num_qubits: usize,
+    qubit_connections: *const u32,
+) -> *mut QubitConnection {
+    // SAFETY: per documentation, `qubit_connections` is aligned and and points to a valid
+    // aligned block of memory valid for `qubit_connections_size` writes of `u32`s
+    let qubits: Vec<u32> =
+        unsafe { ::std::slice::from_raw_parts(qubit_connections, num_qubits).to_vec() };
+    Box::into_raw(Box::new(QubitConnection(qubits)))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_qubit_connection_equal(
+    c1: *const QubitConnection,
+    c2: *const QubitConnection,
+) -> bool {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let c1 = unsafe { const_ptr_as_ref(c1) };
+
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let c2 = unsafe { const_ptr_as_ref(c2) };
+
+    c1.0.eq(&c2.0)
+}
+
 /// @ingroup QkCircuitLibrary
 /// Generate an entanglement following the provided strategies.
 ///
 /// @param num_qubits The number of qubits of the circuit
-/// @param reps Specifies how often the rotation blocks and entanglement blocks are repeated.
+/// @param reps Specifies how often the entanglement blocks are repeated.
 /// @param entanglement_strategy List of strings describing an entanglement strategy for each layer.
 /// @param entanglement_strategy_size Length of the entanglement strategy list provided
 /// @param entanglement_blocks The blocks used in the entanglement layers.
 /// @param entanglement_blocks_size Length of the list of entanglement blocks provided
 ///
 ///
-///
 /// # Safety
 ///
 /// Behavior is undefined ``entanglement_strategy`` is not a valid, non-null pointer to a ``QkEntanglementStrategy`` array.
+/// Behavior is undefined ``entanglement_blocks`` is not a valid, non-null pointer to a ``StandardGate`` array.
 ///
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_get_entanglement_with_multiple_strategy(
@@ -173,7 +247,7 @@ pub unsafe extern "C" fn qk_get_entanglement_with_multiple_strategy(
 /// Generate an entanglement following the provided strategies.
 ///
 /// @param num_qubits The number of qubits of the circuit
-/// @param reps Specifies how often the rotation blocks and entanglement blocks are repeated.
+/// @param reps Specifies how often the entanglement blocks are repeated.
 /// @param entanglement_strategy The entanglement strategy to apply for each layer.
 /// @param entanglement_blocks The blocks used in the entanglement layers.
 /// @param entanglement_blocks_size Length of the list of entanglement blocks provided.

--- a/crates/cext/src/circuit_library/n_local.rs
+++ b/crates/cext/src/circuit_library/n_local.rs
@@ -142,7 +142,7 @@ pub enum EntanglementStrategy {
 /// // the default is QkEntanglementStrategy_Full
 /// settings.entanglement_strategy = QkEntanglementStrategy_Linear;
 ///
-/// QkCircuit *qc = qk_circuit_library_n_local(num_qubits, rotation_blocks, 1, 
+/// QkCircuit *qc = qk_circuit_library_n_local(num_qubits, rotation_blocks, 1,
 ///                                            entanglement_blocks, 1, &settings);
 ///
 /// qk_circuit_free(qc);

--- a/crates/cext/src/circuit_library/n_local.rs
+++ b/crates/cext/src/circuit_library/n_local.rs
@@ -196,7 +196,7 @@ pub unsafe extern "C" fn qk_circuit_library_n_local(
     let entanglement = get_entanglement_with_strategy(
         num_qubits,
         &entanglement_blocks,
-        &entanglement,
+        entanglement,
         settings.reps,
     );
 

--- a/crates/cext/src/circuit_library/n_local.rs
+++ b/crates/cext/src/circuit_library/n_local.rs
@@ -19,6 +19,22 @@ use qiskit_circuit_library::multi_local::n_local;
 use qiskit_circuit_library::parameter_ledger::ParameterLedgerBuilder;
 use std::ffi::{CStr, c_char};
 
+/// Settings for generating a n-local variational circuit.
+///
+/// This contains the entanglement strategy (``entanglement_strategy``),
+/// the repetitions of the rotation and entanglement layers (``reps``),
+/// the parameter prefix for gates that have parameters (``parameter_prefix``),
+/// whether it's wanted to add barriers after each layer (``insert_barriers``)
+/// and if it's wanted to skip the last layer (``skip_final_rotation_layer``)
+///
+/// It's the responsibility of the user that the data is coherent,
+/// see also the below section on safety.
+///
+/// # Safety
+///
+/// ``parameter_prefix`` must be a pointer to memory that contains
+/// a valid nul terminator at the end of the string. It also must be valid for reads of
+/// bytes up to and including the nul terminator.
 #[repr(C)]
 pub struct NLocalSettings {
     /// The entanglement strategy to be used in the generated circuit.
@@ -150,13 +166,10 @@ pub enum EntanglementStrategy {
 ///
 /// # Safety
 ///
-/// Behavior is undefined if ``rotation_blocks`` is not a valid, non-null pointer
-/// to a sequence of ``rotation_blocks_size`` consecutive elements of ``StandardGate``.
-/// Behavior is undefined if ``entanglement_blocks`` is not a valid, non-null pointer
-/// to a sequence of ``entanglement_blocks_size`` consecutive elements of ``StandardGate``.
-/// The `NLocalSettings.parameter_prefix` parameter must be a pointer to memory that contains
-/// a valid nul terminator at the end of the string. It also must be valid for reads of
-/// bytes up to and including the nul terminator.
+/// * Behavior is undefined if ``rotation_blocks`` is not a valid, non-null pointer
+///   to a sequence of ``rotation_blocks_size`` consecutive elements of ``StandardGate``.
+/// * Behavior is undefined if ``entanglement_blocks`` is not a valid, non-null pointer
+///   to a sequence of ``entanglement_blocks_size`` consecutive elements of ``StandardGate``.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_circuit_library_n_local(
     num_qubits: u32,

--- a/crates/cext/src/circuit_library/n_local.rs
+++ b/crates/cext/src/circuit_library/n_local.rs
@@ -46,18 +46,18 @@ pub enum EntanglementStrategy {
     /// number of qubits.
     ReverseLinear = 2,
     /// Entanglement shifted-circular-alternating. It's a generalized and modified
-    /// version of the proposed circuit 14 in 
+    /// version of the proposed circuit 14 in
     /// [Sim et al.](https://arxiv.org/abs/1905.10876)
     /// It consists of circular entanglement where the "long" entanglement connecting
     /// the first with the last qubit is shifted by one each block.  
-    /// Furthermore the role of control and target qubits are swapped every block 
+    /// Furthermore the role of control and target qubits are swapped every block
     /// (therefore alternating).
     Sca = 3,
     /// Entanglement that behaves the same as linear entanglement but with an additional
     /// entanglement of the first and last qubit before the linear part.
     Circular = 4,
     /// Entanglement where one layer contains a qubit \f$i\f$ entangled with
-    /// qubit \f$i + 1\f$, for all even values of \f$i\f$, and then a second layer 
+    /// qubit \f$i + 1\f$, for all even values of \f$i\f$, and then a second layer
     /// where a qubit \f$i\f$ is entangled with qubit \f$i + 1\f$, for all odd values of
     /// \f$i\f$.
     Pairwise = 5,
@@ -137,20 +137,20 @@ pub enum EntanglementStrategy {
 /// qk_entanglement_free(entanglement);
 /// qk_circuit_free(qc);
 /// ```
-/// 
+///
 /// If an entanglement layer contains multiple blocks, then the entanglement can be
 /// given as list of entanglement strategies for each block.
 /// ```c
 /// size_t num_qubits = 2;
 /// int reps = 2;
-/// 
+///
 /// QkGate rotation_blocks[2] = {QkGate_H, QkGate_X};
 /// QkGate entanglement_blocks[2] = {QkGate_CCX, QkGate_CSwap};
-/// 
+///
 /// // linear for CCX and reverse linear for CSwap
 /// QkEntanglementStrategy strategies[2] = {QkEntanglementStrategy_Linear,
 ///                                         QkEntanglementStrategy_ReverseLinear};
-/// 
+///
 /// QkEntanglement *entanglement = qk_get_entanglement_with_multiple_strategy(
 ///     num_qubits, reps, strategies, 2, entanglement_blocks, 2);
 /// QkCircuit *qc = qk_n_local(rotation_blocks, 2, entanglement_blocks, 2,
@@ -160,7 +160,7 @@ pub enum EntanglementStrategy {
 /// qk_entanglement_free(entanglement);
 /// qk_circuit_free(qc);
 /// ```
-/// 
+///
 /// # Safety
 ///
 /// Behavior is undefined if ``entanglement`` is not either null
@@ -254,7 +254,7 @@ pub unsafe extern "C" fn qk_n_local(
 }
 
 /// @ingroup QkCircuitLibrary
-/// Construct a new ``QkQubitConnection`` representing the entanglement between 
+/// Construct a new ``QkQubitConnection`` representing the entanglement between
 /// qubits where a multi-qubit gate acts on.
 ///
 /// @param num_qubits The size of the qubits connections array.
@@ -270,7 +270,7 @@ pub unsafe extern "C" fn qk_n_local(
 ///
 /// # Safety
 ///
-/// Behavior is undefined ``qubit_connections`` is not a valid, 
+/// Behavior is undefined ``qubit_connections`` is not a valid,
 /// non-null pointer to a ``uint32_t`` array.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_qubit_connection_new(
@@ -333,7 +333,7 @@ pub unsafe extern "C" fn qk_qubit_connection_equal(
 ///
 /// # Safety
 ///
-/// Behavior is undefined if ``qubit_connection`` is not 
+/// Behavior is undefined if ``qubit_connection`` is not
 /// either null or a valid pointer to a ``QubitConnection``.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_qubit_connection_free(qubit_connection: *mut QubitConnection) {
@@ -368,7 +368,7 @@ pub unsafe extern "C" fn qk_qubit_connection_free(qubit_connection: *mut QubitCo
 ///
 /// # Safety
 ///
-/// Behavior is undefined if ``entanglement`` is not 
+/// Behavior is undefined if ``entanglement`` is not
 /// either null or a valid pointer to a ``QkEntanglement``.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_entanglement_free(entanglement: *mut Entanglement) {
@@ -409,7 +409,7 @@ pub unsafe extern "C" fn qk_entanglement_free(entanglement: *mut Entanglement) {
 ///
 /// # Safety
 ///
-/// Behavior is undefined if ``entanglement`` is not 
+/// Behavior is undefined if ``entanglement`` is not
 /// either null or a valid pointer to a ``QkEntanglement``.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_get_entanglement_layers_quantity(
@@ -445,7 +445,7 @@ pub unsafe extern "C" fn qk_get_entanglement_layers_quantity(
 ///
 /// # Safety
 ///
-/// Behavior is undefined if ``entanglement`` is not 
+/// Behavior is undefined if ``entanglement`` is not
 /// either null or a valid pointer to a ``QkEntanglement``.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_get_entanglement_layer_blocks_quantity(
@@ -458,7 +458,7 @@ pub unsafe extern "C" fn qk_get_entanglement_layer_blocks_quantity(
 }
 
 /// @ingroup QkCircuitLibrary
-/// Obtain the ``QkQubitConnection`` count on a given layer 
+/// Obtain the ``QkQubitConnection`` count on a given layer
 /// and block in the provided ``QkEntanglement``.
 ///
 /// @param entanglement A pointer to the ``QkEntanglement`` object.
@@ -484,7 +484,7 @@ pub unsafe extern "C" fn qk_get_entanglement_layer_blocks_quantity(
 ///
 /// # Safety
 ///
-/// Behavior is undefined if ``entanglement`` is not 
+/// Behavior is undefined if ``entanglement`` is not
 /// either null or a valid pointer to a ``QkEntanglement``.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_get_entanglement_qubit_connections_quantity(
@@ -498,13 +498,13 @@ pub unsafe extern "C" fn qk_get_entanglement_qubit_connections_quantity(
 }
 
 /// @ingroup QkCircuitLibrary
-/// Obtain the ``QkQubitConnection`` object at a given 
+/// Obtain the ``QkQubitConnection`` object at a given
 /// layer and block in the provided ``QkEntanglement``.
 ///
 /// @param entanglement A pointer to the ``QkEntanglement`` object.
 /// @param layer_index The layer index where the ``QkQubitConnection`` object exists.
 /// @param block_index The block index in the layer where the ``QkQubitConnection`` object exists.
-/// @param connection_index The ``QkQubitConnection`` object index where 
+/// @param connection_index The ``QkQubitConnection`` object index where
 /// the multi-qubit gate acts on.
 ///
 /// @return A pointer to the obtained ``QkQubitConnection``.
@@ -527,7 +527,7 @@ pub unsafe extern "C" fn qk_get_entanglement_qubit_connections_quantity(
 ///
 /// # Safety
 ///
-/// Behavior is undefined if ``entanglement`` is not 
+/// Behavior is undefined if ``entanglement`` is not
 /// either null or a valid pointer to a ``QkEntanglement``.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_get_entanglement_qubit_connections(
@@ -548,7 +548,7 @@ pub unsafe extern "C" fn qk_get_entanglement_qubit_connections(
 ///
 /// @param num_qubits The number of qubits of the circuit
 /// @param reps Specifies how often the entanglement blocks are repeated.
-/// @param entanglement_strategy List of enum items describing an entanglement 
+/// @param entanglement_strategy List of enum items describing an entanglement
 ///   strategy for each layer.
 /// @param entanglement_strategy_size Length of the entanglement strategy list provided
 /// @param entanglement_blocks The blocks used in the entanglement layers.
@@ -558,9 +558,9 @@ pub unsafe extern "C" fn qk_get_entanglement_qubit_connections(
 ///
 /// # Safety
 ///
-/// Behavior is undefined ``entanglement_strategy`` is not a valid, 
+/// Behavior is undefined ``entanglement_strategy`` is not a valid,
 /// non-null pointer to a ``QkEntanglementStrategy`` array.
-/// Behavior is undefined ``entanglement_blocks`` is not a valid, 
+/// Behavior is undefined ``entanglement_blocks`` is not a valid,
 /// non-null pointer to a ``StandardGate`` array.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_get_entanglement_with_multiple_strategy(
@@ -616,7 +616,7 @@ pub unsafe extern "C" fn qk_get_entanglement_with_multiple_strategy(
 ///
 /// # Safety
 ///
-/// Behavior is undefined ``entanglement_blocks`` is not a valid, 
+/// Behavior is undefined ``entanglement_blocks`` is not a valid,
 /// non-null pointer to a ``QkGate`` array.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_get_entanglement_with_strategy(

--- a/crates/cext/src/circuit_library/n_local.rs
+++ b/crates/cext/src/circuit_library/n_local.rs
@@ -699,10 +699,10 @@ fn get_block_qubit_connections_with_strategy(
             num_qubits,
             gate.get_num_qubits(),
             entanglement_strategy,
-            if offset.is_some() { offset.unwrap() } else { 0 },
+            offset.unwrap_or(0),
         )
         .unwrap()
-        .map(|connections| QubitConnection(connections))
+        .map(QubitConnection)
         .collect(),
     )
 }

--- a/crates/cext/src/circuit_library/n_local.rs
+++ b/crates/cext/src/circuit_library/n_local.rs
@@ -52,12 +52,16 @@ pub unsafe extern "C" fn qk_n_local(
     insert_barriers: bool,
     skip_final_rotation_layer: bool,
 ) -> *mut CircuitData {
-    // SAFETY: Per documentation, the pointer is non-null and aligned.
-    let parameter_prefix = unsafe {
-        CStr::from_ptr(parameter_prefix)
-            .to_str()
-            .expect("Invalid UTF-8 character")
-            .to_string()
+    let parameter_prefix = if parameter_prefix.is_null() {
+        "θ".to_string()
+    } else {
+        // SAFETY: Per documentation, the pointer is non-null and aligned.
+        unsafe {
+            CStr::from_ptr(parameter_prefix)
+                .to_str()
+                .expect("Invalid UTF-8 character")
+                .to_string()
+        }
     };
 
     // SAFETY: per documentation, `rotation_blocks` is aligned and and points to a valid
@@ -105,7 +109,7 @@ pub unsafe extern "C" fn qk_n_local(
         &rotation_blocks.iter().collect::<Vec<&Block>>(),
         &entanglement_blocks.iter().collect::<Vec<&Block>>(),
         &entanglement,
-        reps as usize,
+        reps,
         insert_barriers,
         &parameter_prefix,
         skip_final_rotation_layer,
@@ -191,7 +195,7 @@ pub unsafe extern "C" fn qk_qubit_connection_equal(
 ///
 /// @param num_qubits The number of qubits of the circuit
 /// @param reps Specifies how often the entanglement blocks are repeated.
-/// @param entanglement_strategy List of strings describing an entanglement strategy for each layer.
+/// @param entanglement_strategy List of enum items describing an entanglement strategy for each layer.
 /// @param entanglement_strategy_size Length of the entanglement strategy list provided
 /// @param entanglement_blocks The blocks used in the entanglement layers.
 /// @param entanglement_blocks_size Length of the list of entanglement blocks provided

--- a/crates/cext/src/circuit_library/n_local.rs
+++ b/crates/cext/src/circuit_library/n_local.rs
@@ -1,0 +1,285 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use crate::pointers::const_ptr_as_ref;
+use qiskit_circuit::circuit_data::CircuitData;
+use qiskit_circuit::operations::StandardGate;
+use qiskit_circuit_library::blocks::{Block, Entanglement as CoreEntanglement};
+use qiskit_circuit_library::entanglement::get_entanglement_from_str;
+use qiskit_circuit_library::multi_local::n_local;
+use qiskit_circuit_library::parameter_ledger::ParameterLedgerBuilder;
+use std::ffi::{CStr, c_char};
+
+// Opaque structs for FFI compatibility
+pub struct QubitConnection(Vec<u32>);
+pub struct BlockQubitConnection(Vec<QubitConnection>);
+pub struct LayerEntanglement(Vec<BlockQubitConnection>);
+pub struct Entanglement(Vec<LayerEntanglement>);
+
+#[repr(C)]
+pub enum EntanglementStrategy {
+    Full,
+    Linear,
+    ReverseLinear,
+    Sca,
+    Circular,
+    Pairwise,
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_n_local(
+    rotation_blocks: *const StandardGate,
+    rotation_blocks_size: usize,
+    entanglement_blocks: *const StandardGate,
+    entanglement_blocks_size: usize,
+    entanglement: *mut Entanglement,
+    num_qubits: u32,
+    reps: usize,
+    parameter_prefix: *const c_char,
+    insert_barriers: bool,
+    skip_final_rotation_layer: bool,
+) -> *mut CircuitData {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let parameter_prefix = unsafe {
+        CStr::from_ptr(parameter_prefix)
+            .to_str()
+            .expect("Invalid UTF-8 character")
+            .to_string()
+    };
+
+    // SAFETY: per documentation, `rotation_blocks` is aligned and and points to a valid
+    // aligned block of memory valid for `num_rotation_blocks` writes of `Block`s
+    let rotation_blocks: Vec<Block> =
+        unsafe { ::std::slice::from_raw_parts(rotation_blocks, rotation_blocks_size) }
+            .iter()
+            .map(|gate| Block::from_standard_gate(*gate))
+            .collect();
+
+    // SAFETY: per documentation, `entanglement_blocks` is aligned and and points to a valid
+    // aligned block of memory valid for `num_entanglement_blocks` writes of `Block`s
+    let entanglement_blocks: Vec<Block> =
+        unsafe { ::std::slice::from_raw_parts(entanglement_blocks, entanglement_blocks_size) }
+            .iter()
+            .map(|gate| Block::from_standard_gate(*gate))
+            .collect();
+
+    // SAFETY: per documentation, `entanglement` points to valid data.
+    let entanglement = CoreEntanglement {
+        entanglement_vec: unsafe {
+            const_ptr_as_ref(entanglement)
+                .0
+                .iter()
+                .map(|layer| {
+                    layer
+                        .0
+                        .iter()
+                        .map(|block_entanglement| {
+                            block_entanglement
+                                .0
+                                .iter()
+                                .map(|connection| connection.0.clone())
+                                .collect()
+                        })
+                        .collect()
+                })
+                .collect()
+        },
+    };
+
+    match n_local(
+        ParameterLedgerBuilder,
+        num_qubits,
+        &rotation_blocks.iter().collect::<Vec<&Block>>(),
+        &entanglement_blocks.iter().collect::<Vec<&Block>>(),
+        &entanglement,
+        reps as usize,
+        insert_barriers,
+        &parameter_prefix,
+        skip_final_rotation_layer,
+        false,
+    ) {
+        Ok(circuit) => Box::into_raw(Box::new(circuit)),
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+/// @ingroup QkCircuitLibrary
+/// Generate an entanglement following the provided strategies.
+///
+/// @param num_qubits The number of qubits of the circuit
+/// @param reps Specifies how often the rotation blocks and entanglement blocks are repeated.
+/// @param entanglement_strategy List of strings describing an entanglement strategy for each layer.
+/// @param entanglement_strategy_size Length of the entanglement strategy list provided
+/// @param entanglement_blocks The blocks used in the entanglement layers.
+/// @param entanglement_blocks_size Length of the list of entanglement blocks provided
+///
+///
+///
+/// # Safety
+///
+/// Behavior is undefined ``entanglement_strategy`` is not a valid, non-null pointer to a ``QkEntanglementStrategy`` array.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_get_entanglement_with_multiple_strategy(
+    num_qubits: u32,
+    reps: usize,
+    entanglement_strategy: *const EntanglementStrategy,
+    entanglement_strategy_size: usize,
+    entanglement_blocks: *const StandardGate,
+    entanglement_blocks_size: usize,
+) -> *mut Entanglement {
+    if entanglement_strategy_size != entanglement_blocks_size {
+        panic!(
+            "Number of block-entanglements {:?} must match number of entanglement blocks {:?}",
+            entanglement_strategy_size, entanglement_blocks_size
+        )
+    }
+
+    // SAFETY: per documentation, `entanglement_blocks` is aligned and and points to a valid
+    // aligned block of memory valid for `entanglement_blocks_size` writes of `StandardGate`s
+    let entanglement_blocks: Vec<&StandardGate> = unsafe {
+        ::std::slice::from_raw_parts(entanglement_blocks, entanglement_blocks_size)
+            .iter()
+            .collect()
+    };
+
+    // SAFETY: per documentation, `entanglement_strategy` is aligned and and points to a valid
+    // aligned block of memory valid for `entanglement_strategy_size` writes of `EntanglementStrategy`s
+    let entanglement_strategy: Vec<&str> = unsafe {
+        ::std::slice::from_raw_parts(entanglement_strategy, entanglement_strategy_size)
+            .iter()
+            .map(|strategy| get_entanglement_strategy(strategy))
+            .collect()
+    };
+
+    Box::into_raw(Box::new(get_entanglement_with_strategy(
+        num_qubits,
+        &entanglement_blocks,
+        &entanglement_strategy,
+        reps,
+    )))
+}
+
+/// @ingroup QkCircuitLibrary
+/// Generate an entanglement following the provided strategies.
+///
+/// @param num_qubits The number of qubits of the circuit
+/// @param reps Specifies how often the rotation blocks and entanglement blocks are repeated.
+/// @param entanglement_strategy The entanglement strategy to apply for each layer.
+/// @param entanglement_blocks The blocks used in the entanglement layers.
+/// @param entanglement_blocks_size Length of the list of entanglement blocks provided.
+///
+///
+///
+/// # Safety
+///
+/// Behavior is undefined ``entanglement_blocks`` is not a valid, non-null pointer to a ``QkGate`` array.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_get_entanglement_with_strategy(
+    num_qubits: u32,
+    reps: usize,
+    entanglement_strategy: EntanglementStrategy,
+    entanglement_blocks: *const StandardGate,
+    entanglement_blocks_size: usize,
+) -> *mut Entanglement {
+    // SAFETY: per documentation, `entanglement_blocks` is aligned and and points to a valid
+    // aligned block of memory valid for `entanglement_blocks_size` writes of `StandardGate`s
+    let entanglement_blocks: Vec<&StandardGate> = unsafe {
+        ::std::slice::from_raw_parts(entanglement_blocks, entanglement_blocks_size)
+            .iter()
+            .collect()
+    };
+
+    let entanglement_strategy: Vec<&str> = (0..reps)
+        .map(|_| get_entanglement_strategy(&entanglement_strategy))
+        .collect();
+
+    Box::into_raw(Box::new(get_entanglement_with_strategy(
+        num_qubits,
+        &entanglement_blocks,
+        &entanglement_strategy,
+        reps,
+    )))
+}
+
+fn get_entanglement_with_strategy(
+    num_qubits: u32,
+    entanglement_blocks: &[&StandardGate],
+    entanglement_strategy: &[&str],
+    reps: usize,
+) -> Entanglement {
+    Entanglement(
+        (0..reps)
+            .zip(entanglement_strategy)
+            .map(|(layer, strategy)| {
+                get_layer_entanglement_with_strategy(
+                    num_qubits,
+                    &entanglement_blocks,
+                    strategy,
+                    layer,
+                )
+            })
+            .collect(),
+    )
+}
+
+fn get_layer_entanglement_with_strategy(
+    num_qubits: u32,
+    entanglement_blocks: &[&StandardGate],
+    entanglement_strategy: &str,
+    layer_index: usize,
+) -> LayerEntanglement {
+    LayerEntanglement(
+        entanglement_blocks
+            .iter()
+            .map(|gate| {
+                get_block_qubit_connections_with_strategy(
+                    num_qubits,
+                    gate,
+                    entanglement_strategy,
+                    (entanglement_strategy == "sca").then_some(layer_index),
+                )
+            })
+            .collect(),
+    )
+}
+
+fn get_block_qubit_connections_with_strategy(
+    num_qubits: u32,
+    gate: &StandardGate,
+    entanglement_strategy: &str,
+    offset: Option<usize>,
+) -> BlockQubitConnection {
+    BlockQubitConnection(
+        get_entanglement_from_str(
+            num_qubits,
+            gate.get_num_qubits(),
+            entanglement_strategy,
+            if offset.is_some() { offset.unwrap() } else { 0 },
+        )
+        .unwrap()
+        .map(|connections| QubitConnection(connections))
+        .collect(),
+    )
+}
+
+fn get_entanglement_strategy(entanglement_strategy: &EntanglementStrategy) -> &'static str {
+    match entanglement_strategy {
+        EntanglementStrategy::Full => "full",
+        EntanglementStrategy::Linear => "linear",
+        EntanglementStrategy::ReverseLinear => "reverse_linear",
+        EntanglementStrategy::Sca => "sca",
+        EntanglementStrategy::Circular => "circular",
+        EntanglementStrategy::Pairwise => "pairwise",
+    }
+}

--- a/crates/cext/src/circuit_library/n_local.rs
+++ b/crates/cext/src/circuit_library/n_local.rs
@@ -33,18 +33,18 @@ pub struct LayerEntanglement(Vec<BlockQubitConnection>);
 pub struct Entanglement(Vec<LayerEntanglement>);
 
 /// Enum representing all the possible strategies for n_local entanglement blocks.
-#[repr(C)]
+#[repr(u8)]
 pub enum EntanglementStrategy {
     /// Entanglement where each qubit is entangled with all the others.
-    Full,
+    Full = 0,
     /// Entanglement where qubit \f$i\f$ is entangled with qubit \f$i + 1\f$
     /// for all \f$i \in \{0, 1, ... , n - 2\}\f$ where \f$n\f$ is the total
     /// number of qubits.
-    Linear,
+    Linear = 1,
     /// Entanglement where qubit \f$i\f$ is entangled with qubit \f$i + 1\f$
     /// for all \f$i \in \{n-2, n-3, ... , 1, 0\}\f$ where \f$n\f$ is the total
     /// number of qubits.
-    ReverseLinear,
+    ReverseLinear = 2,
     /// Entanglement shifted-circular-alternating. It's a generalized and modified
     /// version of the proposed circuit 14 in 
     /// [Sim et al.](https://arxiv.org/abs/1905.10876)
@@ -52,15 +52,15 @@ pub enum EntanglementStrategy {
     /// the first with the last qubit is shifted by one each block.  
     /// Furthermore the role of control and target qubits are swapped every block 
     /// (therefore alternating).
-    Sca,
+    Sca = 3,
     /// Entanglement that behaves the same as linear entanglement but with an additional
     /// entanglement of the first and last qubit before the linear part.
-    Circular,
+    Circular = 4,
     /// Entanglement where one layer contains a qubit \f$i\f$ entangled with
     /// qubit \f$i + 1\f$, for all even values of \f$i\f$, and then a second layer 
     /// where a qubit \f$i\f$ is entangled with qubit \f$i + 1\f$, for all odd values of
     /// \f$i\f$.
-    Pairwise,
+    Pairwise = 5,
 }
 
 /// @ingroup QkCircuitLibrary

--- a/crates/cext/src/circuit_library/n_local.rs
+++ b/crates/cext/src/circuit_library/n_local.rs
@@ -10,27 +10,42 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::pointers::const_ptr_as_ref;
+use crate::pointers::{check_ptr, const_ptr_as_ref};
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::operations::StandardGate;
-use qiskit_circuit_library::blocks::{Block, Entanglement as CoreEntanglement};
+use qiskit_circuit_library::blocks::{Block, Entanglement};
 use qiskit_circuit_library::entanglement::get_entanglement_from_str;
 use qiskit_circuit_library::multi_local::n_local;
 use qiskit_circuit_library::parameter_ledger::ParameterLedgerBuilder;
-use std::ffi::{CStr, c_char};
+use std::ffi::{CStr, CString, c_char};
 
-// Opaque structs for FFI compatibility
-/// QubitConnection: Indices that the multi-qubit gate acts on
-#[derive(Debug, Clone)]
-pub struct QubitConnection(Vec<u32>);
+#[repr(C)]
+pub struct NLocalSettings {
+    /// The entanglement strategy to be used in the generated circuit.
+    /// See ``QkEntanglementStrategy`` for more details.
+    entanglement_strategy: EntanglementStrategy,
+    /// Specifies how often the rotation blocks and entanglement blocks are repeated.
+    reps: usize,
+    /// The prefix used for the default parameters generated.
+    parameter_prefix: *const c_char,
+    /// If ``true``, barriers are inserted in between each layer.
+    /// If ``false``, no barriers are inserted.
+    insert_barriers: bool,
+    /// Whether a final rotation layer is added to the circuit.
+    skip_final_rotation_layer: bool,
+}
 
-/// BlockQubitConnection: Entanglement for single block
-pub struct BlockQubitConnection(Vec<QubitConnection>);
-
-/// LayerEntanglement: Entanglements for all blocks in the layer
-pub struct LayerEntanglement(Vec<BlockQubitConnection>);
-/// Entanglement: Entanglement for every layer
-pub struct Entanglement(Vec<LayerEntanglement>);
+impl Default for NLocalSettings {
+    fn default() -> Self {
+        Self {
+            entanglement_strategy: EntanglementStrategy::Full,
+            reps: 3,
+            parameter_prefix: CString::new("θ").unwrap().into_raw(),
+            insert_barriers: false,
+            skip_final_rotation_layer: false,
+        }
+    }
+}
 
 /// Enum representing all the possible strategies for n_local entanglement blocks.
 #[repr(u8)]
@@ -105,59 +120,30 @@ pub enum EntanglementStrategy {
 /// gate should acts, e.g. ``[[ctrl0, target0], [ctrl1, target1], ...]``.
 /// To know more about the available entanglement strategies see ``QkEntanglementStrategy``.
 ///
+/// @param num_qubits The number of qubits of the circuit.
 /// @param rotation_blocks The blocks used in the rotation layers.
 /// @param rotation_blocks_size Length of the array of rotation blocks provided.
 /// @param entanglement_blocks The blocks used in the entanglement layers.
 /// @param entanglement_blocks_size Length of the list of entanglement blocks provided.
-/// @param entanglement A pointer to the ``QkEntanglement`` that contains the indices where the
-///   entanglement blocks act.
-/// @param num_qubits The number of qubits of the circuit.
-/// @param reps Specifies how often the rotation blocks and entanglement blocks are repeated.
-/// @param parameter_prefix The prefix used for the default parameters generated.
-/// @param insert_barriers If ``true``, barriers are inserted in between each layer. If ``false``,
-///   no barriers are inserted.
-/// @param skip_final_rotation_layer Whether a final rotation layer is added to the circuit.
+/// @param settings A ``QkNLocalSettings`` pointer that is the settings to be applied
+///    to the generated circuit. See ``QkNLocalSettings`` for more details.
 ///
 /// @return A pointer to the generated circuit.
 ///
 /// # Example
 /// ```c
 /// size_t num_qubits = 2;
-/// int reps = 2;
 /// QkGate rotation_blocks[1] = {QkGate_H};
 /// QkGate entanglement_blocks[1] = {QkGate_CRX};
 ///
-/// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
-///     num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
+/// QkNLocalSettings settings = qk_circuit_library_n_local_settings_default();
+/// settings.reps = 2;
+/// // For this example we use QkEntanglementStrategy_Linear since 
+/// // the default is QkEntanglementStrategy_Full
+/// settings.entanglement_strategy = QkEntanglementStrategy_Linear;
 ///
-/// QkCircuit *qc = qk_n_local(rotation_blocks, 1, entanglement_blocks, 1,
-///                            entanglement, num_qubits,
-///                            reps, NULL, false, false);
+/// QkCircuit *qc = qk_circuit_library_n_local(num_qubits, rotation_blocks, 1, entanglement_blocks, 1, &settings);
 ///
-/// qk_entanglement_free(entanglement);
-/// qk_circuit_free(qc);
-/// ```
-///
-/// If an entanglement layer contains multiple blocks, then the entanglement can be
-/// given as list of entanglement strategies for each block.
-/// ```c
-/// size_t num_qubits = 2;
-/// int reps = 2;
-///
-/// QkGate rotation_blocks[2] = {QkGate_H, QkGate_X};
-/// QkGate entanglement_blocks[2] = {QkGate_CCX, QkGate_CSwap};
-///
-/// // linear for CCX and reverse linear for CSwap
-/// QkEntanglementStrategy strategies[2] = {QkEntanglementStrategy_Linear,
-///                                         QkEntanglementStrategy_ReverseLinear};
-///
-/// QkEntanglement *entanglement = qk_get_entanglement_with_multiple_strategy(
-///     num_qubits, reps, strategies, 2, entanglement_blocks, 2);
-/// QkCircuit *qc = qk_n_local(rotation_blocks, 2, entanglement_blocks, 2,
-///                            entanglement, num_qubits,
-///                            reps, NULL, false, false);
-///
-/// qk_entanglement_free(entanglement);
 /// qk_circuit_free(qc);
 /// ```
 ///
@@ -173,79 +159,64 @@ pub enum EntanglementStrategy {
 /// nul terminator at the end of the string. It also must be valid for reads of
 /// bytes up to and including the nul terminator.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_n_local(
+pub unsafe extern "C" fn qk_circuit_library_n_local(
+    num_qubits: u32,
     rotation_blocks: *const StandardGate,
     rotation_blocks_size: usize,
     entanglement_blocks: *const StandardGate,
     entanglement_blocks_size: usize,
-    entanglement: *mut Entanglement,
-    num_qubits: u32,
-    reps: usize,
-    parameter_prefix: *const c_char,
-    insert_barriers: bool,
-    skip_final_rotation_layer: bool,
+    settings: *const NLocalSettings,
 ) -> *mut CircuitData {
-    let parameter_prefix = if parameter_prefix.is_null() {
-        "θ".to_string()
-    } else {
-        // SAFETY: Per documentation, the pointer is non-null and aligned.
-        unsafe {
-            CStr::from_ptr(parameter_prefix)
-                .to_str()
-                .expect("Invalid UTF-8 character")
-                .to_string()
-        }
-    };
-
     // SAFETY: per documentation, `rotation_blocks` is aligned and and points to a valid
-    // aligned block of memory valid for `num_rotation_blocks` writes of `Block`s
+    // aligned block of memory valid for `num_rotation_blocks` writes of `StandardGate`s
     let rotation_blocks: Vec<Block> =
         unsafe { ::std::slice::from_raw_parts(rotation_blocks, rotation_blocks_size) }
             .iter()
-            .map(|gate| Block::from_standard_gate(*gate))
+            .map(|&gate| Block::from_standard_gate(gate))
             .collect();
+    let rotation_blocks: Vec<&Block> = rotation_blocks.iter().collect();
 
     // SAFETY: per documentation, `entanglement_blocks` is aligned and and points to a valid
-    // aligned block of memory valid for `num_entanglement_blocks` writes of `Block`s
+    // aligned block of memory valid for `num_entanglement_blocks` writes of `StandardGate`s
     let entanglement_blocks: Vec<Block> =
         unsafe { ::std::slice::from_raw_parts(entanglement_blocks, entanglement_blocks_size) }
             .iter()
-            .map(|gate| Block::from_standard_gate(*gate))
+            .map(|&gate| Block::from_standard_gate(gate))
             .collect();
+    let entanglement_blocks: Vec<&Block> = entanglement_blocks.iter().collect();
 
-    // SAFETY: per documentation, `entanglement` points to valid data.
-    let entanglement = CoreEntanglement {
-        entanglement_vec: unsafe {
-            const_ptr_as_ref(entanglement)
-                .0
-                .iter()
-                .map(|layer| {
-                    layer
-                        .0
-                        .iter()
-                        .map(|block_entanglement| {
-                            block_entanglement
-                                .0
-                                .iter()
-                                .map(|connection| connection.0.clone())
-                                .collect()
-                        })
-                        .collect()
-                })
-                .collect()
-        },
+    let (settings, parameter_prefix) = if settings.is_null() {
+        (&NLocalSettings::default(), "θ")
+    } else {
+        // SAFETY: Per documentation, the pointer is non-null and aligned.
+        let settings = unsafe { const_ptr_as_ref(settings) };
+        (settings, unsafe {
+            // SAFETY: Per documentation, the pointer is non-null and aligned.
+            check_ptr(settings.parameter_prefix).expect("Parameter prefix must not be null");
+            CStr::from_ptr(settings.parameter_prefix)
+                .to_str()
+                .expect("Invalid UTF-8 character")
+        })
     };
+
+    let entanglement = get_entanglement_strategy(&settings.entanglement_strategy);
+    let entanglement = get_entanglement_with_strategy(
+        num_qubits,
+        &entanglement_blocks,
+        &entanglement,
+        settings.reps,
+    );
 
     match n_local(
         ParameterLedgerBuilder,
         num_qubits,
-        &rotation_blocks.iter().collect::<Vec<&Block>>(),
-        &entanglement_blocks.iter().collect::<Vec<&Block>>(),
+        &rotation_blocks,
+        &entanglement_blocks,
         &entanglement,
-        reps,
-        insert_barriers,
+        settings.reps,
+        settings.insert_barriers,
         &parameter_prefix,
-        skip_final_rotation_layer,
+        settings.skip_final_rotation_layer,
         false,
     ) {
         Ok(circuit) => Box::into_raw(Box::new(circuit)),
@@ -254,406 +225,25 @@ pub unsafe extern "C" fn qk_n_local(
 }
 
 /// @ingroup QkCircuitLibrary
-/// Construct a new ``QkQubitConnection`` representing the entanglement between
-/// qubits where a multi-qubit gate acts on.
 ///
-/// @param num_qubits The size of the qubits connections array.
-/// @param qubit_connections The qubits connections array.
+/// Generate n_local options defaults
 ///
-/// @return A pointer to the created ``QkQubitConnection``.
+/// This function generates a ``QkNLocalSettings`` with the default settings
 ///
-/// # Example
-///
-/// ```c
-/// QkQubitConnection *qconn = qk_qubit_connection_new((uint32_t[2]){0, 1}, 2);
-/// ```
-///
-/// # Safety
-///
-/// Behavior is undefined ``qubit_connections`` is not a valid,
-/// non-null pointer to a ``uint32_t`` array.
+/// @return A ``QkNLocalSettings`` object with default settings.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_qubit_connection_new(
-    num_qubits: usize,
-    qubit_connections: *const u32,
-) -> *mut QubitConnection {
-    // SAFETY: per documentation, `qubit_connections` is aligned and and points to a valid
-    // aligned block of memory valid for `qubit_connections_size` writes of `u32`s
-    let qubits: Vec<u32> =
-        unsafe { ::std::slice::from_raw_parts(qubit_connections, num_qubits).to_vec() };
-    Box::into_raw(Box::new(QubitConnection(qubits)))
-}
-
-/// @ingroup QkCircuitLibrary
-/// Compare two ``QkQubitConnection`` for equality.
-///
-/// @param c1 A pointer to the left hand side ``QkQubitConnection``.
-/// @param c2 A pointer to the right hand side ``QkQubitConnection``.
-///
-/// @return ``true`` if the ``QkQubitConnection`` objects are equal, ``false`` otherwise.
-///
-/// # Example
-///
-/// ```c
-/// QkQubitConnection *qconn = qk_qubit_connection_new((uint32_t[2]){0, 1}, 2);
-/// QkQubitConnection *qconn2 = qk_qubit_connection_new((uint32_t[2]){0, 1}, 2);
-///
-/// bool equal = qk_qubit_connection_equal(qconn, qconn2);
-/// ```
-///
-/// # Safety
-///
-/// The behavior is undefined if any of ``c1`` or ``c2`` is not a valid, non-null
-/// pointer to a ``QkQubitConnection``.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_qubit_connection_equal(
-    c1: *const QubitConnection,
-    c2: *const QubitConnection,
-) -> bool {
-    // SAFETY: Per documentation, the pointer is non-null and aligned.
-    let c1 = unsafe { const_ptr_as_ref(c1) };
-
-    // SAFETY: Per documentation, the pointer is non-null and aligned.
-    let c2 = unsafe { const_ptr_as_ref(c2) };
-
-    c1.0.eq(&c2.0)
-}
-
-/// @ingroup QkCircuitLibrary
-/// Free the ``QkQubitConnection``.
-///
-/// @param qubit_connection A pointer to the ``QkQubitConnection`` to free.
-///
-/// # Example
-///
-/// ```c
-/// QkQubitConnection *qconn = qk_qubit_connection_new((uint32_t[2]){0, 1}, 2);
-/// qk_qubit_connection_free(qconn);
-/// ```
-///
-/// # Safety
-///
-/// Behavior is undefined if ``qubit_connection`` is not
-/// either null or a valid pointer to a ``QubitConnection``.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_qubit_connection_free(qubit_connection: *mut QubitConnection) {
-    if !qubit_connection.is_null() {
-        if !qubit_connection.is_aligned() {
-            panic!("Attempted to free a non-aligned pointer.")
-        }
-
-        // SAFETY: We have verified the pointer is non-null and aligned, so it should be
-        // readable by Box.
-        unsafe {
-            let _ = Box::from_raw(qubit_connection);
-        }
-    }
-}
-
-/// @ingroup QkCircuitLibrary
-/// Free the ``QkEntanglement``.
-///
-/// @param entanglement A pointer to the ``QkEntanglement`` to free.
-///
-/// # Example
-///
-/// ```c
-/// int reps = 1;
-/// int num_qubits = 2;
-/// QkGate entanglement_blocks[1] = {QkGate_CRX};
-/// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
-///     num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
-/// qk_entanglement_free(entanglement);
-/// ```
-///
-/// # Safety
-///
-/// Behavior is undefined if ``entanglement`` is not
-/// either null or a valid pointer to a ``QkEntanglement``.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_entanglement_free(entanglement: *mut Entanglement) {
-    if !entanglement.is_null() {
-        if !entanglement.is_aligned() {
-            panic!("Attempted to free a non-aligned pointer.")
-        }
-
-        // SAFETY: We have verified the pointer is non-null and aligned, so it should be
-        // readable by Box.
-        unsafe {
-            let _ = Box::from_raw(entanglement);
-        }
-    }
-}
-
-/// @ingroup QkCircuitLibrary
-/// Obtain the layers count in the provided ``QkEntanglement``.
-///
-/// @param entanglement A pointer to the ``QkEntanglement`` object.
-///
-/// @return The layers count on the provided ``QkEntanglement``.
-///
-/// # Example
-///
-/// ```c
-/// int reps = 1;
-/// int num_qubits = 2;
-/// QkGate entanglement_blocks[1] = {QkGate_CRX};
-/// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
-///     num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
-///
-/// size_t layers_count = qk_get_entanglement_layers_quantity(entanglement);
-///
-/// qk_entanglement_free(entanglement);
-/// ```
-///
-///
-/// # Safety
-///
-/// Behavior is undefined if ``entanglement`` is not
-/// either null or a valid pointer to a ``QkEntanglement``.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_get_entanglement_layers_quantity(
-    entanglement: *const Entanglement,
-) -> usize {
-    // SAFETY: Per documentation, the pointer is non-null and aligned.
-    let entanglement = unsafe { const_ptr_as_ref(entanglement) };
-    entanglement.0.len()
-}
-
-/// @ingroup QkCircuitLibrary
-/// Obtain the blocks count on a given layer in the provided ``QkEntanglement``.
-///
-/// @param entanglement A pointer to the ``QkEntanglement`` object.
-/// @param layer_index The layer index where the blocks are.
-///
-/// @return The blocks count on the given layer.
-///
-/// # Example
-///
-/// ```c
-/// int reps = 1;
-/// int num_qubits = 2;
-/// QkGate entanglement_blocks[1] = {QkGate_CRX};
-/// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
-///     num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
-///
-/// size_t blocks_count = qk_get_entanglement_layer_blocks_quantity(entanglement, 0);
-///
-/// qk_entanglement_free(entanglement);
-/// ```
-///
-///
-/// # Safety
-///
-/// Behavior is undefined if ``entanglement`` is not
-/// either null or a valid pointer to a ``QkEntanglement``.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_get_entanglement_layer_blocks_quantity(
-    entanglement: *const Entanglement,
-    layer_index: usize,
-) -> usize {
-    // SAFETY: Per documentation, the pointer is non-null and aligned.
-    let entanglement = unsafe { const_ptr_as_ref(entanglement) };
-    entanglement.0[layer_index].0.len()
-}
-
-/// @ingroup QkCircuitLibrary
-/// Obtain the ``QkQubitConnection`` count on a given layer
-/// and block in the provided ``QkEntanglement``.
-///
-/// @param entanglement A pointer to the ``QkEntanglement`` object.
-/// @param layer_index The layer index where the ``QkQubitConnection`` objects exist.
-/// @param block_index The block index in the layer where the ``QkQubitConnection`` objects exist.
-///
-/// @return The qubit connections count on the given layer and block.
-///
-/// # Example
-///
-/// ```c
-/// int reps = 1;
-/// int num_qubits = 2;
-/// QkGate entanglement_blocks[1] = {QkGate_CRX};
-/// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
-///     num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
-///
-/// size_t connections_count = qk_get_entanglement_qubit_connections_quantity(entanglement, 0, 0);
-///
-/// qk_entanglement_free(entanglement);
-/// ```
-///
-///
-/// # Safety
-///
-/// Behavior is undefined if ``entanglement`` is not
-/// either null or a valid pointer to a ``QkEntanglement``.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_get_entanglement_qubit_connections_quantity(
-    entanglement: *const Entanglement,
-    layer_index: usize,
-    block_index: usize,
-) -> usize {
-    // SAFETY: Per documentation, the pointer is non-null and aligned.
-    let entanglement = unsafe { const_ptr_as_ref(entanglement) };
-    entanglement.0[layer_index].0[block_index].0.len()
-}
-
-/// @ingroup QkCircuitLibrary
-/// Obtain the ``QkQubitConnection`` object at a given
-/// layer and block in the provided ``QkEntanglement``.
-///
-/// @param entanglement A pointer to the ``QkEntanglement`` object.
-/// @param layer_index The layer index where the ``QkQubitConnection`` object exists.
-/// @param block_index The block index in the layer where the ``QkQubitConnection`` object exists.
-/// @param connection_index The ``QkQubitConnection`` object index where
-/// the multi-qubit gate acts on.
-///
-/// @return A pointer to the obtained ``QkQubitConnection``.
-///
-/// # Example
-///
-/// ```c
-/// int reps = 1;
-/// int num_qubits = 2;
-/// QkGate entanglement_blocks[1] = {QkGate_CRX};
-/// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
-///     num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
-///
-/// QkQubitConnection *connection = qk_get_entanglement_qubit_connections(entanglement, 0, 0, 1);
-///
-/// qk_entanglement_free(entanglement);
-/// qk_qubit_connection_free(connection);
-/// ```
-///
-///
-/// # Safety
-///
-/// Behavior is undefined if ``entanglement`` is not
-/// either null or a valid pointer to a ``QkEntanglement``.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_get_entanglement_qubit_connections(
-    entanglement: *const Entanglement,
-    layer_index: usize,
-    block_index: usize,
-    connection_index: usize,
-) -> *mut QubitConnection {
-    // SAFETY: Per documentation, the pointer is non-null and aligned.
-    let entanglement = unsafe { const_ptr_as_ref(entanglement) };
-    Box::into_raw(Box::new(
-        entanglement.0[layer_index].0[block_index].0[connection_index].clone(),
-    ))
-}
-
-/// @ingroup QkCircuitLibrary
-/// Generate an entanglement following the provided strategies.
-///
-/// @param num_qubits The number of qubits of the circuit
-/// @param reps Specifies how often the entanglement blocks are repeated.
-/// @param entanglement_strategy List of enum items describing an entanglement
-///   strategy for each layer.
-/// @param entanglement_strategy_size Length of the entanglement strategy list provided
-/// @param entanglement_blocks The blocks used in the entanglement layers.
-/// @param entanglement_blocks_size Length of the list of entanglement blocks provided
-///
-/// @return A pointer to the created ``QkEntanglement``.
-///
-/// # Safety
-///
-/// Behavior is undefined ``entanglement_strategy`` is not a valid,
-/// non-null pointer to a ``QkEntanglementStrategy`` array.
-/// Behavior is undefined ``entanglement_blocks`` is not a valid,
-/// non-null pointer to a ``StandardGate`` array.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_get_entanglement_with_multiple_strategy(
-    num_qubits: u32,
-    reps: usize,
-    entanglement_strategy: *const EntanglementStrategy,
-    entanglement_strategy_size: usize,
-    entanglement_blocks: *const StandardGate,
-    entanglement_blocks_size: usize,
-) -> *mut Entanglement {
-    if entanglement_strategy_size != entanglement_blocks_size {
-        panic!(
-            "Number of block-entanglements {:?} must match number of entanglement blocks {:?}",
-            entanglement_strategy_size, entanglement_blocks_size
-        )
-    }
-
-    // SAFETY: per documentation, `entanglement_blocks` is aligned and and points to a valid
-    // aligned block of memory valid for `entanglement_blocks_size` writes of `StandardGate`s
-    let entanglement_blocks: Vec<&StandardGate> = unsafe {
-        ::std::slice::from_raw_parts(entanglement_blocks, entanglement_blocks_size)
-            .iter()
-            .collect()
-    };
-
-    // SAFETY: per documentation, `entanglement_strategy` is aligned and and points to a valid
-    // aligned block of memory valid for `entanglement_strategy_size` writes of `EntanglementStrategy`s
-    let entanglement_strategy: Vec<&str> = unsafe {
-        ::std::slice::from_raw_parts(entanglement_strategy, entanglement_strategy_size)
-            .iter()
-            .map(|strategy| get_entanglement_strategy(strategy))
-            .collect()
-    };
-
-    Box::into_raw(Box::new(get_entanglement_with_strategy(
-        num_qubits,
-        &entanglement_blocks,
-        &entanglement_strategy,
-        reps,
-    )))
-}
-
-/// @ingroup QkCircuitLibrary
-/// Generate an entanglement following the provided strategies.
-///
-/// @param num_qubits The number of qubits of the circuit
-/// @param reps Specifies how often the entanglement blocks are repeated.
-/// @param entanglement_strategy The entanglement strategy to apply for each layer.
-/// @param entanglement_blocks The blocks used in the entanglement layers.
-/// @param entanglement_blocks_size Length of the list of entanglement blocks provided.
-///
-/// @return A pointer to the created ``QkEntanglement``.
-///
-/// # Safety
-///
-/// Behavior is undefined ``entanglement_blocks`` is not a valid,
-/// non-null pointer to a ``QkGate`` array.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_get_entanglement_with_strategy(
-    num_qubits: u32,
-    reps: usize,
-    entanglement_strategy: EntanglementStrategy,
-    entanglement_blocks: *const StandardGate,
-    entanglement_blocks_size: usize,
-) -> *mut Entanglement {
-    // SAFETY: per documentation, `entanglement_blocks` is aligned and and points to a valid
-    // aligned block of memory valid for `entanglement_blocks_size` writes of `StandardGate`s
-    let entanglement_blocks: Vec<&StandardGate> = unsafe {
-        ::std::slice::from_raw_parts(entanglement_blocks, entanglement_blocks_size)
-            .iter()
-            .collect()
-    };
-
-    let entanglement_strategy: Vec<&str> = (0..reps)
-        .map(|_| get_entanglement_strategy(&entanglement_strategy))
-        .collect();
-
-    Box::into_raw(Box::new(get_entanglement_with_strategy(
-        num_qubits,
-        &entanglement_blocks,
-        &entanglement_strategy,
-        reps,
-    )))
+pub extern "C" fn qk_circuit_library_n_local_settings_default() -> NLocalSettings {
+    NLocalSettings::default()
 }
 
 fn get_entanglement_with_strategy(
     num_qubits: u32,
-    entanglement_blocks: &[&StandardGate],
-    entanglement_strategy: &[&str],
+    entanglement_blocks: &[&Block],
+    entanglement_strategy: &str,
     reps: usize,
 ) -> Entanglement {
-    Entanglement(
-        (0..reps)
+    Entanglement {
+        entanglement_vec: (0..reps)
             .map(|layer| {
                 get_layer_entanglement_with_strategy(
                     num_qubits,
@@ -663,48 +253,42 @@ fn get_entanglement_with_strategy(
                 )
             })
             .collect(),
-    )
+    }
 }
 
 fn get_layer_entanglement_with_strategy(
     num_qubits: u32,
-    entanglement_blocks: &[&StandardGate],
-    entanglement_strategy: &[&str],
+    entanglement_blocks: &[&Block],
+    strategy: &str,
     layer_index: usize,
-) -> LayerEntanglement {
-    LayerEntanglement(
-        entanglement_blocks
-            .iter()
-            .zip(entanglement_strategy.iter())
-            .map(|(gate, &strategy)| {
-                get_block_qubit_connections_with_strategy(
-                    num_qubits,
-                    gate,
-                    strategy,
-                    (strategy == "sca").then_some(layer_index),
-                )
-            })
-            .collect(),
-    )
+) -> Vec<Vec<Vec<u32>>> {
+    entanglement_blocks
+        .iter()
+        .map(|gate| {
+            get_block_qubit_connections_with_strategy(
+                num_qubits,
+                gate,
+                strategy,
+                (strategy == "sca").then_some(layer_index),
+            )
+        })
+        .collect()
 }
 
 fn get_block_qubit_connections_with_strategy(
     num_qubits: u32,
-    gate: &StandardGate,
+    gate: &Block,
     entanglement_strategy: &str,
     offset: Option<usize>,
-) -> BlockQubitConnection {
-    BlockQubitConnection(
-        get_entanglement_from_str(
-            num_qubits,
-            gate.get_num_qubits(),
-            entanglement_strategy,
-            offset.unwrap_or(0),
-        )
-        .unwrap()
-        .map(QubitConnection)
-        .collect(),
+) -> Vec<Vec<u32>> {
+    get_entanglement_from_str(
+        num_qubits,
+        gate.num_qubits,
+        entanglement_strategy,
+        offset.unwrap_or(0),
     )
+    .unwrap()
+    .collect()
 }
 
 fn get_entanglement_strategy(entanglement_strategy: &EntanglementStrategy) -> &'static str {

--- a/crates/cext/src/circuit_library/n_local.rs
+++ b/crates/cext/src/circuit_library/n_local.rs
@@ -32,17 +32,145 @@ pub struct LayerEntanglement(Vec<BlockQubitConnection>);
 /// Entanglement: Entanglement for every layer
 pub struct Entanglement(Vec<LayerEntanglement>);
 
-/// Enum representing all the possible strategies for n_local entanglement blocks
+/// Enum representing all the possible strategies for n_local entanglement blocks.
 #[repr(C)]
 pub enum EntanglementStrategy {
+    /// Entanglement where each qubit is entangled with all the others.
     Full,
+    /// Entanglement where qubit \f$i\f$ is entangled with qubit \f$i + 1\f$
+    /// for all \f$i \in \{0, 1, ... , n - 2\}\f$ where \f$n\f$ is the total
+    /// number of qubits.
     Linear,
+    /// Entanglement where qubit \f$i\f$ is entangled with qubit \f$i + 1\f$
+    /// for all \f$i \in \{n-2, n-3, ... , 1, 0\}\f$ where \f$n\f$ is the total
+    /// number of qubits.
     ReverseLinear,
+    /// Entanglement shifted-circular-alternating. It's a generalized and modified
+    /// version of the proposed circuit 14 in 
+    /// [Sim et al.](https://arxiv.org/abs/1905.10876)
+    /// It consists of circular entanglement where the "long" entanglement connecting
+    /// the first with the last qubit is shifted by one each block.  
+    /// Furthermore the role of control and target qubits are swapped every block 
+    /// (therefore alternating).
     Sca,
+    /// Entanglement that behaves the same as linear entanglement but with an additional
+    /// entanglement of the first and last qubit before the linear part.
     Circular,
+    /// Entanglement where one layer contains a qubit \f$i\f$ entangled with
+    /// qubit \f$i + 1\f$, for all even values of \f$i\f$, and then a second layer 
+    /// where a qubit \f$i\f$ is entangled with qubit \f$i + 1\f$, for all odd values of
+    /// \f$i\f$.
     Pairwise,
 }
 
+/// @ingroup QkCircuitLibrary
+/// Construct an n-local variational circuit.
+///
+/// The structure of the n-local circuit are alternating rotation and entanglement layers.
+/// In both layers, parameterized circuit-blocks act on the circuit in a defined way.
+/// In the rotation layer, the blocks are applied stacked on top of each other, while in the
+/// entanglement layer according to the ``entanglement`` strategy.
+/// The circuit blocks can have arbitrary sizes (smaller equal to the number of qubits in the
+/// circuit). Each layer is repeated ``reps`` times, and by default a final rotation layer is
+/// appended.
+///
+/// For instance, a rotation block on 2 qubits and an entanglement block on 4 qubits using
+/// ``QkEntanglementStrategy_Linear`` entanglement yields the following circuit.
+///
+/// ```
+///
+///     ┌──────┐ ░ ┌──────┐                      ░ ┌──────┐
+///     ┤0     ├─░─┤0     ├──────────────── ... ─░─┤0     ├
+///     │  Rot │ ░ │      │┌──────┐              ░ │  Rot │
+///     ┤1     ├─░─┤1     ├┤0     ├──────── ... ─░─┤1     ├
+///     ├──────┤ ░ │  Ent ││      │┌──────┐      ░ ├──────┤
+///     ┤0     ├─░─┤2     ├┤1     ├┤0     ├ ... ─░─┤0     ├
+///     │  Rot │ ░ │      ││  Ent ││      │      ░ │  Rot │
+///     ┤1     ├─░─┤3     ├┤2     ├┤1     ├ ... ─░─┤1     ├
+///     ├──────┤ ░ └──────┘│      ││  Ent │      ░ ├──────┤
+///     ┤0     ├─░─────────┤3     ├┤2     ├ ... ─░─┤0     ├
+///     │  Rot │ ░         └──────┘│      │      ░ │  Rot │
+///     ┤1     ├─░─────────────────┤3     ├ ... ─░─┤1     ├
+///     └──────┘ ░                 └──────┘      ░ └──────┘
+///     
+///     |                                 |
+///     +---------------------------------+
+///            repeated reps times
+///
+/// ```
+/// Entanglement:
+///
+/// The entanglement describes the connections of the gates in the entanglement layer.
+/// For a two-qubit gate for example, the entanglement contains pairs of qubits on which the
+/// gate should acts, e.g. ``[[ctrl0, target0], [ctrl1, target1], ...]``.
+/// To know more about the available entanglement strategies see ``QkEntanglementStrategy``.
+///
+/// @param rotation_blocks The blocks used in the rotation layers.
+/// @param rotation_blocks_size Length of the array of rotation blocks provided.
+/// @param entanglement_blocks The blocks used in the entanglement layers.
+/// @param entanglement_blocks_size Length of the list of entanglement blocks provided.
+/// @param entanglement A pointer to the ``QkEntanglement`` that contains the indices where the
+///   entanglement blocks act.
+/// @param num_qubits The number of qubits of the circuit.
+/// @param reps Specifies how often the rotation blocks and entanglement blocks are repeated.
+/// @param parameter_prefix The prefix used for the default parameters generated.
+/// @param insert_barriers If ``true``, barriers are inserted in between each layer. If ``false``,
+///   no barriers are inserted.
+///
+/// @return A pointer to the generated circuit.
+///
+/// # Example
+/// ```c
+/// size_t num_qubits = 2;
+/// int reps = 2;
+/// QkGate rotation_blocks[1] = {QkGate_H};
+/// QkGate entanglement_blocks[1] = {QkGate_CRX};
+///
+/// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
+///     num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
+///
+/// QkCircuit *qc = qk_n_local(rotation_blocks, 1, entanglement_blocks, 1,
+///                            entanglement, num_qubits,
+///                            reps, NULL, false, false);
+///
+/// qk_entanglement_free(entanglement);
+/// qk_circuit_free(qc);
+/// ```
+/// 
+/// If an entanglement layer contains multiple blocks, then the entanglement can be
+/// given as list of entanglement strategies for each block.
+/// ```c
+/// size_t num_qubits = 2;
+/// int reps = 2;
+/// 
+/// QkGate rotation_blocks[2] = {QkGate_H, QkGate_X};
+/// QkGate entanglement_blocks[2] = {QkGate_CCX, QkGate_CSwap};
+/// 
+/// // linear for CCX and reverse linear for CSwap
+/// QkEntanglementStrategy strategies[2] = {QkEntanglementStrategy_Linear,
+///                                         QkEntanglementStrategy_ReverseLinear};
+/// 
+/// QkEntanglement *entanglement = qk_get_entanglement_with_multiple_strategy(
+///     num_qubits, reps, strategies, 2, entanglement_blocks, 2);
+/// QkCircuit *qc = qk_n_local(rotation_blocks, 2, entanglement_blocks, 2,
+///                            entanglement, num_qubits,
+///                            reps, NULL, false, false);
+///
+/// qk_entanglement_free(entanglement);
+/// qk_circuit_free(qc);
+/// ```
+/// 
+/// # Safety
+///
+/// Behavior is undefined if ``entanglement`` is not either null
+/// or a valid pointer to a ``QkEntanglement``.
+/// Behavior is undefined if ``rotation_blocks`` is not a valid, non-null pointer
+/// to a sequence of ``rotation_blocks_size`` consecutive elements of ``StandardGate``.
+/// Behavior is undefined if ``entanglement_blocks`` is not a valid, non-null pointer
+/// to a sequence of ``entanglement_blocks_size`` consecutive elements of ``StandardGate``.
+/// The `parameter_prefix` parameter must be a pointer to memory that contains a valid
+/// nul terminator at the end of the string. It also must be valid for reads of
+/// bytes up to and including the nul terminator.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_n_local(
     rotation_blocks: *const StandardGate,
@@ -125,158 +253,8 @@ pub unsafe extern "C" fn qk_n_local(
 }
 
 /// @ingroup QkCircuitLibrary
-/// Obtain the layers count in the provided ``QkEntanglement``.
-///
-/// @param entanglement A pointer to the ``QkEntanglement`` object.
-///
-/// @return The layers count on the provided ``QkEntanglement``.
-///
-/// # Example
-///
-/// ```c
-/// int reps = 1;
-/// int num_qubits = 2;
-/// QkGate entanglement_blocks[1] = {QkGate_CRX};
-/// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
-///     num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
-///
-/// size_t layers_count = qk_get_entanglement_layers_quantity(entanglement);
-///
-/// qk_entanglement_free(entanglement);
-/// ```
-///
-///
-/// # Safety
-///
-/// Behavior is undefined if ``entanglement`` is not either null or a valid pointer to a ``QkEntanglement``.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_get_entanglement_layers_quantity(
-    entanglement: *const Entanglement,
-) -> usize {
-    // SAFETY: Per documentation, the pointer is non-null and aligned.
-    let entanglement = unsafe { const_ptr_as_ref(entanglement) };
-    entanglement.0.len()
-}
-
-/// @ingroup QkCircuitLibrary
-/// Obtain the blocks count on a given layer in the provided ``QkEntanglement``.
-///
-/// @param entanglement A pointer to the ``QkEntanglement`` object.
-/// @param layer_index The layer index where the blocks are.
-///
-/// @return The blocks count on the given layer.
-///
-/// # Example
-///
-/// ```c
-/// int reps = 1;
-/// int num_qubits = 2;
-/// QkGate entanglement_blocks[1] = {QkGate_CRX};
-/// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
-///     num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
-///
-/// size_t blocks_count = qk_get_entanglement_layer_blocks_quantity(entanglement, 0);
-///
-/// qk_entanglement_free(entanglement);
-/// ```
-///
-///
-/// # Safety
-///
-/// Behavior is undefined if ``entanglement`` is not either null or a valid pointer to a ``QkEntanglement``.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_get_entanglement_layer_blocks_quantity(
-    entanglement: *const Entanglement,
-    layer_index: usize,
-) -> usize {
-    // SAFETY: Per documentation, the pointer is non-null and aligned.
-    let entanglement = unsafe { const_ptr_as_ref(entanglement) };
-    entanglement.0[layer_index].0.len()
-}
-
-/// @ingroup QkCircuitLibrary
-/// Obtain the ``QkQubitConnection`` count on a given layer and block in the provided ``QkEntanglement``.
-///
-/// @param entanglement A pointer to the ``QkEntanglement`` object.
-/// @param layer_index The layer index where the ``QkQubitConnection`` objects exist.
-/// @param block_index The block index in the layer where the ``QkQubitConnection`` objects exist.
-///
-/// @return The qubit connections count on the given layer and block.
-///
-/// # Example
-///
-/// ```c
-/// int reps = 1;
-/// int num_qubits = 2;
-/// QkGate entanglement_blocks[1] = {QkGate_CRX};
-/// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
-///     num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
-///
-/// size_t connections_count = qk_get_entanglement_qubit_connections_quantity(entanglement, 0, 0);
-///
-/// qk_entanglement_free(entanglement);
-/// ```
-///
-///
-/// # Safety
-///
-/// Behavior is undefined if ``entanglement`` is not either null or a valid pointer to a ``QkEntanglement``.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_get_entanglement_qubit_connections_quantity(
-    entanglement: *const Entanglement,
-    layer_index: usize,
-    block_index: usize,
-) -> usize {
-    // SAFETY: Per documentation, the pointer is non-null and aligned.
-    let entanglement = unsafe { const_ptr_as_ref(entanglement) };
-    entanglement.0[layer_index].0[block_index].0.len()
-}
-
-/// @ingroup QkCircuitLibrary
-/// Obtain the ``QkQubitConnection`` object at a given layer and block in the provided ``QkEntanglement``.
-///
-/// @param entanglement A pointer to the ``QkEntanglement`` object.
-/// @param layer_index The layer index where the ``QkQubitConnection`` object exists.
-/// @param block_index The block index in the layer where the ``QkQubitConnection`` object exists.
-/// @param connection_index The ``QkQubitConnection`` object index where the multi-qubit gate acts on.
-///
-/// @return A pointer to the obtained ``QkQubitConnection``.
-///
-/// # Example
-///
-/// ```c
-/// int reps = 1;
-/// int num_qubits = 2;
-/// QkGate entanglement_blocks[1] = {QkGate_CRX};
-/// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
-///     num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
-///
-/// QkQubitConnection *connection = qk_get_entanglement_qubit_connections(entanglement, 0, 0, 1);
-///
-/// qk_entanglement_free(entanglement);
-/// qk_qubit_connection_free(connection);
-/// ```
-///
-///
-/// # Safety
-///
-/// Behavior is undefined if ``entanglement`` is not either null or a valid pointer to a ``QkEntanglement``.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_get_entanglement_qubit_connections(
-    entanglement: *const Entanglement,
-    layer_index: usize,
-    block_index: usize,
-    connection_index: usize,
-) -> *mut QubitConnection {
-    // SAFETY: Per documentation, the pointer is non-null and aligned.
-    let entanglement = unsafe { const_ptr_as_ref(entanglement) };
-    Box::into_raw(Box::new(
-        entanglement.0[layer_index].0[block_index].0[connection_index].clone(),
-    ))
-}
-
-/// @ingroup QkCircuitLibrary
-/// Construct a new ``QkQubitConnection`` representing the entanglement between qubits where a multi-qubit gate acts on.
+/// Construct a new ``QkQubitConnection`` representing the entanglement between 
+/// qubits where a multi-qubit gate acts on.
 ///
 /// @param num_qubits The size of the qubits connections array.
 /// @param qubit_connections The qubits connections array.
@@ -291,7 +269,8 @@ pub unsafe extern "C" fn qk_get_entanglement_qubit_connections(
 ///
 /// # Safety
 ///
-/// Behavior is undefined ``qubit_connections`` is not a valid, non-null pointer to a ``uint32_t`` array.
+/// Behavior is undefined ``qubit_connections`` is not a valid, 
+/// non-null pointer to a ``uint32_t`` array.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_qubit_connection_new(
     num_qubits: usize,
@@ -340,11 +319,236 @@ pub unsafe extern "C" fn qk_qubit_connection_equal(
 }
 
 /// @ingroup QkCircuitLibrary
+/// Free the ``QkQubitConnection``.
+///
+/// @param qubit_connection A pointer to the ``QkQubitConnection`` to free.
+///
+/// # Example
+///
+/// ```c
+/// QkQubitConnection *qconn = qk_qubit_connection_new((uint32_t[2]){0, 1}, 2);
+/// qk_qubit_connection_free(qconn);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``qubit_connection`` is not 
+/// either null or a valid pointer to a ``QubitConnection``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_qubit_connection_free(qubit_connection: *mut QubitConnection) {
+    if !qubit_connection.is_null() {
+        if !qubit_connection.is_aligned() {
+            panic!("Attempted to free a non-aligned pointer.")
+        }
+
+        // SAFETY: We have verified the pointer is non-null and aligned, so it should be
+        // readable by Box.
+        unsafe {
+            let _ = Box::from_raw(qubit_connection);
+        }
+    }
+}
+
+/// @ingroup QkCircuitLibrary
+/// Free the ``QkEntanglement``.
+///
+/// @param entanglement A pointer to the ``QkEntanglement`` to free.
+///
+/// # Example
+///
+/// ```c
+/// int reps = 1;
+/// int num_qubits = 2;
+/// QkGate entanglement_blocks[1] = {QkGate_CRX};
+/// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
+///     num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
+/// qk_entanglement_free(entanglement);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``entanglement`` is not 
+/// either null or a valid pointer to a ``QkEntanglement``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_entanglement_free(entanglement: *mut Entanglement) {
+    if !entanglement.is_null() {
+        if !entanglement.is_aligned() {
+            panic!("Attempted to free a non-aligned pointer.")
+        }
+
+        // SAFETY: We have verified the pointer is non-null and aligned, so it should be
+        // readable by Box.
+        unsafe {
+            let _ = Box::from_raw(entanglement);
+        }
+    }
+}
+
+/// @ingroup QkCircuitLibrary
+/// Obtain the layers count in the provided ``QkEntanglement``.
+///
+/// @param entanglement A pointer to the ``QkEntanglement`` object.
+///
+/// @return The layers count on the provided ``QkEntanglement``.
+///
+/// # Example
+///
+/// ```c
+/// int reps = 1;
+/// int num_qubits = 2;
+/// QkGate entanglement_blocks[1] = {QkGate_CRX};
+/// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
+///     num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
+///
+/// size_t layers_count = qk_get_entanglement_layers_quantity(entanglement);
+///
+/// qk_entanglement_free(entanglement);
+/// ```
+///
+///
+/// # Safety
+///
+/// Behavior is undefined if ``entanglement`` is not 
+/// either null or a valid pointer to a ``QkEntanglement``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_get_entanglement_layers_quantity(
+    entanglement: *const Entanglement,
+) -> usize {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let entanglement = unsafe { const_ptr_as_ref(entanglement) };
+    entanglement.0.len()
+}
+
+/// @ingroup QkCircuitLibrary
+/// Obtain the blocks count on a given layer in the provided ``QkEntanglement``.
+///
+/// @param entanglement A pointer to the ``QkEntanglement`` object.
+/// @param layer_index The layer index where the blocks are.
+///
+/// @return The blocks count on the given layer.
+///
+/// # Example
+///
+/// ```c
+/// int reps = 1;
+/// int num_qubits = 2;
+/// QkGate entanglement_blocks[1] = {QkGate_CRX};
+/// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
+///     num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
+///
+/// size_t blocks_count = qk_get_entanglement_layer_blocks_quantity(entanglement, 0);
+///
+/// qk_entanglement_free(entanglement);
+/// ```
+///
+///
+/// # Safety
+///
+/// Behavior is undefined if ``entanglement`` is not 
+/// either null or a valid pointer to a ``QkEntanglement``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_get_entanglement_layer_blocks_quantity(
+    entanglement: *const Entanglement,
+    layer_index: usize,
+) -> usize {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let entanglement = unsafe { const_ptr_as_ref(entanglement) };
+    entanglement.0[layer_index].0.len()
+}
+
+/// @ingroup QkCircuitLibrary
+/// Obtain the ``QkQubitConnection`` count on a given layer 
+/// and block in the provided ``QkEntanglement``.
+///
+/// @param entanglement A pointer to the ``QkEntanglement`` object.
+/// @param layer_index The layer index where the ``QkQubitConnection`` objects exist.
+/// @param block_index The block index in the layer where the ``QkQubitConnection`` objects exist.
+///
+/// @return The qubit connections count on the given layer and block.
+///
+/// # Example
+///
+/// ```c
+/// int reps = 1;
+/// int num_qubits = 2;
+/// QkGate entanglement_blocks[1] = {QkGate_CRX};
+/// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
+///     num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
+///
+/// size_t connections_count = qk_get_entanglement_qubit_connections_quantity(entanglement, 0, 0);
+///
+/// qk_entanglement_free(entanglement);
+/// ```
+///
+///
+/// # Safety
+///
+/// Behavior is undefined if ``entanglement`` is not 
+/// either null or a valid pointer to a ``QkEntanglement``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_get_entanglement_qubit_connections_quantity(
+    entanglement: *const Entanglement,
+    layer_index: usize,
+    block_index: usize,
+) -> usize {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let entanglement = unsafe { const_ptr_as_ref(entanglement) };
+    entanglement.0[layer_index].0[block_index].0.len()
+}
+
+/// @ingroup QkCircuitLibrary
+/// Obtain the ``QkQubitConnection`` object at a given 
+/// layer and block in the provided ``QkEntanglement``.
+///
+/// @param entanglement A pointer to the ``QkEntanglement`` object.
+/// @param layer_index The layer index where the ``QkQubitConnection`` object exists.
+/// @param block_index The block index in the layer where the ``QkQubitConnection`` object exists.
+/// @param connection_index The ``QkQubitConnection`` object index where 
+/// the multi-qubit gate acts on.
+///
+/// @return A pointer to the obtained ``QkQubitConnection``.
+///
+/// # Example
+///
+/// ```c
+/// int reps = 1;
+/// int num_qubits = 2;
+/// QkGate entanglement_blocks[1] = {QkGate_CRX};
+/// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
+///     num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
+///
+/// QkQubitConnection *connection = qk_get_entanglement_qubit_connections(entanglement, 0, 0, 1);
+///
+/// qk_entanglement_free(entanglement);
+/// qk_qubit_connection_free(connection);
+/// ```
+///
+///
+/// # Safety
+///
+/// Behavior is undefined if ``entanglement`` is not 
+/// either null or a valid pointer to a ``QkEntanglement``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_get_entanglement_qubit_connections(
+    entanglement: *const Entanglement,
+    layer_index: usize,
+    block_index: usize,
+    connection_index: usize,
+) -> *mut QubitConnection {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let entanglement = unsafe { const_ptr_as_ref(entanglement) };
+    Box::into_raw(Box::new(
+        entanglement.0[layer_index].0[block_index].0[connection_index].clone(),
+    ))
+}
+
+/// @ingroup QkCircuitLibrary
 /// Generate an entanglement following the provided strategies.
 ///
 /// @param num_qubits The number of qubits of the circuit
 /// @param reps Specifies how often the entanglement blocks are repeated.
-/// @param entanglement_strategy List of enum items describing an entanglement strategy for each layer.
+/// @param entanglement_strategy List of enum items describing an entanglement 
+///   strategy for each layer.
 /// @param entanglement_strategy_size Length of the entanglement strategy list provided
 /// @param entanglement_blocks The blocks used in the entanglement layers.
 /// @param entanglement_blocks_size Length of the list of entanglement blocks provided
@@ -353,8 +557,10 @@ pub unsafe extern "C" fn qk_qubit_connection_equal(
 ///
 /// # Safety
 ///
-/// Behavior is undefined ``entanglement_strategy`` is not a valid, non-null pointer to a ``QkEntanglementStrategy`` array.
-/// Behavior is undefined ``entanglement_blocks`` is not a valid, non-null pointer to a ``StandardGate`` array.
+/// Behavior is undefined ``entanglement_strategy`` is not a valid, 
+/// non-null pointer to a ``QkEntanglementStrategy`` array.
+/// Behavior is undefined ``entanglement_blocks`` is not a valid, 
+/// non-null pointer to a ``StandardGate`` array.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_get_entanglement_with_multiple_strategy(
     num_qubits: u32,
@@ -409,7 +615,8 @@ pub unsafe extern "C" fn qk_get_entanglement_with_multiple_strategy(
 ///
 /// # Safety
 ///
-/// Behavior is undefined ``entanglement_blocks`` is not a valid, non-null pointer to a ``QkGate`` array.
+/// Behavior is undefined ``entanglement_blocks`` is not a valid, 
+/// non-null pointer to a ``QkGate`` array.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_get_entanglement_with_strategy(
     num_qubits: u32,
@@ -436,70 +643,6 @@ pub unsafe extern "C" fn qk_get_entanglement_with_strategy(
         &entanglement_strategy,
         reps,
     )))
-}
-
-/// @ingroup QkCircuitLibrary
-/// Free the ``QkQubitConnection``.
-///
-/// @param qubit_connection A pointer to the ``QkQubitConnection`` to free.
-///
-/// # Example
-///
-/// ```c
-/// QkQubitConnection *qconn = qk_qubit_connection_new((uint32_t[2]){0, 1}, 2);
-/// qk_qubit_connection_free(qconn);
-/// ```
-///
-/// # Safety
-///
-/// Behavior is undefined if ``qubit_connection`` is not either null or a valid pointer to a ``QubitConnection``.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_qubit_connection_free(qubit_connection: *mut QubitConnection) {
-    if !qubit_connection.is_null() {
-        if !qubit_connection.is_aligned() {
-            panic!("Attempted to free a non-aligned pointer.")
-        }
-
-        // SAFETY: We have verified the pointer is non-null and aligned, so it should be
-        // readable by Box.
-        unsafe {
-            let _ = Box::from_raw(qubit_connection);
-        }
-    }
-}
-
-/// @ingroup QkCircuitLibrary
-/// Free the ``QkEntanglement``.
-///
-/// @param entanglement A pointer to the ``QkEntanglement`` to free.
-///
-/// # Example
-///
-/// ```c
-/// int reps = 1;
-/// int num_qubits = 2;
-/// QkGate entanglement_blocks[1] = {QkGate_CRX};
-/// QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
-///     num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
-/// qk_entanglement_free(entanglement);
-/// ```
-///
-/// # Safety
-///
-/// Behavior is undefined if ``entanglement`` is not either null or a valid pointer to a ``QkEntanglement``.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_entanglement_free(entanglement: *mut Entanglement) {
-    if !entanglement.is_null() {
-        if !entanglement.is_aligned() {
-            panic!("Attempted to free a non-aligned pointer.")
-        }
-
-        // SAFETY: We have verified the pointer is non-null and aligned, so it should be
-        // readable by Box.
-        unsafe {
-            let _ = Box::from_raw(entanglement);
-        }
-    }
 }
 
 fn get_entanglement_with_strategy(

--- a/crates/cext/src/circuit_library/n_local.rs
+++ b/crates/cext/src/circuit_library/n_local.rs
@@ -16,7 +16,6 @@ use qiskit_circuit::operations::StandardGate;
 use qiskit_circuit_library::blocks::{Block, Entanglement};
 use qiskit_circuit_library::entanglement::get_entanglement_from_str;
 use qiskit_circuit_library::multi_local::n_local;
-use qiskit_circuit_library::parameter_ledger::ParameterLedgerBuilder;
 use std::ffi::{CStr, c_char};
 
 /// Settings for generating a n-local variational circuit.
@@ -243,7 +242,6 @@ pub unsafe extern "C" fn qk_circuit_library_n_local(
     };
 
     match n_local(
-        ParameterLedgerBuilder,
         num_qubits,
         &rotation_blocks,
         &entanglement_blocks,

--- a/crates/cext/src/circuit_library/n_local.rs
+++ b/crates/cext/src/circuit_library/n_local.rs
@@ -182,7 +182,7 @@ pub unsafe extern "C" fn qk_circuit_library_n_local(
     settings: *const NLocalSettings,
 ) -> *mut CircuitData {
     // SAFETY: per documentation, `rotation_blocks` is aligned and and points to a valid
-    // aligned block of memory valid for `num_rotation_blocks` writes of `StandardGate`s
+    // aligned block of memory valid for `num_rotation_blocks` reads of `StandardGate`s
     let rotation_blocks: Vec<Block> =
         unsafe { ::std::slice::from_raw_parts(rotation_blocks, rotation_blocks_size) }
             .iter()
@@ -191,7 +191,7 @@ pub unsafe extern "C" fn qk_circuit_library_n_local(
     let rotation_blocks: Vec<&Block> = rotation_blocks.iter().collect();
 
     // SAFETY: per documentation, `entanglement_blocks` is aligned and and points to a valid
-    // aligned block of memory valid for `num_entanglement_blocks` writes of `StandardGate`s
+    // aligned block of memory valid for `num_entanglement_blocks` reads of `StandardGate`s
     let entanglement_blocks: Vec<Block> =
         unsafe { ::std::slice::from_raw_parts(entanglement_blocks, entanglement_blocks_size) }
             .iter()

--- a/crates/cext/src/circuit_library/n_local.rs
+++ b/crates/cext/src/circuit_library/n_local.rs
@@ -206,13 +206,37 @@ pub unsafe extern "C" fn qk_circuit_library_n_local(
         unsafe { const_ptr_as_ref(settings) }
     };
 
-    let entanglement = get_entanglement_strategy(&settings.entanglement_strategy);
-    let entanglement = get_entanglement_with_strategy(
-        num_qubits,
-        &entanglement_blocks,
-        entanglement,
-        settings.reps,
-    );
+    // Create entanglement
+    let entanglement_strategy = match settings.entanglement_strategy {
+        EntanglementStrategy::Full => "full",
+        EntanglementStrategy::Linear => "linear",
+        EntanglementStrategy::ReverseLinear => "reverse_linear",
+        EntanglementStrategy::Sca => "sca",
+        EntanglementStrategy::Circular => "circular",
+        EntanglementStrategy::Pairwise => "pairwise",
+    };
+    let is_sca = matches!(settings.entanglement_strategy, EntanglementStrategy::Sca);
+    let entanglement = Entanglement {
+        entanglement_vec: (0..settings.reps)
+            .map(|layer| {
+                // Create entanglement layer
+                entanglement_blocks
+                    .iter()
+                    .map(|gate| {
+                        // Create block entanglement
+                        get_entanglement_from_str(
+                            num_qubits,
+                            gate.num_qubits,
+                            entanglement_strategy,
+                            if is_sca { layer } else { 0 },
+                        )
+                        .unwrap()
+                        .collect()
+                    })
+                    .collect()
+            })
+            .collect(),
+    };
 
     match n_local(
         ParameterLedgerBuilder,
@@ -248,70 +272,4 @@ pub unsafe extern "C" fn qk_circuit_library_n_local(
 #[unsafe(no_mangle)]
 pub extern "C" fn qk_circuit_library_n_local_settings_default() -> NLocalSettings {
     NLocalSettings::default()
-}
-
-fn get_entanglement_with_strategy(
-    num_qubits: u32,
-    entanglement_blocks: &[&Block],
-    entanglement_strategy: &str,
-    reps: usize,
-) -> Entanglement {
-    Entanglement {
-        entanglement_vec: (0..reps)
-            .map(|layer| {
-                get_layer_entanglement_with_strategy(
-                    num_qubits,
-                    entanglement_blocks,
-                    entanglement_strategy,
-                    layer,
-                )
-            })
-            .collect(),
-    }
-}
-
-fn get_layer_entanglement_with_strategy(
-    num_qubits: u32,
-    entanglement_blocks: &[&Block],
-    strategy: &str,
-    layer_index: usize,
-) -> Vec<Vec<Vec<u32>>> {
-    entanglement_blocks
-        .iter()
-        .map(|gate| {
-            get_block_qubit_connections_with_strategy(
-                num_qubits,
-                gate,
-                strategy,
-                (strategy == "sca").then_some(layer_index),
-            )
-        })
-        .collect()
-}
-
-fn get_block_qubit_connections_with_strategy(
-    num_qubits: u32,
-    gate: &Block,
-    entanglement_strategy: &str,
-    offset: Option<usize>,
-) -> Vec<Vec<u32>> {
-    get_entanglement_from_str(
-        num_qubits,
-        gate.num_qubits,
-        entanglement_strategy,
-        offset.unwrap_or(0),
-    )
-    .unwrap()
-    .collect()
-}
-
-fn get_entanglement_strategy(entanglement_strategy: &EntanglementStrategy) -> &'static str {
-    match entanglement_strategy {
-        EntanglementStrategy::Full => "full",
-        EntanglementStrategy::Linear => "linear",
-        EntanglementStrategy::ReverseLinear => "reverse_linear",
-        EntanglementStrategy::Sca => "sca",
-        EntanglementStrategy::Circular => "circular",
-        EntanglementStrategy::Pairwise => "pairwise",
-    }
 }

--- a/crates/cext/src/circuit_library/n_local.rs
+++ b/crates/cext/src/circuit_library/n_local.rs
@@ -216,26 +216,30 @@ pub unsafe extern "C" fn qk_circuit_library_n_local(
         EntanglementStrategy::Pairwise => "pairwise",
     };
     let is_sca = matches!(settings.entanglement_strategy, EntanglementStrategy::Sca);
-    let entanglement = Entanglement {
-        entanglement_vec: (0..settings.reps)
-            .map(|layer| {
-                // Create entanglement layer
-                entanglement_blocks
-                    .iter()
-                    .map(|gate| {
-                        // Create block entanglement
-                        get_entanglement_from_str(
-                            num_qubits,
-                            gate.num_qubits,
-                            entanglement_strategy,
-                            if is_sca { layer } else { 0 },
-                        )
-                        .unwrap()
-                        .collect()
-                    })
-                    .collect()
-            })
-            .collect(),
+
+    let entanglement = match (0..settings.reps)
+        .map(|layer| {
+            // Create entanglement layer
+            entanglement_blocks
+                .iter()
+                .map(|gate| {
+                    // Create block entanglement
+                    get_entanglement_from_str(
+                        num_qubits,
+                        gate.num_qubits,
+                        entanglement_strategy,
+                        if is_sca { layer } else { 0 },
+                    )
+                    .map(|connection| connection.collect())
+                })
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .collect::<Result<Vec<_>, _>>()
+    {
+        Ok(entanglement_vector) => Entanglement {
+            entanglement_vec: entanglement_vector,
+        },
+        Err(_) => return std::ptr::null_mut(),
     };
 
     match n_local(

--- a/crates/cext/src/circuit_library/n_local.rs
+++ b/crates/cext/src/circuit_library/n_local.rs
@@ -76,6 +76,14 @@ pub enum EntanglementStrategy {
     /// for all \f$i \in \{n-2, n-3, ... , 1, 0\}\f$ where \f$n\f$ is the total
     /// number of qubits.
     ReverseLinear = 2,
+    /// Entanglement that behaves the same as linear entanglement but with an additional
+    /// entanglement of the first and last qubit before the linear part.
+    Circular = 3,
+    /// Entanglement where one layer contains a qubit \f$i\f$ entangled with
+    /// qubit \f$i + 1\f$, for all even values of \f$i\f$, and then a second layer
+    /// where a qubit \f$i\f$ is entangled with qubit \f$i + 1\f$, for all odd values of
+    /// \f$i\f$.
+    Pairwise = 4,
     /// Entanglement shifted-circular-alternating. It's a generalized and modified
     /// version of the proposed circuit 14 in
     /// [Sim et al.](https://arxiv.org/abs/1905.10876)
@@ -83,15 +91,7 @@ pub enum EntanglementStrategy {
     /// the first with the last qubit is shifted by one each block.  
     /// Furthermore the role of control and target qubits are swapped every block
     /// (therefore alternating).
-    Sca = 3,
-    /// Entanglement that behaves the same as linear entanglement but with an additional
-    /// entanglement of the first and last qubit before the linear part.
-    Circular = 4,
-    /// Entanglement where one layer contains a qubit \f$i\f$ entangled with
-    /// qubit \f$i + 1\f$, for all even values of \f$i\f$, and then a second layer
-    /// where a qubit \f$i\f$ is entangled with qubit \f$i + 1\f$, for all odd values of
-    /// \f$i\f$.
-    Pairwise = 5,
+    Sca = 5,
 }
 
 /// @ingroup QkCircuitLibrary
@@ -142,7 +142,8 @@ pub enum EntanglementStrategy {
 /// @param entanglement_blocks The blocks used in the entanglement layers.
 /// @param entanglement_blocks_size Length of the list of entanglement blocks provided.
 /// @param settings A ``QkNLocalSettings`` pointer that is the settings to be applied
-///    to the generated circuit. See ``QkNLocalSettings`` for more details.
+///    to the generated circuit. If ``NULL``, the default settings are used,
+///    see ``QkNLocalSettings`` for more details.
 ///
 /// @return A pointer to the generated circuit.
 ///
@@ -170,6 +171,7 @@ pub enum EntanglementStrategy {
 ///   to a sequence of ``rotation_blocks_size`` consecutive elements of ``StandardGate``.
 /// * Behavior is undefined if ``entanglement_blocks`` is not a valid, non-null pointer
 ///   to a sequence of ``entanglement_blocks_size`` consecutive elements of ``StandardGate``.
+/// * Behavior is undefined if ``settings`` is not a valid, non-null pointer.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_circuit_library_n_local(
     num_qubits: u32,
@@ -240,9 +242,7 @@ pub unsafe extern "C" fn qk_circuit_library_n_local(
 
 /// @ingroup QkCircuitLibrary
 ///
-/// Generate n_local options defaults
-///
-/// This function generates a ``QkNLocalSettings`` with the default settings
+/// Generate default options for ``qk_circuit_library_n_local``.
 ///
 /// @return A ``QkNLocalSettings`` object with default settings.
 #[unsafe(no_mangle)]

--- a/crates/circuit_library/src/blocks.rs
+++ b/crates/circuit_library/src/blocks.rs
@@ -68,16 +68,6 @@ pub struct Block {
     pub num_parameters: usize,
 }
 
-impl Block {
-    fn from_gate(gate: &StandardGate) -> Self {
-        Self {
-            operation: BlockOperation::Standard { gate: gate.copy() },
-            num_parameters: gate.get_num_params() as usize,
-            num_qubits: gate.get_num_qubits(),
-        }
-    }
-}
-
 #[pymethods]
 impl Block {
     #[staticmethod]

--- a/crates/circuit_library/src/blocks.rs
+++ b/crates/circuit_library/src/blocks.rs
@@ -33,7 +33,6 @@ pub enum BlockOperation {
 impl BlockOperation {
     pub fn assign_parameters(
         &self,
-        py: Python,
         params: &[&Param],
     ) -> PyResult<(PackedOperation, SmallVec<[Param; 3]>)> {
         match self {
@@ -41,7 +40,7 @@ impl BlockOperation {
                 (*gate).into(),
                 SmallVec::from_iter(params.iter().map(|&p| p.clone())),
             )),
-            Self::PyCustom { builder } => {
+            Self::PyCustom { builder } => Python::attach(|py| {
                 // the builder returns a Python operation plus the bound parameters
                 let py_params = PyList::new(py, params.iter().map(|&p| p.clone()))?.into_any();
 
@@ -56,7 +55,7 @@ impl BlockOperation {
                     .collect::<PyResult<SmallVec<[Param; 3]>>>()?;
 
                 Ok((operation.operation, bound_params))
-            }
+            }),
         }
     }
 }

--- a/crates/circuit_library/src/blocks.rs
+++ b/crates/circuit_library/src/blocks.rs
@@ -68,6 +68,16 @@ pub struct Block {
     pub num_parameters: usize,
 }
 
+impl Block {
+    fn from_gate(gate: &StandardGate) -> Self {
+        Self {
+            operation: BlockOperation::Standard { gate: gate.copy() },
+            num_parameters: gate.get_num_params() as usize,
+            num_qubits: gate.get_num_qubits(),
+        }
+    }
+}
+
 #[pymethods]
 impl Block {
     #[staticmethod]
@@ -119,7 +129,7 @@ pub struct Entanglement {
     // This could be done more efficiently, e.g., by creating entanglement objects that store
     // their underlying representation (e.g. a string or a list of connections) and returning
     // these when given a layer-index.
-    entanglement_vec: Vec<LayerEntanglement>,
+    pub entanglement_vec: Vec<LayerEntanglement>,
 }
 
 impl Entanglement {

--- a/crates/circuit_library/src/lib.rs
+++ b/crates/circuit_library/src/lib.rs
@@ -13,11 +13,11 @@
 use pyo3::import_exception;
 use pyo3::prelude::*;
 
-mod blocks;
-mod entanglement;
+pub mod blocks;
+pub mod entanglement;
 pub mod iqp;
-mod multi_local;
-mod parameter_ledger;
+pub mod multi_local;
+pub mod parameter_ledger;
 pub mod pauli_evolution;
 mod pauli_feature_map;
 pub mod quantum_volume;

--- a/crates/circuit_library/src/multi_local.rs
+++ b/crates/circuit_library/src/multi_local.rs
@@ -240,7 +240,7 @@ pub fn n_local(
 #[pyo3(signature = (num_qubits, rotation_blocks, entanglement_blocks, entanglement, reps, insert_barriers, parameter_prefix, skip_final_rotation_layer, skip_unentangled_qubits))]
 #[allow(clippy::too_many_arguments)]
 pub fn py_n_local(
-    py: Python,
+    _py: Python,
     num_qubits: u32,
     rotation_blocks: Vec<PyRef<Block>>,
     entanglement_blocks: Vec<PyRef<Block>>,

--- a/crates/circuit_library/src/multi_local.rs
+++ b/crates/circuit_library/src/multi_local.rs
@@ -23,11 +23,10 @@ use qiskit_circuit::operations::{Param, StandardInstruction};
 use qiskit_circuit::{Clbit, Qubit};
 
 use itertools::izip;
-use thiserror::Error;
 
 use super::blocks::{Block, Entanglement, LayerEntanglement};
 use super::parameter_ledger::{
-    LayerParameters, LayerType, LedgerBuilder, ParameterLedgerError, PyParameterLedgerBuilder,
+    LayerParameters, LayerType, LedgerBuilder, PyParameterLedgerBuilder,
 };
 
 type Instruction = (
@@ -168,25 +167,20 @@ pub fn n_local(
     parameter_prefix: &str,
     skip_final_rotation_layer: bool,
     skip_unentangled_qubits: bool,
-) -> Result<CircuitData, MultiLocalError> {
+) -> PyResult<CircuitData> {
     // Construct the parameter ledger, which will define all free parameters and provide
     // access to them, given an index for a layer and the current gate to implement.
-    let ledger = match parameter_ledger_builder.build_from_nlocal(
-        num_qubits,
-        reps,
-        entanglement,
-        rotation_blocks,
-        entanglement_blocks,
-        skip_final_rotation_layer,
-        parameter_prefix,
-    ) {
-        Ok(ledger) => ledger,
-        Err(err) => match err {
-            ParameterLedgerError::PyParameterVectorError(err) => {
-                return Err(MultiLocalError::PyParameterLedgerCreationError(err));
-            }
-        },
-    };
+    let ledger = parameter_ledger_builder
+        .build_from_nlocal(
+            num_qubits,
+            reps,
+            entanglement,
+            rotation_blocks,
+            entanglement_blocks,
+            skip_final_rotation_layer,
+            parameter_prefix,
+        )
+        .unwrap();
 
     // Compute the qubits that are skipped in the rotation layer. If this is set,
     // we skip qubits that do not appear in any of the entanglement layers.
@@ -318,25 +312,6 @@ impl MaybeBarrier {
         match &self.barrier {
             None => Box::new(std::iter::empty()),
             Some(inst) => Box::new(std::iter::once(Ok(inst.clone()))),
-        }
-    }
-}
-
-#[derive(Debug, Error)]
-pub enum MultiLocalError {
-    /// A general error when trying to build the parameter ledger
-    #[error["Failed creating parameter ledger"]]
-    PyParameterLedgerCreationError(#[from] PyErr),
-
-    /// A general error when trying to create the circuit from n_local
-    #[error["Failed creating circuit data"]]
-    CircuitCreationError(#[from] CircuitDataError),
-}
-impl From<MultiLocalError> for PyErr {
-    fn from(value: MultiLocalError) -> Self {
-        match value {
-            MultiLocalError::PyParameterLedgerCreationError(err) => err,
-            MultiLocalError::CircuitCreationError(err) => err.into(),
         }
     }
 }

--- a/crates/circuit_library/src/multi_local.rs
+++ b/crates/circuit_library/src/multi_local.rs
@@ -23,9 +23,12 @@ use qiskit_circuit::operations::{Param, StandardInstruction};
 use qiskit_circuit::{Clbit, Qubit};
 
 use itertools::izip;
+use thiserror::Error;
 
 use super::blocks::{Block, Entanglement, LayerEntanglement};
-use super::parameter_ledger::{LayerParameters, LayerType, ParameterLedger};
+use super::parameter_ledger::{
+    LayerParameters, LayerType, LedgerBuilder, ParameterLedgerError, PyParameterLedgerBuilder,
+};
 
 type Instruction = (
     PackedOperation,
@@ -51,7 +54,6 @@ type Instruction = (
 ///
 /// An iterator for the rotation instructions.
 fn rotation_layer<'a>(
-    py: Python<'a>,
     num_qubits: u32,
     rotation_blocks: &'a [&'a Block],
     parameters: Vec<Vec<Vec<&'a Param>>>,
@@ -72,7 +74,7 @@ fn rotation_layer<'a>(
                 .map(move |(start_idx, params)| {
                     let (bound_op, bound_params) = block
                         .operation
-                        .assign_parameters(py, &params)
+                        .assign_parameters(&params)
                         .expect("Failed to rebind");
                     Ok((
                         bound_op,
@@ -104,7 +106,6 @@ fn rotation_layer<'a>(
 ///
 /// An iterator for the entanglement instructions.
 fn entanglement_layer<'a>(
-    py: Python<'a>,
     entanglement: &'a LayerEntanglement,
     entanglement_blocks: &'a [&'a Block],
     parameters: LayerParameters<'a>,
@@ -117,7 +118,7 @@ fn entanglement_layer<'a>(
             .map(move |(indices, params)| {
                 let (bound_op, bound_params) = block
                     .operation
-                    .assign_parameters(py, &params)
+                    .assign_parameters(&params)
                     .expect("Failed to rebind");
                 Ok((
                     bound_op,
@@ -157,7 +158,7 @@ fn entanglement_layer<'a>(
 /// An N-local circuit.
 #[allow(clippy::too_many_arguments)]
 pub fn n_local(
-    py: Python,
+    parameter_ledger_builder: impl LedgerBuilder,
     num_qubits: u32,
     rotation_blocks: &[&Block],
     entanglement_blocks: &[&Block],
@@ -167,11 +168,10 @@ pub fn n_local(
     parameter_prefix: &String,
     skip_final_rotation_layer: bool,
     skip_unentangled_qubits: bool,
-) -> PyResult<PyCircuitData> {
+) -> Result<CircuitData, MultiLocalError> {
     // Construct the parameter ledger, which will define all free parameters and provide
     // access to them, given an index for a layer and the current gate to implement.
-    let ledger = ParameterLedger::from_nlocal(
-        py,
+    let ledger = match parameter_ledger_builder.from_nlocal(
         num_qubits,
         reps,
         entanglement,
@@ -179,7 +179,14 @@ pub fn n_local(
         entanglement_blocks,
         skip_final_rotation_layer,
         parameter_prefix,
-    )?;
+    ) {
+        Ok(ledger) => ledger,
+        Err(err) => match err {
+            ParameterLedgerError::PyParameterVectorError(err) => {
+                return Err(MultiLocalError::PyParameterLedgerCreationError(err));
+            }
+        },
+    };
 
     // Compute the qubits that are skipped in the rotation layer. If this is set,
     // we skip qubits that do not appear in any of the entanglement layers.
@@ -197,7 +204,6 @@ pub fn n_local(
 
     let packed_insts = (0..reps).flat_map(|layer| {
         rotation_layer(
-            py,
             num_qubits,
             rotation_blocks,
             ledger.get_parameters(LayerType::Rotation, layer),
@@ -205,7 +211,6 @@ pub fn n_local(
         )
         .chain(maybe_barrier.get())
         .chain(entanglement_layer(
-            py,
             entanglement.get_layer(layer),
             entanglement_blocks,
             ledger.get_parameters(LayerType::Entangle, layer),
@@ -214,7 +219,6 @@ pub fn n_local(
     });
     if !skip_final_rotation_layer {
         let packed_insts = packed_insts.chain(rotation_layer(
-            py,
             num_qubits,
             rotation_blocks,
             ledger.get_parameters(LayerType::Rotation, reps),
@@ -262,8 +266,8 @@ pub fn py_n_local(
     // circuit layer.
     let entanglement = Entanglement::from_py(num_qubits, reps, entanglement, &entanglement_blocks)?;
 
-    n_local(
-        py,
+    Ok(n_local(
+        PyParameterLedgerBuilder,
         num_qubits,
         &rotation_blocks,
         &entanglement_blocks,
@@ -273,7 +277,8 @@ pub fn py_n_local(
         &parameter_prefix,
         skip_final_rotation_layer,
         skip_unentangled_qubits,
-    )
+    )?
+    .into())
 }
 
 /// A convenient struct to optionally yield barriers to inject in-between circuit layers.
@@ -309,6 +314,25 @@ impl MaybeBarrier {
         match &self.barrier {
             None => Box::new(std::iter::empty()),
             Some(inst) => Box::new(std::iter::once(Ok(inst.clone()))),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum MultiLocalError {
+    /// A general error when trying to build the parameter ledger
+    #[error["Failed creating parameter ledger"]]
+    PyParameterLedgerCreationError(#[from] PyErr),
+
+    /// A general error when trying to create the circuit from n_local
+    #[error["Failed creating circuit data"]]
+    CircuitCreationError(#[from] CircuitDataError),
+}
+impl From<MultiLocalError> for PyErr {
+    fn from(value: MultiLocalError) -> Self {
+        match value {
+            MultiLocalError::PyParameterLedgerCreationError(err) => err,
+            MultiLocalError::CircuitCreationError(err) => err.into(),
         }
     }
 }

--- a/crates/circuit_library/src/multi_local.rs
+++ b/crates/circuit_library/src/multi_local.rs
@@ -165,13 +165,13 @@ pub fn n_local(
     entanglement: &Entanglement,
     reps: usize,
     insert_barriers: bool,
-    parameter_prefix: &String,
+    parameter_prefix: &str,
     skip_final_rotation_layer: bool,
     skip_unentangled_qubits: bool,
 ) -> Result<CircuitData, MultiLocalError> {
     // Construct the parameter ledger, which will define all free parameters and provide
     // access to them, given an index for a layer and the current gate to implement.
-    let ledger = match parameter_ledger_builder.from_nlocal(
+    let ledger = match parameter_ledger_builder.build_from_nlocal(
         num_qubits,
         reps,
         entanglement,
@@ -224,15 +224,19 @@ pub fn n_local(
             ledger.get_parameters(LayerType::Rotation, reps),
             &skipped_qubits,
         ));
-        Ok(
-            CircuitData::from_packed_operations(num_qubits, 0, packed_insts, Param::Float(0.0))?
-                .into(),
-        )
+        Ok(CircuitData::from_packed_operations(
+            num_qubits,
+            0,
+            packed_insts,
+            Param::Float(0.0),
+        )?)
     } else {
-        Ok(
-            CircuitData::from_packed_operations(num_qubits, 0, packed_insts, Param::Float(0.0))?
-                .into(),
-        )
+        Ok(CircuitData::from_packed_operations(
+            num_qubits,
+            0,
+            packed_insts,
+            Param::Float(0.0),
+        )?)
     }
 }
 

--- a/crates/circuit_library/src/multi_local.rs
+++ b/crates/circuit_library/src/multi_local.rs
@@ -238,7 +238,6 @@ pub fn n_local(
 #[pyo3(signature = (num_qubits, rotation_blocks, entanglement_blocks, entanglement, reps, insert_barriers, parameter_prefix, skip_final_rotation_layer, skip_unentangled_qubits))]
 #[allow(clippy::too_many_arguments)]
 pub fn py_n_local(
-    _py: Python,
     num_qubits: u32,
     rotation_blocks: Vec<PyRef<Block>>,
     entanglement_blocks: Vec<PyRef<Block>>,

--- a/crates/circuit_library/src/multi_local.rs
+++ b/crates/circuit_library/src/multi_local.rs
@@ -170,17 +170,15 @@ pub fn n_local(
 ) -> PyResult<CircuitData> {
     // Construct the parameter ledger, which will define all free parameters and provide
     // access to them, given an index for a layer and the current gate to implement.
-    let ledger = parameter_ledger_builder
-        .build_from_nlocal(
-            num_qubits,
-            reps,
-            entanglement,
-            rotation_blocks,
-            entanglement_blocks,
-            skip_final_rotation_layer,
-            parameter_prefix,
-        )
-        .unwrap();
+    let ledger = parameter_ledger_builder.build_from_nlocal(
+        num_qubits,
+        reps,
+        entanglement,
+        rotation_blocks,
+        entanglement_blocks,
+        skip_final_rotation_layer,
+        parameter_prefix,
+    )?;
 
     // Compute the qubits that are skipped in the rotation layer. If this is set,
     // we skip qubits that do not appear in any of the entanglement layers.

--- a/crates/circuit_library/src/multi_local.rs
+++ b/crates/circuit_library/src/multi_local.rs
@@ -24,10 +24,10 @@ use qiskit_circuit::{Clbit, Qubit};
 
 use itertools::izip;
 
+use crate::parameter_ledger::ParameterLedger;
+
 use super::blocks::{Block, Entanglement, LayerEntanglement};
-use super::parameter_ledger::{
-    LayerParameters, LayerType, LedgerBuilder, PyParameterLedgerBuilder,
-};
+use super::parameter_ledger::{LayerParameters, LayerType};
 
 type Instruction = (
     PackedOperation,
@@ -157,7 +157,6 @@ fn entanglement_layer<'a>(
 /// An N-local circuit.
 #[allow(clippy::too_many_arguments)]
 pub fn n_local(
-    parameter_ledger_builder: impl LedgerBuilder,
     num_qubits: u32,
     rotation_blocks: &[&Block],
     entanglement_blocks: &[&Block],
@@ -170,15 +169,15 @@ pub fn n_local(
 ) -> PyResult<CircuitData> {
     // Construct the parameter ledger, which will define all free parameters and provide
     // access to them, given an index for a layer and the current gate to implement.
-    let ledger = parameter_ledger_builder.build_from_nlocal(
+    let ledger = ParameterLedger::from_nlocal(
         num_qubits,
         reps,
         entanglement,
         rotation_blocks,
         entanglement_blocks,
         skip_final_rotation_layer,
-        parameter_prefix,
-    )?;
+        &parameter_prefix.to_string(),
+    );
 
     // Compute the qubits that are skipped in the rotation layer. If this is set,
     // we skip qubits that do not appear in any of the entanglement layers.
@@ -262,7 +261,6 @@ pub fn py_n_local(
     let entanglement = Entanglement::from_py(num_qubits, reps, entanglement, &entanglement_blocks)?;
 
     Ok(n_local(
-        PyParameterLedgerBuilder,
         num_qubits,
         &rotation_blocks,
         &entanglement_blocks,

--- a/crates/circuit_library/src/parameter_ledger.rs
+++ b/crates/circuit_library/src/parameter_ledger.rs
@@ -15,7 +15,6 @@ use pyo3::prelude::*;
 use qiskit_circuit::parameter::parameter_expression::ParameterExpression;
 use qiskit_circuit::parameter::symbol_expr::Symbol;
 use qiskit_circuit::{imports, operations::Param};
-use thiserror::Error;
 
 /// Enum to determine the type of circuit layer.
 pub(super) enum LayerType {
@@ -97,7 +96,7 @@ pub trait LedgerBuilder {
     fn build_parameter_vector(
         parameter_prefix: &str,
         num_parameters: usize,
-    ) -> Result<Vec<Param>, ParameterLedgerError>;
+    ) -> PyResult<Vec<Param>>;
 
     /// Initialize the ledger n-local input data. This will call Python to create a new
     /// ``ParameterVector`` of adequate size and compute all required indices to access
@@ -112,7 +111,7 @@ pub trait LedgerBuilder {
         entanglement_blocks: &[&Block],
         skip_final_rotation_layer: bool,
         parameter_prefix: &str,
-    ) -> Result<ParameterLedger, ParameterLedgerError> {
+    ) -> PyResult<ParameterLedger> {
         // if we keep the final layer (i.e. skip=false), add parameters on the final layer
         let final_layer_rep = match skip_final_rotation_layer {
             true => 0,
@@ -183,7 +182,7 @@ impl LedgerBuilder for ParameterLedgerBuilder {
     fn build_parameter_vector(
         parameter_prefix: &str,
         num_parameters: usize,
-    ) -> Result<Vec<Param>, ParameterLedgerError> {
+    ) -> PyResult<Vec<Param>> {
         Ok((0..num_parameters)
             .map(|i| {
                 Param::ParameterExpression(
@@ -205,26 +204,16 @@ impl LedgerBuilder for PyParameterLedgerBuilder {
     fn build_parameter_vector(
         parameter_prefix: &str,
         num_parameters: usize,
-    ) -> Result<Vec<Param>, ParameterLedgerError> {
+    ) -> PyResult<Vec<Param>> {
         // generate a ParameterVector Python-side, containing all parameters, and then
         // map it onto Rust-space parameters
-        match Python::attach(|py| {
+        Python::attach(|py| {
             imports::PARAMETER_VECTOR
                 .get_bound(py)
                 .call1((parameter_prefix, num_parameters))? // get the Python ParameterVector
                 .try_iter()? // iterate over the elements and cast them to Rust Params
                 .map(|ob| Param::extract_no_coerce(ob?.as_borrowed()))
                 .collect::<PyResult<_>>()
-        }) {
-            Ok(param_vec) => Ok(param_vec),
-            Err(err) => Err(ParameterLedgerError::PyParameterVectorError(err)),
-        }
+        })
     }
-}
-
-#[derive(Debug, Error)]
-pub enum ParameterLedgerError {
-    /// A general error when trying to build the parameter vector from the Python side
-    #[error["Failed creating Python parameter vector"]]
-    PyParameterVectorError(#[from] PyErr),
 }

--- a/crates/circuit_library/src/parameter_ledger.rs
+++ b/crates/circuit_library/src/parameter_ledger.rs
@@ -185,10 +185,14 @@ impl LedgerBuilder for ParameterLedgerBuilder {
         num_parameters: usize,
     ) -> Result<Vec<Param>, ParameterLedgerError> {
         Ok((0..num_parameters)
-            .map(|_| {
+            .map(|i| {
                 Param::ParameterExpression(
-                    ParameterExpression::from_symbol(Symbol::new(parameter_prefix, None, None))
-                        .into(),
+                    ParameterExpression::from_symbol(Symbol::new(
+                        &format!("{}[{}]", parameter_prefix, i),
+                        None,
+                        None,
+                    ))
+                    .into(),
                 )
             })
             .collect())

--- a/crates/circuit_library/src/parameter_ledger.rs
+++ b/crates/circuit_library/src/parameter_ledger.rs
@@ -10,10 +10,10 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use super::blocks::{Block, Entanglement};
 use pyo3::prelude::*;
 use qiskit_circuit::{imports, operations::Param};
-
-use super::blocks::{Block, Entanglement};
+use thiserror::Error;
 
 /// Enum to determine the type of circuit layer.
 pub(super) enum LayerType {
@@ -51,88 +51,6 @@ pub(super) struct ParameterLedger {
 }
 
 impl ParameterLedger {
-    /// Initialize the ledger n-local input data. This will call Python to create a new
-    /// ``ParameterVector`` of adequate size and compute all required indices to access
-    /// parameter of a specific layer.
-    #[allow(clippy::too_many_arguments)]
-    pub(super) fn from_nlocal(
-        py: Python,
-        num_qubits: u32,
-        reps: usize,
-        entanglement: &Entanglement,
-        rotation_blocks: &[&Block],
-        entanglement_blocks: &[&Block],
-        skip_final_rotation_layer: bool,
-        parameter_prefix: &String,
-    ) -> PyResult<Self> {
-        // if we keep the final layer (i.e. skip=false), add parameters on the final layer
-        let final_layer_rep = match skip_final_rotation_layer {
-            true => 0,
-            false => 1,
-        };
-
-        // compute the number of parameters used for the rotation layers
-        let mut num_rotation_params_per_layer: usize = 0;
-        let mut rotations: Vec<(u32, usize)> = Vec::new();
-
-        for block in rotation_blocks {
-            let num_blocks = num_qubits / block.num_qubits;
-            rotations.push((num_blocks, block.num_parameters));
-            num_rotation_params_per_layer += (num_blocks as usize) * block.num_parameters;
-        }
-
-        // compute the number of parameters used for the entanglement layers
-        let mut num_entangle_params_per_layer: Vec<usize> = Vec::with_capacity(reps);
-        let mut entanglements: Vec<Vec<(u32, usize)>> = Vec::with_capacity(reps);
-        for this_entanglement in entanglement.iter() {
-            let mut this_entanglements: Vec<(u32, usize)> = Vec::new();
-            let mut this_num_params: usize = 0;
-            for (block, block_entanglement) in entanglement_blocks.iter().zip(this_entanglement) {
-                let num_blocks = block_entanglement.len();
-                this_num_params += num_blocks * block.num_parameters;
-                this_entanglements.push((num_blocks as u32, block.num_parameters));
-            }
-            num_entangle_params_per_layer.push(this_num_params);
-            entanglements.push(this_entanglements);
-        }
-
-        let num_rotation_params: usize = (reps + final_layer_rep) * num_rotation_params_per_layer;
-        let num_entangle_params: usize = num_entangle_params_per_layer.iter().sum();
-
-        // generate a ParameterVector Python-side, containing all parameters, and then
-        // map it onto Rust-space parameters
-        let num_parameters = num_rotation_params + num_entangle_params;
-        let parameter_vector: Vec<Param> = imports::PARAMETER_VECTOR
-            .get_bound(py)
-            .call1((parameter_prefix, num_parameters))? // get the Python ParameterVector
-            .try_iter()? // iterate over the elements and cast them to Rust Params
-            .map(|ob| Param::extract_no_coerce(ob?.as_borrowed()))
-            .collect::<PyResult<_>>()?;
-
-        // finally, distribute the parameters onto the repetitions and blocks for each
-        // rotation layer and entanglement layer
-        let mut rotation_indices: Vec<usize> = Vec::with_capacity(reps + final_layer_rep);
-        let mut entangle_indices: Vec<usize> = Vec::with_capacity(reps);
-        let mut index: usize = 0;
-        for num_entangle in num_entangle_params_per_layer {
-            rotation_indices.push(index);
-            index += num_rotation_params_per_layer;
-            entangle_indices.push(index);
-            index += num_entangle;
-        }
-        if !skip_final_rotation_layer {
-            rotation_indices.push(index);
-        }
-
-        Ok(ParameterLedger {
-            parameter_vector,
-            rotation_indices,
-            entangle_indices,
-            rotations,
-            entanglements,
-        })
-    }
-
     /// Get the parameters in the rotation or entanglement layer.
     pub(super) fn get_parameters(&self, kind: LayerType, layer: usize) -> LayerParameters<'_> {
         let (mut index, blocks) = match kind {
@@ -171,4 +89,129 @@ impl ParameterLedger {
 
         parameters
     }
+}
+
+pub trait LedgerBuilder {
+    fn build_parameter_vector(
+        parameter_prefix: &String,
+        num_parameters: usize,
+    ) -> Result<Vec<Param>, ParameterLedgerError>;
+
+    /// Initialize the ledger n-local input data. This will call Python to create a new
+    /// ``ParameterVector`` of adequate size and compute all required indices to access
+    /// parameter of a specific layer.
+    #[allow(clippy::too_many_arguments)]
+    fn from_nlocal(
+        &self,
+        num_qubits: u32,
+        reps: usize,
+        entanglement: &Entanglement,
+        rotation_blocks: &[&Block],
+        entanglement_blocks: &[&Block],
+        skip_final_rotation_layer: bool,
+        parameter_prefix: &String,
+    ) -> Result<ParameterLedger, ParameterLedgerError> {
+        // if we keep the final layer (i.e. skip=false), add parameters on the final layer
+        let final_layer_rep = match skip_final_rotation_layer {
+            true => 0,
+            false => 1,
+        };
+
+        // compute the number of parameters used for the rotation layers
+        let mut num_rotation_params_per_layer: usize = 0;
+        let mut rotations: Vec<(u32, usize)> = Vec::new();
+
+        for block in rotation_blocks {
+            let num_blocks = num_qubits / block.num_qubits;
+            rotations.push((num_blocks, block.num_parameters));
+            num_rotation_params_per_layer += (num_blocks as usize) * block.num_parameters;
+        }
+
+        // compute the number of parameters used for the entanglement layers
+        let mut num_entangle_params_per_layer: Vec<usize> = Vec::with_capacity(reps);
+        let mut entanglements: Vec<Vec<(u32, usize)>> = Vec::with_capacity(reps);
+        for this_entanglement in entanglement.iter() {
+            let mut this_entanglements: Vec<(u32, usize)> = Vec::new();
+            let mut this_num_params: usize = 0;
+            for (block, block_entanglement) in entanglement_blocks.iter().zip(this_entanglement) {
+                let num_blocks = block_entanglement.len();
+                this_num_params += num_blocks * block.num_parameters;
+                this_entanglements.push((num_blocks as u32, block.num_parameters));
+            }
+            num_entangle_params_per_layer.push(this_num_params);
+            entanglements.push(this_entanglements);
+        }
+
+        let num_rotation_params: usize = (reps + final_layer_rep) * num_rotation_params_per_layer;
+        let num_entangle_params: usize = num_entangle_params_per_layer.iter().sum();
+
+        let num_parameters = num_rotation_params + num_entangle_params;
+
+        let parameter_vector: Vec<Param> =
+            Self::build_parameter_vector(parameter_prefix, num_parameters)?;
+
+        // finally, distribute the parameters onto the repetitions and blocks for each
+        // rotation layer and entanglement layer
+        let mut rotation_indices: Vec<usize> = Vec::with_capacity(reps + final_layer_rep);
+        let mut entangle_indices: Vec<usize> = Vec::with_capacity(reps);
+        let mut index: usize = 0;
+        for num_entangle in num_entangle_params_per_layer {
+            rotation_indices.push(index);
+            index += num_rotation_params_per_layer;
+            entangle_indices.push(index);
+            index += num_entangle;
+        }
+        if !skip_final_rotation_layer {
+            rotation_indices.push(index);
+        }
+
+        Ok(ParameterLedger {
+            parameter_vector,
+            rotation_indices,
+            entangle_indices,
+            rotations,
+            entanglements,
+        })
+    }
+}
+
+pub struct ParameterLedgerBuilder;
+
+impl LedgerBuilder for ParameterLedgerBuilder {
+    fn build_parameter_vector(
+        parameter_prefix: &String,
+        num_parameters: usize,
+    ) -> Result<Vec<Param>, ParameterLedgerError> {
+        Ok(Vec::with_capacity(num_parameters))
+    }
+}
+
+pub struct PyParameterLedgerBuilder;
+
+impl LedgerBuilder for PyParameterLedgerBuilder {
+    fn build_parameter_vector(
+        parameter_prefix: &String,
+        num_parameters: usize,
+    ) -> Result<Vec<Param>, ParameterLedgerError> {
+        // generate a ParameterVector Python-side, containing all parameters, and then
+        // map it onto Rust-space parameters
+        match Python::attach(|py| {
+            imports::PARAMETER_VECTOR
+                .get_bound(py)
+                .call1((parameter_prefix, num_parameters))? // get the Python ParameterVector
+                .try_iter()? // iterate over the elements and cast them to Rust Params
+                .map(|ob| Param::extract_no_coerce(ob?.as_borrowed()))
+                .collect::<PyResult<_>>()
+        }) {
+            Ok(param_vec) => Ok(param_vec),
+            Err(err) => Err(ParameterLedgerError::PyParameterVectorError(err)),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ParameterLedgerError {
+    /// A general error when trying to build the parameter vector from the Python side
+    #[error["Failed creating Python parameter vector"]]
+    PyParameterVectorError(#[from] PyErr),
 }

--- a/crates/circuit_library/src/parameter_ledger.rs
+++ b/crates/circuit_library/src/parameter_ledger.rs
@@ -13,7 +13,7 @@
 use super::blocks::{Block, Entanglement};
 use pyo3::prelude::*;
 use qiskit_circuit::parameter::parameter_expression::ParameterExpression;
-use qiskit_circuit::parameter::symbol_expr::{Symbol, SymbolExpr};
+use qiskit_circuit::parameter::symbol_expr::Symbol;
 use qiskit_circuit::{imports, operations::Param};
 use thiserror::Error;
 

--- a/crates/circuit_library/src/parameter_ledger.rs
+++ b/crates/circuit_library/src/parameter_ledger.rs
@@ -95,7 +95,7 @@ impl ParameterLedger {
 
 pub trait LedgerBuilder {
     fn build_parameter_vector(
-        parameter_prefix: &String,
+        parameter_prefix: &str,
         num_parameters: usize,
     ) -> Result<Vec<Param>, ParameterLedgerError>;
 
@@ -103,7 +103,7 @@ pub trait LedgerBuilder {
     /// ``ParameterVector`` of adequate size and compute all required indices to access
     /// parameter of a specific layer.
     #[allow(clippy::too_many_arguments)]
-    fn from_nlocal(
+    fn build_from_nlocal(
         &self,
         num_qubits: u32,
         reps: usize,
@@ -111,7 +111,7 @@ pub trait LedgerBuilder {
         rotation_blocks: &[&Block],
         entanglement_blocks: &[&Block],
         skip_final_rotation_layer: bool,
-        parameter_prefix: &String,
+        parameter_prefix: &str,
     ) -> Result<ParameterLedger, ParameterLedgerError> {
         // if we keep the final layer (i.e. skip=false), add parameters on the final layer
         let final_layer_rep = match skip_final_rotation_layer {
@@ -181,7 +181,7 @@ pub struct ParameterLedgerBuilder;
 
 impl LedgerBuilder for ParameterLedgerBuilder {
     fn build_parameter_vector(
-        parameter_prefix: &String,
+        parameter_prefix: &str,
         num_parameters: usize,
     ) -> Result<Vec<Param>, ParameterLedgerError> {
         Ok((0..num_parameters)
@@ -203,7 +203,7 @@ pub struct PyParameterLedgerBuilder;
 
 impl LedgerBuilder for PyParameterLedgerBuilder {
     fn build_parameter_vector(
-        parameter_prefix: &String,
+        parameter_prefix: &str,
         num_parameters: usize,
     ) -> Result<Vec<Param>, ParameterLedgerError> {
         // generate a ParameterVector Python-side, containing all parameters, and then

--- a/crates/circuit_library/src/parameter_ledger.rs
+++ b/crates/circuit_library/src/parameter_ledger.rs
@@ -186,9 +186,8 @@ impl LedgerBuilder for ParameterLedgerBuilder {
         Ok((0..num_parameters)
             .map(|i| {
                 Param::ParameterExpression(
-                    ParameterExpression::from_symbol(Symbol::new(
-                        &format!("{}[{}]", parameter_prefix, i),
-                        None,
+                    ParameterExpression::from_symbol(Symbol::standalone(
+                        format!("{}[{}]", parameter_prefix, i),
                         None,
                     ))
                     .into(),

--- a/crates/circuit_library/src/parameter_ledger.rs
+++ b/crates/circuit_library/src/parameter_ledger.rs
@@ -12,6 +12,8 @@
 
 use super::blocks::{Block, Entanglement};
 use pyo3::prelude::*;
+use qiskit_circuit::parameter::parameter_expression::ParameterExpression;
+use qiskit_circuit::parameter::symbol_expr::{Symbol, SymbolExpr};
 use qiskit_circuit::{imports, operations::Param};
 use thiserror::Error;
 
@@ -42,7 +44,7 @@ pub(super) type LayerParameters<'a> = Vec<BlockParameters<'a>>; // parameter in 
 ///     let params_in_that_layer: LayerParameters =
 ///         ledger.get_parameter(LayerType::Rotation, layer);
 ///
-pub(super) struct ParameterLedger {
+pub struct ParameterLedger {
     parameter_vector: Vec<Param>, // all parameters
     rotation_indices: Vec<usize>, // indices where rotation blocks start
     entangle_indices: Vec<usize>,
@@ -182,7 +184,14 @@ impl LedgerBuilder for ParameterLedgerBuilder {
         parameter_prefix: &String,
         num_parameters: usize,
     ) -> Result<Vec<Param>, ParameterLedgerError> {
-        Ok(Vec::with_capacity(num_parameters))
+        Ok((0..num_parameters)
+            .map(|_| {
+                Param::ParameterExpression(
+                    ParameterExpression::from_symbol(Symbol::new(parameter_prefix, None, None))
+                        .into(),
+                )
+            })
+            .collect())
     }
 }
 

--- a/crates/circuit_library/src/parameter_ledger.rs
+++ b/crates/circuit_library/src/parameter_ledger.rs
@@ -10,11 +10,12 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use qiskit_circuit::{
+    operations::Param,
+    parameter::{parameter_expression::ParameterExpression, symbol_expr::SymbolVector},
+};
+
 use super::blocks::{Block, Entanglement};
-use pyo3::prelude::*;
-use qiskit_circuit::parameter::parameter_expression::ParameterExpression;
-use qiskit_circuit::parameter::symbol_expr::SymbolVector;
-use qiskit_circuit::{imports, operations::Param};
 
 /// Enum to determine the type of circuit layer.
 pub(super) enum LayerType {
@@ -43,7 +44,7 @@ pub(super) type LayerParameters<'a> = Vec<BlockParameters<'a>>; // parameter in 
 ///     let params_in_that_layer: LayerParameters =
 ///         ledger.get_parameter(LayerType::Rotation, layer);
 ///
-pub struct ParameterLedger {
+pub(super) struct ParameterLedger {
     parameter_vector: Vec<Param>, // all parameters
     rotation_indices: Vec<usize>, // indices where rotation blocks start
     entangle_indices: Vec<usize>,
@@ -52,6 +53,87 @@ pub struct ParameterLedger {
 }
 
 impl ParameterLedger {
+    /// Initialize the ledger n-local input data. This will call Python to create a new
+    /// ``ParameterVector`` of adequate size and compute all required indices to access
+    /// parameter of a specific layer.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn from_nlocal(
+        num_qubits: u32,
+        reps: usize,
+        entanglement: &Entanglement,
+        rotation_blocks: &[&Block],
+        entanglement_blocks: &[&Block],
+        skip_final_rotation_layer: bool,
+        parameter_prefix: &String,
+    ) -> Self {
+        // if we keep the final layer (i.e. skip=false), add parameters on the final layer
+        let final_layer_rep = match skip_final_rotation_layer {
+            true => 0,
+            false => 1,
+        };
+
+        // compute the number of parameters used for the rotation layers
+        let mut num_rotation_params_per_layer: usize = 0;
+        let mut rotations: Vec<(u32, usize)> = Vec::new();
+
+        for block in rotation_blocks {
+            let num_blocks = num_qubits / block.num_qubits;
+            rotations.push((num_blocks, block.num_parameters));
+            num_rotation_params_per_layer += (num_blocks as usize) * block.num_parameters;
+        }
+
+        // compute the number of parameters used for the entanglement layers
+        let mut num_entangle_params_per_layer: Vec<usize> = Vec::with_capacity(reps);
+        let mut entanglements: Vec<Vec<(u32, usize)>> = Vec::with_capacity(reps);
+        for this_entanglement in entanglement.iter() {
+            let mut this_entanglements: Vec<(u32, usize)> = Vec::new();
+            let mut this_num_params: usize = 0;
+            for (block, block_entanglement) in entanglement_blocks.iter().zip(this_entanglement) {
+                let num_blocks = block_entanglement.len();
+                this_num_params += num_blocks * block.num_parameters;
+                this_entanglements.push((num_blocks as u32, block.num_parameters));
+            }
+            num_entangle_params_per_layer.push(this_num_params);
+            entanglements.push(this_entanglements);
+        }
+
+        let num_rotation_params: usize = (reps + final_layer_rep) * num_rotation_params_per_layer;
+        let num_entangle_params: usize = num_entangle_params_per_layer.iter().sum();
+
+        // generate a ParameterVector Python-side, containing all parameters, and then
+        // map it onto Rust-space parameters
+        let num_parameters = num_rotation_params + num_entangle_params;
+
+        let parameter_vector: Vec<Param> =
+            SymbolVector::new(parameter_prefix.to_string(), num_parameters)
+                .iter()
+                .map(|sym| Param::ParameterExpression(ParameterExpression::from_symbol(sym).into()))
+                .collect();
+
+        // finally, distribute the parameters onto the repetitions and blocks for each
+        // rotation layer and entanglement layer
+        let mut rotation_indices: Vec<usize> = Vec::with_capacity(reps + final_layer_rep);
+        let mut entangle_indices: Vec<usize> = Vec::with_capacity(reps);
+        let mut index: usize = 0;
+        for num_entangle in num_entangle_params_per_layer {
+            rotation_indices.push(index);
+            index += num_rotation_params_per_layer;
+            entangle_indices.push(index);
+            index += num_entangle;
+        }
+        if !skip_final_rotation_layer {
+            rotation_indices.push(index);
+        }
+
+        ParameterLedger {
+            parameter_vector,
+            rotation_indices,
+            entangle_indices,
+            rotations,
+            entanglements,
+        }
+    }
+
     /// Get the parameters in the rotation or entanglement layer.
     pub(super) fn get_parameters(&self, kind: LayerType, layer: usize) -> LayerParameters<'_> {
         let (mut index, blocks) = match kind {
@@ -89,125 +171,5 @@ impl ParameterLedger {
         }
 
         parameters
-    }
-}
-
-pub trait LedgerBuilder {
-    fn build_parameter_vector(
-        parameter_prefix: &str,
-        num_parameters: usize,
-    ) -> PyResult<Vec<Param>>;
-
-    /// Initialize the ledger n-local input data. This will call Python to create a new
-    /// ``ParameterVector`` of adequate size and compute all required indices to access
-    /// parameter of a specific layer.
-    #[allow(clippy::too_many_arguments)]
-    fn build_from_nlocal(
-        &self,
-        num_qubits: u32,
-        reps: usize,
-        entanglement: &Entanglement,
-        rotation_blocks: &[&Block],
-        entanglement_blocks: &[&Block],
-        skip_final_rotation_layer: bool,
-        parameter_prefix: &str,
-    ) -> PyResult<ParameterLedger> {
-        // if we keep the final layer (i.e. skip=false), add parameters on the final layer
-        let final_layer_rep = match skip_final_rotation_layer {
-            true => 0,
-            false => 1,
-        };
-
-        // compute the number of parameters used for the rotation layers
-        let mut num_rotation_params_per_layer: usize = 0;
-        let mut rotations: Vec<(u32, usize)> = Vec::new();
-
-        for block in rotation_blocks {
-            let num_blocks = num_qubits / block.num_qubits;
-            rotations.push((num_blocks, block.num_parameters));
-            num_rotation_params_per_layer += (num_blocks as usize) * block.num_parameters;
-        }
-
-        // compute the number of parameters used for the entanglement layers
-        let mut num_entangle_params_per_layer: Vec<usize> = Vec::with_capacity(reps);
-        let mut entanglements: Vec<Vec<(u32, usize)>> = Vec::with_capacity(reps);
-        for this_entanglement in entanglement.iter() {
-            let mut this_entanglements: Vec<(u32, usize)> = Vec::new();
-            let mut this_num_params: usize = 0;
-            for (block, block_entanglement) in entanglement_blocks.iter().zip(this_entanglement) {
-                let num_blocks = block_entanglement.len();
-                this_num_params += num_blocks * block.num_parameters;
-                this_entanglements.push((num_blocks as u32, block.num_parameters));
-            }
-            num_entangle_params_per_layer.push(this_num_params);
-            entanglements.push(this_entanglements);
-        }
-
-        let num_rotation_params: usize = (reps + final_layer_rep) * num_rotation_params_per_layer;
-        let num_entangle_params: usize = num_entangle_params_per_layer.iter().sum();
-
-        let num_parameters = num_rotation_params + num_entangle_params;
-
-        let parameter_vector: Vec<Param> =
-            Self::build_parameter_vector(parameter_prefix, num_parameters)?;
-
-        // finally, distribute the parameters onto the repetitions and blocks for each
-        // rotation layer and entanglement layer
-        let mut rotation_indices: Vec<usize> = Vec::with_capacity(reps + final_layer_rep);
-        let mut entangle_indices: Vec<usize> = Vec::with_capacity(reps);
-        let mut index: usize = 0;
-        for num_entangle in num_entangle_params_per_layer {
-            rotation_indices.push(index);
-            index += num_rotation_params_per_layer;
-            entangle_indices.push(index);
-            index += num_entangle;
-        }
-        if !skip_final_rotation_layer {
-            rotation_indices.push(index);
-        }
-
-        Ok(ParameterLedger {
-            parameter_vector,
-            rotation_indices,
-            entangle_indices,
-            rotations,
-            entanglements,
-        })
-    }
-}
-
-pub struct ParameterLedgerBuilder;
-
-impl LedgerBuilder for ParameterLedgerBuilder {
-    fn build_parameter_vector(
-        parameter_prefix: &str,
-        num_parameters: usize,
-    ) -> PyResult<Vec<Param>> {
-        Ok(
-            SymbolVector::new(parameter_prefix.to_string(), num_parameters)
-                .iter()
-                .map(|sym| Param::ParameterExpression(ParameterExpression::from_symbol(sym).into()))
-                .collect(),
-        )
-    }
-}
-
-pub struct PyParameterLedgerBuilder;
-
-impl LedgerBuilder for PyParameterLedgerBuilder {
-    fn build_parameter_vector(
-        parameter_prefix: &str,
-        num_parameters: usize,
-    ) -> PyResult<Vec<Param>> {
-        // generate a ParameterVector Python-side, containing all parameters, and then
-        // map it onto Rust-space parameters
-        Python::attach(|py| {
-            imports::PARAMETER_VECTOR
-                .get_bound(py)
-                .call1((parameter_prefix, num_parameters))? // get the Python ParameterVector
-                .try_iter()? // iterate over the elements and cast them to Rust Params
-                .map(|ob| Param::extract_no_coerce(ob?.as_borrowed()))
-                .collect::<PyResult<_>>()
-        })
     }
 }

--- a/crates/circuit_library/src/parameter_ledger.rs
+++ b/crates/circuit_library/src/parameter_ledger.rs
@@ -13,7 +13,7 @@
 use super::blocks::{Block, Entanglement};
 use pyo3::prelude::*;
 use qiskit_circuit::parameter::parameter_expression::ParameterExpression;
-use qiskit_circuit::parameter::symbol_expr::Symbol;
+use qiskit_circuit::parameter::symbol_expr::SymbolVector;
 use qiskit_circuit::{imports, operations::Param};
 
 /// Enum to determine the type of circuit layer.
@@ -183,17 +183,12 @@ impl LedgerBuilder for ParameterLedgerBuilder {
         parameter_prefix: &str,
         num_parameters: usize,
     ) -> PyResult<Vec<Param>> {
-        Ok((0..num_parameters)
-            .map(|i| {
-                Param::ParameterExpression(
-                    ParameterExpression::from_symbol(Symbol::standalone(
-                        format!("{}[{}]", parameter_prefix, i),
-                        None,
-                    ))
-                    .into(),
-                )
-            })
-            .collect())
+        Ok(
+            SymbolVector::new(parameter_prefix.to_string(), num_parameters)
+                .iter()
+                .map(|sym| Param::ParameterExpression(ParameterExpression::from_symbol(sym).into()))
+                .collect(),
+        )
     }
 }
 

--- a/releasenotes/notes/expose-n-local-to-c-api-a6e421ca5b10e62d.yaml
+++ b/releasenotes/notes/expose-n-local-to-c-api-a6e421ca5b10e62d.yaml
@@ -1,0 +1,41 @@
+---
+features_c:
+  - |
+    Exposed the n-local circuit to C API by adding the
+    circuit generator in the circuit library. 
+
+    A couple of new functions were added: 
+    * ``qk_circuit_library_n_local``
+    * ``qk_circuit_library_n_local_settings_default``
+
+    A new struct called ``QkNLocalSettings`` is added.
+    This struct holds information needed to build the n-local circuit.
+
+    A new enum called ``QkEntanglementStrategy`` is added. 
+    This enum has all the available entanglement strategies
+    to be used when generating the circuit.
+
+    The function ``qk_circuit_library_n_local`` is responsible of
+    generating the circuit and can be used as follows:
+
+    .. code-block:: C
+
+      uint32_t num_qubits = 2;
+
+      // Setup the `QkNLocalSettings`
+      QkNLocalSettings settings = qk_circuit_library_n_local_settings_default();
+      settings.reps = 2;
+      settings.entanglement_strategy = QkEntanglementStrategy_Linear;
+      settings.skip_final_rotation_layer = true;
+      settings.parameter_prefix = "θ";
+
+      // Setup the rotation and entanglement blocks
+      QkGate rotation_blocks[1] = {QkGate_H};
+      QkGate entanglement_blocks[1] = {QkGate_CRX};
+
+      // Create the circuit
+      QkCircuit *qc = qk_circuit_library_n_local(num_qubits, rotation_blocks, 1, 
+                                                 entanglement_blocks, 1, &settings);
+
+      // Free the object
+      qk_circuit_free(qc);

--- a/releasenotes/notes/expose-n-local-to-c-api-a6e421ca5b10e62d.yaml
+++ b/releasenotes/notes/expose-n-local-to-c-api-a6e421ca5b10e62d.yaml
@@ -1,41 +1,19 @@
 ---
 features_c:
   - |
-    Exposed the n-local circuit to C API by adding the
-    circuit generator in the circuit library. 
+    Exposed the n-local circuit to the C API. 
 
-    A couple of new functions were added: 
-    * ``qk_circuit_library_n_local``
-    * ``qk_circuit_library_n_local_settings_default``
+    * A couple of new functions were added: 
 
-    A new struct called ``QkNLocalSettings`` is added.
-    This struct holds information needed to build the n-local circuit.
+      * ``qk_circuit_library_n_local``
 
-    A new enum called ``QkEntanglementStrategy`` is added. 
-    This enum has all the available entanglement strategies
-    to be used when generating the circuit.
+        Constructs an n-local variational circuit.      
+      * ``qk_circuit_library_n_local_settings_default``
 
-    The function ``qk_circuit_library_n_local`` is responsible of
-    generating the circuit and can be used as follows:
+        Generates default options for ``qk_circuit_library_n_local``.
+    * New struct ``QkNLocalSettings`` is added.
 
-    .. code-block:: C
+      Holds settings needed to build the n-local circuit.
+    * New enum ``QkEntanglementStrategy`` is added. 
 
-      uint32_t num_qubits = 2;
-
-      // Setup the `QkNLocalSettings`
-      QkNLocalSettings settings = qk_circuit_library_n_local_settings_default();
-      settings.reps = 2;
-      settings.entanglement_strategy = QkEntanglementStrategy_Linear;
-      settings.skip_final_rotation_layer = true;
-      settings.parameter_prefix = "θ";
-
-      // Setup the rotation and entanglement blocks
-      QkGate rotation_blocks[1] = {QkGate_H};
-      QkGate entanglement_blocks[1] = {QkGate_CRX};
-
-      // Create the circuit
-      QkCircuit *qc = qk_circuit_library_n_local(num_qubits, rotation_blocks, 1, 
-                                                 entanglement_blocks, 1, &settings);
-
-      // Free the object
-      qk_circuit_free(qc);
+      Enum representing all the strategies that can be used for the circuit entanglement blocks.

--- a/test/c/test_nlocal.c
+++ b/test/c/test_nlocal.c
@@ -19,23 +19,94 @@
  * Test setting the entanglement of the layers by entanglement strategy
  */
 static int test_entanglement_by_strategy(void) {
-    // int result = (compare_circuits(qc, expected)) ? Ok : EqualityError;
-    char *paramenter_prefix = "";
+    int result = Ok;
+    int reps = 3;
 
-    QkGate rotation_blocks[1] = {QkGate_X};
     QkGate entanglement_blocks[1] = {QkGate_CCX};
 
-    QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
-        5, 3, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
+    uint32_t expected_connections_full[10][3] = {
+        {0, 1, 2}, {0, 1, 3}, {0, 1, 4}, {0, 2, 3}, {0, 2, 4},
+        {0, 3, 4}, {1, 2, 3}, {1, 2, 4}, {1, 3, 4}, {2, 3, 4},
+    };
+    uint32_t expected_connections_linear[3][3] = {{0, 1, 2}, {1, 2, 3}, {2, 3, 4}};
+    uint32_t expected_connections_reverse_linear[3][3] = {{2, 3, 4}, {1, 2, 3}, {0, 1, 2}};
+    uint32_t expected_connections_circular[5][3] = {
+        {3, 4, 0}, {4, 0, 1}, {0, 1, 2}, {1, 2, 3}, {2, 3, 4}};
+    uint32_t expected_connections_sca[5][3] = {{0}};
 
-    QkCircuit *qc = qk_n_local(rotation_blocks, 1, entanglement_blocks, 1, entanglement, 5, 3,
-                               paramenter_prefix, false, false);
+    for (size_t strategy = 0; strategy < 5; strategy++) {
 
-    
+        QkEntanglement *entanglement =
+            qk_get_entanglement_with_strategy(5, reps, strategy, entanglement_blocks, 1);
 
-    qk_circuit_free(qc);
+        if (qk_get_entanglement_layers_quantity(entanglement) != (size_t)reps) {
+            result = EqualityError;
+        }
 
-    return Ok;
+        if (qk_get_entanglement_layer_blocks_quantity(entanglement, 0) != (size_t)1) {
+            result = EqualityError;
+        }
+
+        bool break_loop = false;
+        for (size_t i = 0; i < (size_t)reps; i++) {
+            if (break_loop)
+                break;
+
+            uint32_t (*expected_connections)[3] = NULL;
+            uint32_t expected_connections_length;
+            switch (strategy) {
+            case QkEntanglementStrategy_Full:
+                expected_connections = expected_connections_full;
+                expected_connections_length = 10;
+                break;
+            case QkEntanglementStrategy_Linear:
+                expected_connections = expected_connections_linear;
+                expected_connections_length = 3;
+                break;
+            case QkEntanglementStrategy_ReverseLinear:
+                expected_connections = expected_connections_reverse_linear;
+                expected_connections_length = 3;
+                break;
+            case QkEntanglementStrategy_Sca:
+                expected_connections_length = 5;
+                for (size_t k = 0; k < expected_connections_length; k++) {
+                    int offset = ((int)k) - ((int)i);
+                    int ind = offset >= 0 ? offset : expected_connections_length + offset;
+                    for (size_t m = 0; m < 3; m++) {
+                        expected_connections_sca[k][m] =
+                            expected_connections_circular[ind][i % 2 == 1 ? 2 - m : m];
+                    }
+                }
+                expected_connections = expected_connections_sca;
+                break;
+            case QkEntanglementStrategy_Circular:
+                expected_connections = expected_connections_circular;
+                expected_connections_length = 5;
+                break;
+            }
+
+            if (qk_get_entanglement_qubit_connections_quantity(entanglement, i, 0) !=
+                expected_connections_length) {
+                result = EqualityError;
+                break_loop = true;
+                break;
+            }
+
+            for (size_t j = 0; j < expected_connections_length; j++) {
+                uint32_t *connections = *(expected_connections + j);
+                QkQubitConnection *expected_connection = qk_qubit_connection_new(3, connections);
+                QkQubitConnection *connection =
+                    qk_get_entanglement_qubit_connections(entanglement, i, 0, j);
+
+                if (!qk_qubit_connection_equal(connection, expected_connection)) {
+                    result = EqualityError;
+                    break_loop = true;
+                    break;
+                }
+            }
+        }
+    }
+    return result;
 }
 
 int test_nlocal(void) {

--- a/test/c/test_nlocal.c
+++ b/test/c/test_nlocal.c
@@ -109,10 +109,48 @@ static int test_entanglement_by_strategy(void) {
     return result;
 }
 
+static int test_pairwise_entanglement(void) {
+    int result = Ok;
+    int reps = 1;
+
+    QkGate entanglement_blocks[1] = {QkGate_CX};
+    QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
+        5, reps, QkEntanglementStrategy_Pairwise, entanglement_blocks, 1);
+
+    if (qk_get_entanglement_layers_quantity(entanglement) != (size_t)reps) {
+        result = EqualityError;
+    }
+
+    if (qk_get_entanglement_layer_blocks_quantity(entanglement, 0) != (size_t)1) {
+        result = EqualityError;
+    }
+
+    if (qk_get_entanglement_qubit_connections_quantity(entanglement, 0, 0) != 4) {
+        result = EqualityError;
+    }
+
+    uint32_t expected_connections_pairwise[4][2] = {{0, 1}, {2, 3}, {1, 2}, {3, 4}};
+
+    for (size_t i = 0; i < 4; i++) {
+        uint32_t *connections = expected_connections_pairwise[i];
+        QkQubitConnection *expected_connection = qk_qubit_connection_new(2, connections);
+        QkQubitConnection *connection =
+            qk_get_entanglement_qubit_connections(entanglement, 0, 0, i);
+
+        if (!qk_qubit_connection_equal(connection, expected_connection)) {
+            result = EqualityError;
+            break;
+        }
+    }
+
+    return result;
+}
+
 int test_nlocal(void) {
     int num_failed = 0;
 
     num_failed += RUN_TEST(test_entanglement_by_strategy);
+    num_failed += RUN_TEST(test_pairwise_entanglement);
 
     fflush(stderr);
     fprintf(stderr, "=== Number of failed subtests (n_local): %i\n", num_failed);

--- a/test/c/test_nlocal.c
+++ b/test/c/test_nlocal.c
@@ -1,0 +1,50 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2025.
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+#include "common.h"
+#include <math.h>
+#include <qiskit.h>
+#include <string.h>
+
+/**
+ * Test setting the entanglement of the layers by entanglement strategy
+ */
+static int test_entanglement_by_strategy(void) {
+    // int result = (compare_circuits(qc, expected)) ? Ok : EqualityError;
+    char *paramenter_prefix = "";
+
+    QkGate rotation_blocks[1] = {QkGate_X};
+    QkGate entanglement_blocks[1] = {QkGate_CCX};
+
+    QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
+        5, 3, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
+
+    QkCircuit *qc = qk_n_local(rotation_blocks, 1, entanglement_blocks, 1, entanglement, 5, 3,
+                               paramenter_prefix, false, false);
+
+    
+
+    qk_circuit_free(qc);
+
+    return Ok;
+}
+
+int test_nlocal(void) {
+    int num_failed = 0;
+
+    num_failed += RUN_TEST(test_entanglement_by_strategy);
+
+    fflush(stderr);
+    fprintf(stderr, "=== Number of failed subtests (n_local): %i\n", num_failed);
+
+    return num_failed;
+}

--- a/test/c/test_nlocal.c
+++ b/test/c/test_nlocal.c
@@ -1,6 +1,6 @@
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2025.
+// (C) Copyright IBM 2026.
 //
 // This code is licensed under the Apache License, Version 2.0. You may
 // obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -14,6 +14,96 @@
 #include <math.h>
 #include <qiskit.h>
 #include <string.h>
+
+static int test_nlocal_circuit_creation(void) {
+    size_t num_qubits = 5;
+    int reps = 2;
+
+    QkCircuit *expected = qk_circuit_new(num_qubits, 0);
+
+    // Add first rotation layer for X Gate
+    for (size_t i = 0; i < num_qubits; i++) {
+        qk_circuit_gate(expected, QkGate_X, (uint32_t[1]){i}, NULL);
+    }
+
+    qk_circuit_barrier(expected, (uint32_t[5]){0, 1, 2, 3, 4}, 5);
+
+    // Add first entanglement layer for CCX Gate
+    for (size_t i = 0; i < 3; i++) {
+        qk_circuit_gate(expected, QkGate_CCX, (uint32_t[3]){i, i + 1, i + 2}, NULL);
+    }
+
+    qk_circuit_barrier(expected, (uint32_t[5]){0, 1, 2, 3, 4}, 5);
+
+    // Add second rotation layer for X Gate
+    for (size_t i = 0; i < num_qubits; i++) {
+        qk_circuit_gate(expected, QkGate_X, (uint32_t[1]){i}, NULL);
+    }
+
+    qk_circuit_barrier(expected, (uint32_t[5]){0, 1, 2, 3, 4}, 5);
+
+    // Add second entanglement layer for CCX Gate
+    for (size_t i = 0; i < 3; i++) {
+        qk_circuit_gate(expected, QkGate_CCX, (uint32_t[3]){i, i + 1, i + 2}, NULL);
+    }
+    qk_circuit_barrier(expected, (uint32_t[5]){0, 1, 2, 3, 4}, 5);
+
+    // Add final rotation layer for X Gate
+    for (size_t i = 0; i < num_qubits; i++) {
+        qk_circuit_gate(expected, QkGate_X, (uint32_t[1]){i}, NULL);
+    }
+
+    QkGate entanglement_blocks[1] = {QkGate_CCX};
+    QkGate rotation_blocks[1] = {QkGate_X};
+
+    QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
+        num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
+
+    QkCircuit *qc = qk_n_local(rotation_blocks, 1, entanglement_blocks, 1, entanglement, num_qubits,
+                               reps, NULL, true, false);
+
+    int result = (compare_circuits(qc, expected)) ? Ok : EqualityError;
+
+    qk_circuit_free(qc);
+    qk_circuit_free(expected);
+
+    return result;
+}
+
+static int test_parameter_prefix(void) {
+    int result = Ok;
+    size_t num_qubits = 2;
+    int reps = 1;
+
+    QkGate rotation_blocks[1] = {QkGate_H};
+    QkGate entanglement_blocks[1] = {QkGate_CRX};
+    QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
+        num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
+
+    char *prefix = "myprefix";
+
+    QkCircuit *qc = qk_n_local(rotation_blocks, 1, entanglement_blocks, 1, entanglement, num_qubits,
+                               reps, prefix, false, true);
+
+    QkCircuitInstruction inst;
+    for (size_t i = 0; i < qk_circuit_num_instructions(qc); i++) {
+        qk_circuit_get_instruction(qc, i, &inst);
+        if (strstr(inst.name, "crx") != NULL) {
+            char *parameter_str = qk_param_str(inst.params[0]);
+            if (strcmp(parameter_str, "myprefix[0]") != 0) {
+                result = EqualityError;
+                qk_str_free(parameter_str);
+                break;
+            }
+            qk_str_free(parameter_str);
+        }
+    }
+
+    qk_circuit_instruction_clear(&inst);
+    qk_circuit_free(qc);
+
+    return result;
+}
 
 /**
  * Test setting the entanglement of the layers by entanglement strategy
@@ -109,7 +199,7 @@ static int test_entanglement_by_strategy(void) {
     return result;
 }
 
-static int test_pairwise_entanglement(void) {
+static int test_pairwise_entanglement_strategy(void) {
     int result = Ok;
     int reps = 1;
 
@@ -149,8 +239,10 @@ static int test_pairwise_entanglement(void) {
 int test_nlocal(void) {
     int num_failed = 0;
 
+    num_failed += RUN_TEST(test_nlocal_circuit_creation);
+    num_failed += RUN_TEST(test_parameter_prefix);
     num_failed += RUN_TEST(test_entanglement_by_strategy);
-    num_failed += RUN_TEST(test_pairwise_entanglement);
+    num_failed += RUN_TEST(test_pairwise_entanglement_strategy);
 
     fflush(stderr);
     fprintf(stderr, "=== Number of failed subtests (n_local): %i\n", num_failed);

--- a/test/c/test_nlocal.c
+++ b/test/c/test_nlocal.c
@@ -167,6 +167,8 @@ static int test_entanglement_by_strategy(void) {
         {3, 4, 0}, {4, 0, 1}, {0, 1, 2}, {1, 2, 3}, {2, 3, 4}};
     uint32_t expected_connections_sca[5][3] = {{0}};
 
+    uint32_t(*expected_connections)[3] = NULL;
+    uint32_t expected_connections_length;
     for (QkEntanglementStrategy strategy = 0; strategy < 5; strategy++) {
 
         QkEntanglement *entanglement =
@@ -185,8 +187,6 @@ static int test_entanglement_by_strategy(void) {
             if (break_loop)
                 break;
 
-            uint32_t (*expected_connections)[3] = NULL;
-            uint32_t expected_connections_length;
             switch (strategy) {
             case QkEntanglementStrategy_Full:
                 expected_connections = expected_connections_full;

--- a/test/c/test_nlocal.c
+++ b/test/c/test_nlocal.c
@@ -64,6 +64,7 @@ static int test_nlocal_circuit_creation(void) {
 
     int result = (compare_circuits(qc, expected)) ? Ok : EqualityError;
 
+    qk_entanglement_free(entanglement);
     qk_circuit_free(qc);
     qk_circuit_free(expected);
 
@@ -99,6 +100,7 @@ static int test_parameter_prefix(void) {
         }
     }
 
+    qk_entanglement_free(entanglement);
     qk_circuit_instruction_clear(&inst);
     qk_circuit_free(qc);
 
@@ -195,6 +197,7 @@ static int test_entanglement_by_strategy(void) {
                 }
             }
         }
+        qk_entanglement_free(entanglement);
     }
     return result;
 }
@@ -229,8 +232,13 @@ static int test_pairwise_entanglement_strategy(void) {
 
         if (!qk_qubit_connection_equal(connection, expected_connection)) {
             result = EqualityError;
+            qk_qubit_connection_free(expected_connection);
+            qk_qubit_connection_free(connection);
             break;
         }
+
+        qk_qubit_connection_free(expected_connection);
+        qk_qubit_connection_free(connection);
     }
 
     return result;

--- a/test/c/test_nlocal.c
+++ b/test/c/test_nlocal.c
@@ -74,7 +74,7 @@ static int test_nlocal_circuit_creation(void) {
 static int test_parameter_prefix(void) {
     int result = Ok;
     size_t num_qubits = 2;
-    int reps = 1;
+    int reps = 2;
 
     QkGate rotation_blocks[1] = {QkGate_H};
     QkGate entanglement_blocks[1] = {QkGate_CRX};
@@ -82,6 +82,7 @@ static int test_parameter_prefix(void) {
         num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
 
     char *prefix = "myprefix";
+    size_t prefix_len = strlen(prefix);
 
     QkCircuit *qc = qk_n_local(rotation_blocks, 1, entanglement_blocks, 1, entanglement, num_qubits,
                                reps, prefix, false, true);
@@ -91,7 +92,7 @@ static int test_parameter_prefix(void) {
         qk_circuit_get_instruction(qc, i, &inst);
         if (strstr(inst.name, "crx") != NULL) {
             char *parameter_str = qk_param_str(inst.params[0]);
-            if (strcmp(parameter_str, "myprefix[0]") != 0) {
+            if (strncmp(parameter_str, prefix, prefix_len) != 0) {
                 result = EqualityError;
                 qk_str_free(parameter_str);
                 break;
@@ -104,6 +105,47 @@ static int test_parameter_prefix(void) {
     qk_circuit_instruction_clear(&inst);
     qk_circuit_free(qc);
 
+    return result;
+}
+
+static int test_entanglement_by_multiple_strategy(void) {
+    int result = Ok;
+    int reps = 1;
+    int num_qubits = 5;
+
+    QkGate entanglement_blocks[2] = {QkGate_CCX, QkGate_CSwap};
+
+    QkEntanglementStrategy strategies[2] = {QkEntanglementStrategy_Linear,
+                                            QkEntanglementStrategy_ReverseLinear};
+
+    uint32_t expected_connections[6][3] = {{0, 1, 2}, {1, 2, 3}, {2, 3, 4},
+                                           {2, 3, 4}, {1, 2, 3}, {0, 1, 2}};
+
+    QkEntanglement *entanglement = qk_get_entanglement_with_multiple_strategy(
+        num_qubits, reps, strategies, 2, entanglement_blocks, 2);
+
+    bool break_loop = false;
+    for (size_t i = 0;
+         (i < qk_get_entanglement_layer_blocks_quantity(entanglement, 0)) && !break_loop; i++) {
+
+        for (size_t j = 0; j < qk_get_entanglement_qubit_connections_quantity(entanglement, 0, i);
+             j++) {
+            QkQubitConnection *connection =
+                qk_get_entanglement_qubit_connections(entanglement, 0, i, j);
+            QkQubitConnection *expected_connection =
+                qk_qubit_connection_new(3, expected_connections[((6 * i) / 2) + j]);
+            if (!qk_qubit_connection_equal(connection, expected_connection)) {
+                result = EqualityError;
+                break_loop = true;
+                qk_qubit_connection_free(expected_connection);
+                qk_qubit_connection_free(connection);
+                break;
+            }
+            qk_qubit_connection_free(expected_connection);
+            qk_qubit_connection_free(connection);
+        }
+    }
+    qk_entanglement_free(entanglement);
     return result;
 }
 
@@ -193,8 +235,12 @@ static int test_entanglement_by_strategy(void) {
                 if (!qk_qubit_connection_equal(connection, expected_connection)) {
                     result = EqualityError;
                     break_loop = true;
+                    qk_qubit_connection_free(expected_connection);
+                    qk_qubit_connection_free(connection);
                     break;
                 }
+                qk_qubit_connection_free(expected_connection);
+                qk_qubit_connection_free(connection);
             }
         }
         qk_entanglement_free(entanglement);
@@ -249,6 +295,7 @@ int test_nlocal(void) {
 
     num_failed += RUN_TEST(test_nlocal_circuit_creation);
     num_failed += RUN_TEST(test_parameter_prefix);
+    num_failed += RUN_TEST(test_entanglement_by_multiple_strategy);
     num_failed += RUN_TEST(test_entanglement_by_strategy);
     num_failed += RUN_TEST(test_pairwise_entanglement_strategy);
 

--- a/test/c/test_nlocal.c
+++ b/test/c/test_nlocal.c
@@ -15,56 +15,93 @@
 #include <qiskit.h>
 #include <string.h>
 
-static int test_nlocal_circuit_creation(void) {
+static void build_circuit_based_on_entanglement_strategy(uint32_t num_qubits, uint32_t reps,
+                                                         QkCircuit *circuit,
+                                                         QkEntanglementStrategy strategy) {
+
+    uint32_t connections_full[10][3] = {
+        {0, 1, 2}, {0, 1, 3}, {0, 1, 4}, {0, 2, 3}, {0, 2, 4},
+        {0, 3, 4}, {1, 2, 3}, {1, 2, 4}, {1, 3, 4}, {2, 3, 4},
+    };
+    uint32_t connections_linear[3][3] = {{0, 1, 2}, {1, 2, 3}, {2, 3, 4}};
+    uint32_t connections_reverse_linear[3][3] = {{2, 3, 4}, {1, 2, 3}, {0, 1, 2}};
+    uint32_t connections_circular[5][3] = {{3, 4, 0}, {4, 0, 1}, {0, 1, 2}, {1, 2, 3}, {2, 3, 4}};
+
+    for (uint32_t i = 0; i < reps; i++) {
+        // Add rotation layer for Y Gate
+        for (uint32_t j = 0; j < num_qubits; j++) {
+            qk_circuit_gate(circuit, QkGate_Y, (uint32_t[1]){j}, NULL);
+        }
+        // Add entanglement layer for CCX Gate
+        switch (strategy) {
+        case QkEntanglementStrategy_Full:
+            for (size_t j = 0; j < 10; j++) {
+                qk_circuit_gate(circuit, QkGate_CCX, connections_full[j], NULL);
+            }
+            break;
+        case QkEntanglementStrategy_Linear:
+            for (size_t j = 0; j < 3; j++) {
+                qk_circuit_gate(circuit, QkGate_CCX, connections_linear[j], NULL);
+            }
+            break;
+        case QkEntanglementStrategy_ReverseLinear:
+            for (size_t j = 0; j < 3; j++) {
+                qk_circuit_gate(circuit, QkGate_CCX, connections_reverse_linear[j], NULL);
+            }
+            break;
+        case QkEntanglementStrategy_Circular:
+            for (size_t j = 0; j < 5; j++) {
+                qk_circuit_gate(circuit, QkGate_CCX, connections_circular[j], NULL);
+            }
+            break;
+        case QkEntanglementStrategy_Sca:
+            for (size_t k = 0; k < 5; k++) {
+                int offset = ((int)k) - ((int)i);
+                int ind = offset >= 0 ? offset : 5 + offset;
+                uint32_t connection[3] = {0};
+                for (size_t m = 0; m < 3; m++) {
+                    connection[m] = connections_circular[ind][i % 2 == 1 ? 2 - m : m];
+                }
+                qk_circuit_gate(circuit, QkGate_CCX, connection, NULL);
+            }
+            break;
+        }
+    }
+}
+
+static int test_nlocal_circuit_creation_with_default_settings(void) {
     uint32_t num_qubits = 5;
-    int reps = 2;
+    size_t reps = 3;
+
+    uint32_t expected_connections[10][2] = {{0, 1}, {0, 2}, {0, 3}, {0, 4}, {1, 2},
+                                            {1, 3}, {1, 4}, {2, 3}, {2, 4}, {3, 4}};
 
     QkCircuit *expected = qk_circuit_new(num_qubits, 0);
 
-    // Add first rotation layer for X Gate
-    for (uint32_t i = 0; i < num_qubits; i++) {
-        qk_circuit_gate(expected, QkGate_X, (uint32_t[1]){i}, NULL);
+    for (size_t i = 0; i < reps; i++) {
+        // Add first rotation layer for X Gate
+        for (uint32_t j = 0; j < num_qubits; j++) {
+            qk_circuit_gate(expected, QkGate_X, (uint32_t[1]){j}, NULL);
+        }
+
+        // Add first entanglement layer for CX Gate
+        for (uint32_t j = 0; j < 10; j++) {
+            qk_circuit_gate(expected, QkGate_CX, expected_connections[j], NULL);
+        }
+    }
+    // Add final rotation layer
+    for (uint32_t j = 0; j < num_qubits; j++) {
+        qk_circuit_gate(expected, QkGate_X, (uint32_t[1]){j}, NULL);
     }
 
-    qk_circuit_barrier(expected, (uint32_t[5]){0, 1, 2, 3, 4}, 5);
-
-    // Add first entanglement layer for CCX Gate
-    for (uint32_t i = 0; i < 3; i++) {
-        qk_circuit_gate(expected, QkGate_CCX, (uint32_t[3]){i, i + 1, i + 2}, NULL);
-    }
-
-    qk_circuit_barrier(expected, (uint32_t[5]){0, 1, 2, 3, 4}, 5);
-
-    // Add second rotation layer for X Gate
-    for (uint32_t i = 0; i < num_qubits; i++) {
-        qk_circuit_gate(expected, QkGate_X, (uint32_t[1]){i}, NULL);
-    }
-
-    qk_circuit_barrier(expected, (uint32_t[5]){0, 1, 2, 3, 4}, 5);
-
-    // Add second entanglement layer for CCX Gate
-    for (uint32_t i = 0; i < 3; i++) {
-        qk_circuit_gate(expected, QkGate_CCX, (uint32_t[3]){i, i + 1, i + 2}, NULL);
-    }
-    qk_circuit_barrier(expected, (uint32_t[5]){0, 1, 2, 3, 4}, 5);
-
-    // Add final rotation layer for X Gate
-    for (uint32_t i = 0; i < num_qubits; i++) {
-        qk_circuit_gate(expected, QkGate_X, (uint32_t[1]){i}, NULL);
-    }
-
-    QkGate entanglement_blocks[1] = {QkGate_CCX};
     QkGate rotation_blocks[1] = {QkGate_X};
+    QkGate entanglement_blocks[1] = {QkGate_CX};
 
-    QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
-        num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
-
-    QkCircuit *qc = qk_n_local(rotation_blocks, 1, entanglement_blocks, 1, entanglement, num_qubits,
-                               reps, NULL, true, false);
+    QkCircuit *qc =
+        qk_circuit_library_n_local(num_qubits, rotation_blocks, 1, entanglement_blocks, 1, NULL);
 
     int result = (compare_circuits(qc, expected)) ? Ok : EqualityError;
 
-    qk_entanglement_free(entanglement);
     qk_circuit_free(qc);
     qk_circuit_free(expected);
 
@@ -74,25 +111,27 @@ static int test_nlocal_circuit_creation(void) {
 static int test_parameter_prefix(void) {
     int result = Ok;
     uint32_t num_qubits = 2;
-    int reps = 2;
 
     QkGate rotation_blocks[1] = {QkGate_H};
     QkGate entanglement_blocks[1] = {QkGate_CRX};
-    QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
-        num_qubits, reps, QkEntanglementStrategy_Linear, entanglement_blocks, 1);
 
-    char *prefix = "myprefix";
-    size_t prefix_len = strlen(prefix);
+    QkNLocalSettings settings = qk_circuit_library_n_local_settings_default();
+    settings.reps = 2;
+    settings.entanglement_strategy = QkEntanglementStrategy_Linear;
+    settings.skip_final_rotation_layer = true;
 
-    QkCircuit *qc = qk_n_local(rotation_blocks, 1, entanglement_blocks, 1, entanglement, num_qubits,
-                               reps, prefix, false, true);
+    settings.parameter_prefix = "myprefix";
+    size_t prefix_len = strlen(settings.parameter_prefix);
+
+    QkCircuit *qc = qk_circuit_library_n_local(num_qubits, rotation_blocks, 1, entanglement_blocks,
+                                               1, &settings);
 
     QkCircuitInstruction inst;
     for (size_t i = 0; i < qk_circuit_num_instructions(qc); i++) {
         qk_circuit_get_instruction(qc, i, &inst);
         if (strstr(inst.name, "crx") != NULL) {
             char *parameter_str = qk_param_str(inst.params[0]);
-            if (strncmp(parameter_str, prefix, prefix_len) != 0) {
+            if (strncmp(parameter_str, settings.parameter_prefix, prefix_len) != 0) {
                 result = EqualityError;
                 qk_str_free(parameter_str);
                 break;
@@ -101,50 +140,52 @@ static int test_parameter_prefix(void) {
         }
     }
 
-    qk_entanglement_free(entanglement);
     qk_circuit_instruction_clear(&inst);
     qk_circuit_free(qc);
 
     return result;
 }
 
-static int test_entanglement_by_multiple_strategy(void) {
-    int result = Ok;
-    int reps = 1;
-    int num_qubits = 5;
+static int test_insert_barrier(void) {
+    uint32_t num_qubits = 5;
 
-    uint32_t expected_connections[6][3] = {{0, 1, 2}, {1, 2, 3}, {2, 3, 4},
-                                           {2, 3, 4}, {1, 2, 3}, {0, 1, 2}};
+    uint32_t expected_connections[10][3] = {
+        {0, 1, 2}, {0, 1, 3}, {0, 1, 4}, {0, 2, 3}, {0, 2, 4},
+        {0, 3, 4}, {1, 2, 3}, {1, 2, 4}, {1, 3, 4}, {2, 3, 4},
+    };
 
-    QkGate entanglement_blocks[2] = {QkGate_CCX, QkGate_CSwap};
-    QkEntanglementStrategy strategies[2] = {QkEntanglementStrategy_Linear,
-                                            QkEntanglementStrategy_ReverseLinear};
+    QkCircuit *expected = qk_circuit_new(num_qubits, 0);
 
-    QkEntanglement *entanglement = qk_get_entanglement_with_multiple_strategy(
-        num_qubits, reps, strategies, 2, entanglement_blocks, 2);
-
-    bool break_loop = false;
-    for (size_t i = 0;
-         (i < qk_get_entanglement_layer_blocks_quantity(entanglement, 0)) && !break_loop; i++) {
-
-        for (size_t j = 0; j < qk_get_entanglement_qubit_connections_quantity(entanglement, 0, i);
-             j++) {
-            QkQubitConnection *connection =
-                qk_get_entanglement_qubit_connections(entanglement, 0, i, j);
-            QkQubitConnection *expected_connection =
-                qk_qubit_connection_new(3, expected_connections[((6 * i) / 2) + j]);
-            if (!qk_qubit_connection_equal(connection, expected_connection)) {
-                result = EqualityError;
-                break_loop = true;
-                qk_qubit_connection_free(expected_connection);
-                qk_qubit_connection_free(connection);
-                break;
-            }
-            qk_qubit_connection_free(expected_connection);
-            qk_qubit_connection_free(connection);
-        }
+    // Add first rotation layer for X Gate
+    for (uint32_t j = 0; j < num_qubits; j++) {
+        qk_circuit_gate(expected, QkGate_X, (uint32_t[1]){j}, NULL);
     }
-    qk_entanglement_free(entanglement);
+
+    qk_circuit_barrier(expected, (uint32_t[5]){0, 1, 2, 3, 4}, num_qubits);
+
+    // Add first entanglement layer for CCX Gate
+    for (uint32_t j = 0; j < 10; j++) {
+        qk_circuit_gate(expected, QkGate_CCX, expected_connections[j], NULL);
+    }
+
+    qk_circuit_barrier(expected, (uint32_t[5]){0, 1, 2, 3, 4}, num_qubits);
+
+    QkGate rotation_blocks[1] = {QkGate_X};
+    QkGate entanglement_blocks[1] = {QkGate_CCX};
+
+    QkNLocalSettings settings = qk_circuit_library_n_local_settings_default();
+    settings.reps = 1;
+    settings.insert_barriers = true;
+    settings.skip_final_rotation_layer = true;
+
+    QkCircuit *qc = qk_circuit_library_n_local(num_qubits, rotation_blocks, 1, entanglement_blocks,
+                                               1, &settings);
+
+    int result = (compare_circuits(qc, expected)) ? Ok : EqualityError;
+
+    qk_circuit_free(qc);
+    qk_circuit_free(expected);
+
     return result;
 }
 
@@ -152,139 +193,115 @@ static int test_entanglement_by_multiple_strategy(void) {
  * Test setting the entanglement of the layers by entanglement strategy
  */
 static int test_entanglement_by_strategy(void) {
+    int num_qubits = 5;
     int result = Ok;
-    int reps = 3;
+    uint32_t reps = 3;
 
+    char *strategies[] = {"Full", "Linear", "ReverseLinear", "Circular", "SCA"};
+
+    // Full entanglement strategy
+    QkCircuit *expected_full = qk_circuit_new(num_qubits, 0);
+    build_circuit_based_on_entanglement_strategy(num_qubits, reps, expected_full,
+                                                 QkEntanglementStrategy_Full);
+
+    // Linear entanglement strategy
+    QkCircuit *expected_linear = qk_circuit_new(num_qubits, 0);
+    build_circuit_based_on_entanglement_strategy(num_qubits, reps, expected_linear,
+                                                 QkEntanglementStrategy_Linear);
+
+    // ReverseLinear entanglement strategy
+    QkCircuit *expected_revlinear = qk_circuit_new(num_qubits, 0);
+    build_circuit_based_on_entanglement_strategy(num_qubits, reps, expected_revlinear,
+                                                 QkEntanglementStrategy_ReverseLinear);
+
+    // Circular entanglement strategy
+    QkCircuit *expected_circular = qk_circuit_new(num_qubits, 0);
+    build_circuit_based_on_entanglement_strategy(num_qubits, reps, expected_circular,
+                                                 QkEntanglementStrategy_Circular);
+
+    // SCA entanglement strategy
+    QkCircuit *expected_sca = qk_circuit_new(num_qubits, 0);
+    build_circuit_based_on_entanglement_strategy(num_qubits, reps, expected_sca,
+                                                 QkEntanglementStrategy_Sca);
+
+    QkGate rotation_blocks[1] = {QkGate_Y};
     QkGate entanglement_blocks[1] = {QkGate_CCX};
 
-    uint32_t expected_connections_full[10][3] = {
-        {0, 1, 2}, {0, 1, 3}, {0, 1, 4}, {0, 2, 3}, {0, 2, 4},
-        {0, 3, 4}, {1, 2, 3}, {1, 2, 4}, {1, 3, 4}, {2, 3, 4},
-    };
-    uint32_t expected_connections_linear[3][3] = {{0, 1, 2}, {1, 2, 3}, {2, 3, 4}};
-    uint32_t expected_connections_reverse_linear[3][3] = {{2, 3, 4}, {1, 2, 3}, {0, 1, 2}};
-    uint32_t expected_connections_circular[5][3] = {
-        {3, 4, 0}, {4, 0, 1}, {0, 1, 2}, {1, 2, 3}, {2, 3, 4}};
-    uint32_t expected_connections_sca[5][3] = {{0}};
-
-    uint32_t(*expected_connections)[3] = NULL;
-    uint32_t expected_connections_length;
     for (QkEntanglementStrategy strategy = 0; strategy < 5; strategy++) {
+        QkNLocalSettings settings = qk_circuit_library_n_local_settings_default();
+        settings.entanglement_strategy = strategy;
+        settings.reps = reps;
+        settings.skip_final_rotation_layer = true;
 
-        QkEntanglement *entanglement =
-            qk_get_entanglement_with_strategy(5, reps, strategy, entanglement_blocks, 1);
-
-        if (qk_get_entanglement_layers_quantity(entanglement) != (size_t)reps) {
+        QkCircuit *qc = qk_circuit_library_n_local(num_qubits, rotation_blocks, 1,
+                                                   entanglement_blocks, 1, &settings);
+        QkCircuit *expected = NULL;
+        switch (strategy) {
+        case QkEntanglementStrategy_Full:
+            expected = expected_full;
+            break;
+        case QkEntanglementStrategy_Linear:
+            expected = expected_linear;
+            break;
+        case QkEntanglementStrategy_ReverseLinear:
+            expected = expected_revlinear;
+            break;
+        case QkEntanglementStrategy_Circular:
+            expected = expected_circular;
+            break;
+        case QkEntanglementStrategy_Sca:
+            expected = expected_sca;
+            break;
+        }
+        if (!(compare_circuits(qc, expected))) {
             result = EqualityError;
+            printf("Strategy %s failed", strategies[(size_t)strategy]);
+            qk_circuit_free(qc);
+            goto cleanup;
         }
-
-        if (qk_get_entanglement_layer_blocks_quantity(entanglement, 0) != (size_t)1) {
-            result = EqualityError;
-        }
-
-        bool break_loop = false;
-        for (size_t i = 0; i < (size_t)reps; i++) {
-            if (break_loop)
-                break;
-
-            switch (strategy) {
-            case QkEntanglementStrategy_Full:
-                expected_connections = expected_connections_full;
-                expected_connections_length = 10;
-                break;
-            case QkEntanglementStrategy_Linear:
-                expected_connections = expected_connections_linear;
-                expected_connections_length = 3;
-                break;
-            case QkEntanglementStrategy_ReverseLinear:
-                expected_connections = expected_connections_reverse_linear;
-                expected_connections_length = 3;
-                break;
-            case QkEntanglementStrategy_Sca:
-                expected_connections_length = 5;
-                for (size_t k = 0; k < expected_connections_length; k++) {
-                    int offset = ((int)k) - ((int)i);
-                    int ind = offset >= 0 ? offset : ((int)expected_connections_length) + offset;
-                    for (size_t m = 0; m < 3; m++) {
-                        expected_connections_sca[k][m] =
-                            expected_connections_circular[ind][i % 2 == 1 ? 2 - m : m];
-                    }
-                }
-                expected_connections = expected_connections_sca;
-                break;
-            case QkEntanglementStrategy_Circular:
-                expected_connections = expected_connections_circular;
-                expected_connections_length = 5;
-                break;
-            }
-
-            if (qk_get_entanglement_qubit_connections_quantity(entanglement, i, 0) !=
-                expected_connections_length) {
-                result = EqualityError;
-                break_loop = true;
-                break;
-            }
-
-            for (size_t j = 0; j < expected_connections_length; j++) {
-                uint32_t *connections = *(expected_connections + j);
-                QkQubitConnection *expected_connection = qk_qubit_connection_new(3, connections);
-                QkQubitConnection *connection =
-                    qk_get_entanglement_qubit_connections(entanglement, i, 0, j);
-
-                if (!qk_qubit_connection_equal(connection, expected_connection)) {
-                    result = EqualityError;
-                    break_loop = true;
-                    qk_qubit_connection_free(expected_connection);
-                    qk_qubit_connection_free(connection);
-                    break;
-                }
-                qk_qubit_connection_free(expected_connection);
-                qk_qubit_connection_free(connection);
-            }
-        }
-        qk_entanglement_free(entanglement);
+        qk_circuit_free(qc);
     }
+    goto cleanup;
+cleanup:
+    qk_circuit_free(expected_full);
+    qk_circuit_free(expected_linear);
+    qk_circuit_free(expected_revlinear);
+    qk_circuit_free(expected_circular);
+    qk_circuit_free(expected_sca);
     return result;
 }
 
 static int test_pairwise_entanglement_strategy(void) {
-    int result = Ok;
-    int reps = 1;
+    uint32_t num_qubits = 5;
 
+    QkCircuit *expected = qk_circuit_new(num_qubits, 0);
+
+    // Add rotation layer for X Gate
+    for (uint32_t i = 0; i < num_qubits; i++) {
+        qk_circuit_gate(expected, QkGate_X, (uint32_t[1]){i}, NULL);
+    }
+
+    // Add entanglement layer for CX Gate
+    qk_circuit_gate(expected, QkGate_CX, (uint32_t[2]){0, 1}, NULL);
+    qk_circuit_gate(expected, QkGate_CX, (uint32_t[2]){2, 3}, NULL);
+    qk_circuit_gate(expected, QkGate_CX, (uint32_t[2]){1, 2}, NULL);
+    qk_circuit_gate(expected, QkGate_CX, (uint32_t[2]){3, 4}, NULL);
+
+    QkGate rotation_blocks[1] = {QkGate_X};
     QkGate entanglement_blocks[1] = {QkGate_CX};
-    QkEntanglement *entanglement = qk_get_entanglement_with_strategy(
-        5, reps, QkEntanglementStrategy_Pairwise, entanglement_blocks, 1);
 
-    if (qk_get_entanglement_layers_quantity(entanglement) != (size_t)reps) {
-        result = EqualityError;
-    }
+    QkNLocalSettings settings = qk_circuit_library_n_local_settings_default();
+    settings.entanglement_strategy = QkEntanglementStrategy_Pairwise;
+    settings.reps = 1;
+    settings.skip_final_rotation_layer = true;
 
-    if (qk_get_entanglement_layer_blocks_quantity(entanglement, 0) != (size_t)1) {
-        result = EqualityError;
-    }
+    QkCircuit *qc = qk_circuit_library_n_local(num_qubits, rotation_blocks, 1, entanglement_blocks,
+                                               1, &settings);
 
-    if (qk_get_entanglement_qubit_connections_quantity(entanglement, 0, 0) != 4) {
-        result = EqualityError;
-    }
+    int result = (compare_circuits(qc, expected)) ? Ok : EqualityError;
 
-    uint32_t expected_connections_pairwise[4][2] = {{0, 1}, {2, 3}, {1, 2}, {3, 4}};
-
-    for (size_t i = 0; i < 4; i++) {
-        uint32_t *connections = expected_connections_pairwise[i];
-        QkQubitConnection *expected_connection = qk_qubit_connection_new(2, connections);
-        QkQubitConnection *connection =
-            qk_get_entanglement_qubit_connections(entanglement, 0, 0, i);
-
-        if (!qk_qubit_connection_equal(connection, expected_connection)) {
-            result = EqualityError;
-            qk_qubit_connection_free(expected_connection);
-            qk_qubit_connection_free(connection);
-            break;
-        }
-
-        qk_qubit_connection_free(expected_connection);
-        qk_qubit_connection_free(connection);
-    }
+    qk_circuit_free(qc);
+    qk_circuit_free(expected);
 
     return result;
 }
@@ -292,9 +309,9 @@ static int test_pairwise_entanglement_strategy(void) {
 int test_nlocal(void) {
     int num_failed = 0;
 
-    num_failed += RUN_TEST(test_nlocal_circuit_creation);
+    num_failed += RUN_TEST(test_nlocal_circuit_creation_with_default_settings);
     num_failed += RUN_TEST(test_parameter_prefix);
-    num_failed += RUN_TEST(test_entanglement_by_multiple_strategy);
+    num_failed += RUN_TEST(test_insert_barrier);
     num_failed += RUN_TEST(test_entanglement_by_strategy);
     num_failed += RUN_TEST(test_pairwise_entanglement_strategy);
 

--- a/test/c/test_nlocal.c
+++ b/test/c/test_nlocal.c
@@ -16,40 +16,40 @@
 #include <string.h>
 
 static int test_nlocal_circuit_creation(void) {
-    size_t num_qubits = 5;
+    uint32_t num_qubits = 5;
     int reps = 2;
 
     QkCircuit *expected = qk_circuit_new(num_qubits, 0);
 
     // Add first rotation layer for X Gate
-    for (size_t i = 0; i < num_qubits; i++) {
+    for (uint32_t i = 0; i < num_qubits; i++) {
         qk_circuit_gate(expected, QkGate_X, (uint32_t[1]){i}, NULL);
     }
 
     qk_circuit_barrier(expected, (uint32_t[5]){0, 1, 2, 3, 4}, 5);
 
     // Add first entanglement layer for CCX Gate
-    for (size_t i = 0; i < 3; i++) {
+    for (uint32_t i = 0; i < 3; i++) {
         qk_circuit_gate(expected, QkGate_CCX, (uint32_t[3]){i, i + 1, i + 2}, NULL);
     }
 
     qk_circuit_barrier(expected, (uint32_t[5]){0, 1, 2, 3, 4}, 5);
 
     // Add second rotation layer for X Gate
-    for (size_t i = 0; i < num_qubits; i++) {
+    for (uint32_t i = 0; i < num_qubits; i++) {
         qk_circuit_gate(expected, QkGate_X, (uint32_t[1]){i}, NULL);
     }
 
     qk_circuit_barrier(expected, (uint32_t[5]){0, 1, 2, 3, 4}, 5);
 
     // Add second entanglement layer for CCX Gate
-    for (size_t i = 0; i < 3; i++) {
+    for (uint32_t i = 0; i < 3; i++) {
         qk_circuit_gate(expected, QkGate_CCX, (uint32_t[3]){i, i + 1, i + 2}, NULL);
     }
     qk_circuit_barrier(expected, (uint32_t[5]){0, 1, 2, 3, 4}, 5);
 
     // Add final rotation layer for X Gate
-    for (size_t i = 0; i < num_qubits; i++) {
+    for (uint32_t i = 0; i < num_qubits; i++) {
         qk_circuit_gate(expected, QkGate_X, (uint32_t[1]){i}, NULL);
     }
 
@@ -73,7 +73,7 @@ static int test_nlocal_circuit_creation(void) {
 
 static int test_parameter_prefix(void) {
     int result = Ok;
-    size_t num_qubits = 2;
+    uint32_t num_qubits = 2;
     int reps = 2;
 
     QkGate rotation_blocks[1] = {QkGate_H};
@@ -204,7 +204,7 @@ static int test_entanglement_by_strategy(void) {
                 expected_connections_length = 5;
                 for (size_t k = 0; k < expected_connections_length; k++) {
                     int offset = ((int)k) - ((int)i);
-                    int ind = offset >= 0 ? offset : expected_connections_length + offset;
+                    int ind = offset >= 0 ? offset : ((int)expected_connections_length) + offset;
                     for (size_t m = 0; m < 3; m++) {
                         expected_connections_sca[k][m] =
                             expected_connections_circular[ind][i % 2 == 1 ? 2 - m : m];

--- a/test/c/test_nlocal.c
+++ b/test/c/test_nlocal.c
@@ -113,13 +113,12 @@ static int test_entanglement_by_multiple_strategy(void) {
     int reps = 1;
     int num_qubits = 5;
 
-    QkGate entanglement_blocks[2] = {QkGate_CCX, QkGate_CSwap};
-
-    QkEntanglementStrategy strategies[2] = {QkEntanglementStrategy_Linear,
-                                            QkEntanglementStrategy_ReverseLinear};
-
     uint32_t expected_connections[6][3] = {{0, 1, 2}, {1, 2, 3}, {2, 3, 4},
                                            {2, 3, 4}, {1, 2, 3}, {0, 1, 2}};
+
+    QkGate entanglement_blocks[2] = {QkGate_CCX, QkGate_CSwap};
+    QkEntanglementStrategy strategies[2] = {QkEntanglementStrategy_Linear,
+                                            QkEntanglementStrategy_ReverseLinear};
 
     QkEntanglement *entanglement = qk_get_entanglement_with_multiple_strategy(
         num_qubits, reps, strategies, 2, entanglement_blocks, 2);

--- a/test/c/test_nlocal.c
+++ b/test/c/test_nlocal.c
@@ -167,7 +167,7 @@ static int test_entanglement_by_strategy(void) {
         {3, 4, 0}, {4, 0, 1}, {0, 1, 2}, {1, 2, 3}, {2, 3, 4}};
     uint32_t expected_connections_sca[5][3] = {{0}};
 
-    for (size_t strategy = 0; strategy < 5; strategy++) {
+    for (QkEntanglementStrategy strategy = 0; strategy < 5; strategy++) {
 
         QkEntanglement *entanglement =
             qk_get_entanglement_with_strategy(5, reps, strategy, entanglement_blocks, 1);

--- a/test/c/test_nlocal.c
+++ b/test/c/test_nlocal.c
@@ -300,6 +300,46 @@ cleanup:
     return result;
 }
 
+static int test_pairwise_with_3_qubits(void) {
+    int num_qubits = 3;
+    QkGate rotation_blocks[3] = {QkGate_X, QkGate_Z, QkGate_Y};
+    QkGate entanglement_blocks[1] = {QkGate_CCX};
+    QkNLocalSettings settings = qk_circuit_library_n_local_settings_default();
+    settings.entanglement_strategy = QkEntanglementStrategy_Pairwise;
+    QkCircuit *qc = qk_circuit_library_n_local(num_qubits, rotation_blocks, 3, entanglement_blocks,
+                                               1, &settings);
+    if (qc != NULL) {
+        printf("Inconsistent result when testing pairwise entanglement with 3 qubits: A null "
+               "response was expected, "
+               "but it was obtain a circuit");
+        qk_circuit_free(qc);
+        return EqualityError;
+    }
+    return Ok;
+}
+
+/*
+ * Test CCX gate on 2 qubits on full entanglement
+ */
+static int test_full_entaglement_with_3_qubit_gate_for_2_qubits(void) {
+    //
+    int num_qubits = 2;
+    QkGate rotation_blocks[1] = {QkGate_X};
+    QkGate entanglement_blocks[1] = {QkGate_CCX};
+    QkCircuit *qc =
+        qk_circuit_library_n_local(num_qubits, rotation_blocks, 1, entanglement_blocks, 1, NULL);
+
+    if (qc != NULL) {
+        printf("Inconsistent result when testing 2 qubits with a 3 qubit gate: A null "
+               "response was expected, "
+               "but it was obtain a circuit");
+        qk_circuit_free(qc);
+        return EqualityError;
+    }
+
+    return Ok;
+}
+
 int test_nlocal(void) {
     int num_failed = 0;
 
@@ -307,6 +347,8 @@ int test_nlocal(void) {
     num_failed += RUN_TEST(test_parameter_prefix);
     num_failed += RUN_TEST(test_insert_barrier);
     num_failed += RUN_TEST(test_entanglement_by_strategy);
+    num_failed += RUN_TEST(test_pairwise_with_3_qubits);
+    num_failed += RUN_TEST(test_full_entaglement_with_3_qubit_gate_for_2_qubits);
 
     fflush(stderr);
     fprintf(stderr, "=== Number of failed subtests (n_local): %i\n", num_failed);

--- a/test/c/test_nlocal.c
+++ b/test/c/test_nlocal.c
@@ -295,6 +295,7 @@ cleanup:
     qk_circuit_free(expected_linear);
     qk_circuit_free(expected_revlinear);
     qk_circuit_free(expected_circular);
+    qk_circuit_free(expected_pairwise);
     qk_circuit_free(expected_sca);
     return result;
 }

--- a/test/c/test_nlocal.c
+++ b/test/c/test_nlocal.c
@@ -310,8 +310,7 @@ static int test_pairwise_with_3_qubits(void) {
                                                1, &settings);
     if (qc != NULL) {
         printf("Inconsistent result when testing pairwise entanglement with 3 qubits: A null "
-               "response was expected, "
-               "but it was obtain a circuit");
+               "response was expected, but a circuit was obtained.");
         qk_circuit_free(qc);
         return EqualityError;
     }
@@ -321,8 +320,7 @@ static int test_pairwise_with_3_qubits(void) {
 /*
  * Test CCX gate on 2 qubits on full entanglement
  */
-static int test_full_entaglement_with_3_qubit_gate_for_2_qubits(void) {
-    //
+static int test_full_entanglement_with_3_qubit_gate_for_2_qubits(void) {
     int num_qubits = 2;
     QkGate rotation_blocks[1] = {QkGate_X};
     QkGate entanglement_blocks[1] = {QkGate_CCX};
@@ -331,8 +329,7 @@ static int test_full_entaglement_with_3_qubit_gate_for_2_qubits(void) {
 
     if (qc != NULL) {
         printf("Inconsistent result when testing 2 qubits with a 3 qubit gate: A null "
-               "response was expected, "
-               "but it was obtain a circuit");
+               "response was expected, but a circuit was returned.");
         qk_circuit_free(qc);
         return EqualityError;
     }
@@ -348,7 +345,7 @@ int test_nlocal(void) {
     num_failed += RUN_TEST(test_insert_barrier);
     num_failed += RUN_TEST(test_entanglement_by_strategy);
     num_failed += RUN_TEST(test_pairwise_with_3_qubits);
-    num_failed += RUN_TEST(test_full_entaglement_with_3_qubit_gate_for_2_qubits);
+    num_failed += RUN_TEST(test_full_entanglement_with_3_qubit_gate_for_2_qubits);
 
     fflush(stderr);
     fprintf(stderr, "=== Number of failed subtests (n_local): %i\n", num_failed);

--- a/test/c/test_nlocal.c
+++ b/test/c/test_nlocal.c
@@ -27,6 +27,21 @@ static void build_circuit_based_on_entanglement_strategy(uint32_t num_qubits, ui
     uint32_t connections_reverse_linear[3][3] = {{2, 3, 4}, {1, 2, 3}, {0, 1, 2}};
     uint32_t connections_circular[5][3] = {{3, 4, 0}, {4, 0, 1}, {0, 1, 2}, {1, 2, 3}, {2, 3, 4}};
 
+    if (strategy == QkEntanglementStrategy_Pairwise) {
+        // Add rotation layer for X Gate
+        for (uint32_t i = 0; i < (uint32_t)num_qubits; i++) {
+            qk_circuit_gate(circuit, QkGate_X, (uint32_t[1]){i}, NULL);
+        }
+
+        // Add entanglement layer for CX Gate
+        qk_circuit_gate(circuit, QkGate_CX, (uint32_t[2]){0, 1}, NULL);
+        qk_circuit_gate(circuit, QkGate_CX, (uint32_t[2]){2, 3}, NULL);
+        qk_circuit_gate(circuit, QkGate_CX, (uint32_t[2]){1, 2}, NULL);
+        qk_circuit_gate(circuit, QkGate_CX, (uint32_t[2]){3, 4}, NULL);
+
+        return;
+    }
+
     for (uint32_t i = 0; i < reps; i++) {
         // Add rotation layer for Y Gate
         for (uint32_t j = 0; j < num_qubits; j++) {
@@ -224,17 +239,28 @@ static int test_entanglement_by_strategy(void) {
     build_circuit_based_on_entanglement_strategy(num_qubits, reps, expected_sca,
                                                  QkEntanglementStrategy_Sca);
 
+    // Pairwise entanglement strategy
+    QkCircuit *expected_pairwise = qk_circuit_new(num_qubits, 0);
+    build_circuit_based_on_entanglement_strategy(num_qubits, 1, expected_pairwise,
+                                                 QkEntanglementStrategy_Pairwise);
+
+    QkGate p_rotation_blocks[1] = {QkGate_X};
+    QkGate p_entanglement_blocks[1] = {QkGate_CX};
+
     QkGate rotation_blocks[1] = {QkGate_Y};
     QkGate entanglement_blocks[1] = {QkGate_CCX};
 
     for (QkEntanglementStrategy strategy = 0; strategy < 5; strategy++) {
+        bool is_pairwise = strategy == QkEntanglementStrategy_Pairwise;
         QkNLocalSettings settings = qk_circuit_library_n_local_settings_default();
         settings.entanglement_strategy = strategy;
-        settings.reps = reps;
+        settings.reps = is_pairwise ? 1 : reps;
         settings.skip_final_rotation_layer = true;
 
-        QkCircuit *qc = qk_circuit_library_n_local(num_qubits, rotation_blocks, 1,
-                                                   entanglement_blocks, 1, &settings);
+        QkCircuit *qc = qk_circuit_library_n_local(
+            num_qubits, is_pairwise ? p_rotation_blocks : rotation_blocks, 1,
+            is_pairwise ? p_entanglement_blocks : entanglement_blocks, 1, &settings);
+
         QkCircuit *expected = NULL;
         switch (strategy) {
         case QkEntanglementStrategy_Full:
@@ -252,6 +278,8 @@ static int test_entanglement_by_strategy(void) {
         case QkEntanglementStrategy_Sca:
             expected = expected_sca;
             break;
+        case QkEntanglementStrategy_Pairwise:
+            expected = expected_pairwise;
         }
         if (!(compare_circuits(qc, expected))) {
             result = EqualityError;
@@ -271,41 +299,6 @@ cleanup:
     return result;
 }
 
-static int test_pairwise_entanglement_strategy(void) {
-    uint32_t num_qubits = 5;
-
-    QkCircuit *expected = qk_circuit_new(num_qubits, 0);
-
-    // Add rotation layer for X Gate
-    for (uint32_t i = 0; i < num_qubits; i++) {
-        qk_circuit_gate(expected, QkGate_X, (uint32_t[1]){i}, NULL);
-    }
-
-    // Add entanglement layer for CX Gate
-    qk_circuit_gate(expected, QkGate_CX, (uint32_t[2]){0, 1}, NULL);
-    qk_circuit_gate(expected, QkGate_CX, (uint32_t[2]){2, 3}, NULL);
-    qk_circuit_gate(expected, QkGate_CX, (uint32_t[2]){1, 2}, NULL);
-    qk_circuit_gate(expected, QkGate_CX, (uint32_t[2]){3, 4}, NULL);
-
-    QkGate rotation_blocks[1] = {QkGate_X};
-    QkGate entanglement_blocks[1] = {QkGate_CX};
-
-    QkNLocalSettings settings = qk_circuit_library_n_local_settings_default();
-    settings.entanglement_strategy = QkEntanglementStrategy_Pairwise;
-    settings.reps = 1;
-    settings.skip_final_rotation_layer = true;
-
-    QkCircuit *qc = qk_circuit_library_n_local(num_qubits, rotation_blocks, 1, entanglement_blocks,
-                                               1, &settings);
-
-    int result = (compare_circuits(qc, expected)) ? Ok : EqualityError;
-
-    qk_circuit_free(qc);
-    qk_circuit_free(expected);
-
-    return result;
-}
-
 int test_nlocal(void) {
     int num_failed = 0;
 
@@ -313,7 +306,6 @@ int test_nlocal(void) {
     num_failed += RUN_TEST(test_parameter_prefix);
     num_failed += RUN_TEST(test_insert_barrier);
     num_failed += RUN_TEST(test_entanglement_by_strategy);
-    num_failed += RUN_TEST(test_pairwise_entanglement_strategy);
 
     fflush(stderr);
     fprintf(stderr, "=== Number of failed subtests (n_local): %i\n", num_failed);


### PR DESCRIPTION
### Summary

This pull request exposes the n_local variational circuit within the C API.

#### 1. `BlockOperation` and module `crates/circuit_library/src/multi_local.rs` functions `rotation_layer` and `entanglement_layer` were modified
It was removed the python dependency when calling `BlockOperation::assign_parameters`. This has the caveat of using `Python::attach` every time it's added a parameter in case the function is called from Python. Then, the functions `rotation_layer` and `entanglement_layer` don't have anymore the `py` parameter.

#### 2. Module `crates/circuit_library/src/parameter_ledger.rs` impl `ParameterLedger` and module `crates/circuit_library/src/multi_local.rs` functions `n_local` and `py_n_local` were modified

With the ability of building parameter vectors from rust, the function `from_nlocal` of `ParameterLedger` was modified so the parameter vector built is now owned by the rust side. 

The above produces to not need anymore the `py` parameter on `py_n_local` and `n_local`.

#### 3. Module `crates/cext/src/circuit_library/n_local.rs` was added
- New struct `NLocalSettings` was added for ease of configuration
- New enum called `EntanglementStrategy` was added for easier usage of entanglement strategies.

**There are a couple of new functions created:**
- `qk_circuit_library_n_local`
- `qk_circuit_library_n_local_settings_default`

#### 4. As part of this work, some APIs were made public:

- module`circuit_library/blocks`
- module`circuit_library/entanglement` 
- module`circuit_library/multi_local`
- module`circuit_library/parameter_ledger` 
- `ParameterLedger` struct from `crates/circuit_library/src/parameter_ledger.rs`
- `entanglement_vec` field on struct `Entanglement` from `crates/circuit_library/src/blocks.rs`

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
