### PR TITLE
Add allow_non_hermitian parameter to BitArray.expectation_values (depends on #16443 related to fixes #11393)

### DIFF
--- a/qiskit/primitives/containers/bit_array.py
+++ b/qiskit/primitives/containers/bit_array.py
@@ -610,25 +610,28 @@ class BitArray(ShapedMixin):
             num_bits=self.num_bits,
         )
 
-    def expectation_values(self, observables: ObservablesArrayLike) -> NDArray[np.float64]:
+    def expectation_values(
+        self,
+        observables: ObservablesArrayLike,
+        allow_non_hermitian: bool = False,
+    ) -> NDArray[np.float64] | NDArray[np.complex128]:
         """Compute the expectation values of the provided observables, broadcasted against
         this bit array.
-
-        .. note::
-
-            This method returns the real part of the expectation value even if
-            the operator has complex coefficients due to the specification of
-            :func:`~.sampled_expectation_value`.
 
         Args:
             observables: The observable(s) to take the expectation value of.
                 Must have a shape broadcastable with this bit array and
                 the same number of qubits as the number of bits of this bit array.
                 The observables must be diagonal (I, Z, 0 or 1) too.
+            allow_non_hermitian: If True, non-Hermitian observables with complex
+                coefficients are accepted. When passed, the return type becomes
+                ``NDArray[np.complex128]`` for complex-valued coefficients.
+                Default: False.
 
         Returns:
             An array of expectation values whose shape is the broadcast shape of ``observables``
-            and this bit array.
+            and this bit array. The dtype is ``float64``; when ``allow_non_hermitian=True``
+            and the input has complex coefficients, returns ``complex128``.
 
         Raises:
             ValueError: If the provided observables does not have a shape broadcastable with
@@ -636,12 +639,23 @@ class BitArray(ShapedMixin):
             ValueError: If the provided observables does not have the same number of qubits as
                 the number of bits of this bit array.
             ValueError: If the provided observables are not diagonal.
+            ValueError: If ``allow_non_hermitian=False`` and the input is non-Hermitian.
         """
         observables = ObservablesArray.coerce(observables)
         arr_indices = np.fromiter(np.ndindex(self.shape), dtype=object).reshape(self.shape)
         bc_indices, bc_obs = np.broadcast_arrays(arr_indices, observables)
         counts = {}
-        arr = np.zeros_like(bc_indices, dtype=float)
+        arr = np.zeros_like(bc_indices, dtype=complex)
+
+        if allow_non_hermitian:
+            # Rebuild dicts from raw SparseObservable to keep complex coeffs.
+            # Copy bc_obs since broadcast_arrays returns read-only views.
+            bc_obs = bc_obs.copy()
+            raw_obs = observables.sparse_observables_array()  # type: ignore[union-attr]
+            bc_raw = np.broadcast_to(raw_obs, bc_obs.shape)
+            for ndi in np.ndindex(bc_obs.shape):
+                bc_obs[ndi] = ObservablesArray._obs_to_complex_dict(bc_raw[ndi])
+
         for index in np.ndindex(bc_indices.shape):
             loc = bc_indices[index]
             for pauli, coeff in bc_obs[index].items():
@@ -652,7 +666,7 @@ class BitArray(ShapedMixin):
                 except QiskitError as ex:
                     raise ValueError(ex.message) from ex
                 arr[index] += expval * coeff
-        return arr
+        return np.real_if_close(arr)
 
     @staticmethod
     def concatenate(bit_arrays: Sequence[BitArray], axis: int = 0) -> BitArray:

--- a/qiskit/primitives/containers/observables_array.py
+++ b/qiskit/primitives/containers/observables_array.py
@@ -14,6 +14,7 @@
 """
 ND-Array container class for Estimator observables.
 """
+
 from __future__ import annotations
 
 from copy import deepcopy
@@ -28,7 +29,6 @@ from qiskit.quantum_info import Pauli, PauliList, SparsePauliOp, SparseObservabl
 
 from .object_array import object_array
 from .shape import ShapedMixin, shape_tuple
-
 
 if TYPE_CHECKING:
     from qiskit.transpiler.layout import TranspileLayout
@@ -122,6 +122,26 @@ class ObservablesArray(ShapedMixin):
             # because the observable is guaranteed to be simplified
             result[full_pauli_str] = np.real(coeff)
 
+        return result
+
+    @staticmethod
+    def _obs_to_complex_dict(obs: SparseObservable) -> Mapping[str, complex]:
+        """Convert a sparse observable to a mapping from Pauli strings to
+        coefficients, preserving complex values (no ``np.real()`` strip)."""
+        result = {}
+        for sparse_pauli_str, pauli_qubits, coeff in obs.to_sparse_list():
+            if len(sparse_pauli_str) == 0:
+                full_pauli_str = "I" * obs.num_qubits
+            else:
+                sorted_lists = sorted(zip(pauli_qubits, sparse_pauli_str))
+                string_fragments = []
+                prev_qubit = -1
+                for qubit, pauli in sorted_lists:
+                    string_fragments.append("I" * (qubit - prev_qubit - 1) + pauli)
+                    prev_qubit = qubit
+                string_fragments.append("I" * (obs.num_qubits - max(pauli_qubits) - 1))
+                full_pauli_str = "".join(string_fragments)[::-1]
+            result[full_pauli_str] = coeff  # keep complex!
         return result
 
     def __repr__(self):

--- a/qiskit/primitives/containers/observables_array.py
+++ b/qiskit/primitives/containers/observables_array.py
@@ -141,7 +141,10 @@ class ObservablesArray(ShapedMixin):
                     prev_qubit = qubit
                 string_fragments.append("I" * (obs.num_qubits - max(pauli_qubits) - 1))
                 full_pauli_str = "".join(string_fragments)[::-1]
-            result[full_pauli_str] = coeff  # keep complex!
+            # Unlike _obs_to_dict (which operates on pre-simplified observables),
+            # _obs_to_complex_dict may receive unsimplified observables with
+            # repeated Pauli terms — accumulate coefficients to avoid data loss.
+            result[full_pauli_str] = result.get(full_pauli_str, 0) + coeff
         return result
 
     def __repr__(self):

--- a/releasenotes/notes/allow-non-hermitian-expectation-values.yaml
+++ b/releasenotes/notes/allow-non-hermitian-expectation-values.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Added ``allow_non_hermitian`` parameter to
+    :meth:`.BitArray.expectation_values`. When ``True``, non-Hermitian
+    observables with complex coefficients are accepted and the method
+    returns ``complex128`` arrays. Requires both
+    ``ObservablesArray(obs, validate=False)`` (to bypass Hermiticity
+    enforcement) and ``allow_non_hermitian=True`` for complex return.

--- a/test/python/primitives/containers/test_bit_array.py
+++ b/test/python/primitives/containers/test_bit_array.py
@@ -18,7 +18,7 @@ from test import QiskitTestCase
 import ddt
 import numpy as np
 
-from qiskit.primitives.containers import BitArray
+from qiskit.primitives.containers import BitArray, ObservablesArray
 from qiskit.quantum_info import Pauli, SparsePauliOp
 from qiskit.result import Counts
 
@@ -773,6 +773,29 @@ class BitArrayTestCase(QiskitTestCase):
                 _ = ba.expectation_values("Z")
             with self.assertRaisesRegex(ValueError, "is not diagonal"):
                 _ = ba.expectation_values("X" * ba.num_bits)
+
+    def test_expectation_values_dtype(self):
+        """expectation_values returns float64 (ObservableArray enforces
+        Hermiticity, so results are always real; np.real_if_close handles
+        SparsePauliOp's internal complex storage)."""
+        ba = BitArray.from_counts([{0: 1}, {1: 1}]).reshape(2, 1)
+        result = ba.expectation_values("Z")
+        self.assertEqual(result.dtype, np.float64)
+
+    def test_expectation_values_complex_return(self):
+        """expectation_values with allow_non_hermitian=True can return
+        complex128 when the observable has complex coefficients.
+        Z|0⟩ = +1|0⟩, Z|1⟩ = -1|1⟩, coeff = -1j
+        → |0⟩: (+1) × (-1j) = -1j
+        → |1⟩: (-1) × (-1j) = +1j"""
+        sp = SparsePauliOp.from_list([["Z", -1j]])
+        obs = ObservablesArray(sp, validate=False)
+        ba = BitArray.from_counts([{0: 1}, {1: 1}]).reshape(2, 1)
+        result = ba.expectation_values(obs, allow_non_hermitian=True)
+        self.assertEqual(result.dtype, np.complex128)
+        self.assertTrue(np.iscomplexobj(result))
+        self.assertIsInstance(result.flat[0], np.complex128)
+        np.testing.assert_array_almost_equal(result, [[-1j], [1j]])
 
     def test_postselection(self):
         """Test the postselection method."""

--- a/test/python/primitives/containers/test_observables_array.py
+++ b/test/python/primitives/containers/test_observables_array.py
@@ -642,3 +642,19 @@ class ObservablesArrayTestCase(QiskitTestCase):
         invalid_basis = {1: "value", 2: "another_value"}  # Invalid keys (integers)
         with self.assertRaises(TypeError):
             ObservablesArray.coerce_observable(invalid_basis)
+
+    def test_obs_to_complex_dict_accumulates_duplicates(self):
+        """Duplicate Pauli terms in unsimplified observables must be
+        accumulated, not silently overwritten."""
+        obs = qi.SparseObservable.from_list([("Z", 1j), ("Z", 2 + 3j), ("Z", -1j)])
+        result = ObservablesArray._obs_to_complex_dict(obs)
+        # 1j + (2+3j) + (-1j) = 2+3j
+        self.assertEqual(result["Z"], 2 + 3j)
+        # All three terms collapse to one key
+        self.assertEqual(len(result), 1)
+
+    def test_obs_to_complex_dict_cancellation(self):
+        """Terms that cancel to zero should be preserved as 0j, not dropped."""
+        obs = qi.SparseObservable.from_list([("X", 1 + 2j), ("X", -1 - 2j)])
+        result = ObservablesArray._obs_to_complex_dict(obs)
+        self.assertEqual(result["X"], 0j)


### PR DESCRIPTION
Allow complex expectation values in BitArray.expectation_values
without a manual loop. Two flags unlock the path:
~ObservablesArray(obs, validate=False) > bypass Hermiticity gate
~expectation_values(obs, allow_non_hermitian=True) > complex return path

follow up to fix #16443 
related to fix #11393

### AI/LLM disclosure

-[x]I used the following tool to generate or modify code: copilot All code reviewed, tested, and verified manually, with black formatting, 2 new tests, one for complex128 and one for float64


