### PR TITLE
Fix UGate docstring note about the OpenQASM 3 U definition

### DIFF
--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -61,11 +61,12 @@ class UGate(Gate):
 
     .. note::
 
-        The matrix representation shown here is the same as in the `OpenQASM 3.0 specification
-        <https://openqasm.com/language/gates.html#built-in-gates>`_,
-        which differs from the `OpenQASM 2.0 specification
-        <https://doi.org/10.48550/arXiv.1707.03429>`_ by a global phase of
-        :math:`e^{i(\phi+\lambda)/2}`.
+        The matrix representation shown here differs from the `OpenQASM 3.0 specification
+        <https://openqasm.com/language/gates.html#built-in-gates>`_ by a global phase of
+        :math:`e^{i\theta/2}`; the built-in ``U`` gate of OpenQASM 3.0 is equal to
+        :math:`e^{i\theta/2} U(\theta, \phi, \lambda)`.  It also differs from the
+        `OpenQASM 2.0 specification <https://doi.org/10.48550/arXiv.1707.03429>`_ by a
+        global phase of :math:`e^{i(\phi+\lambda)/2}`.
 
     Examples:
 

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -63,10 +63,9 @@ class UGate(Gate):
 
         The matrix representation shown here differs from the `OpenQASM 3.0 specification
         <https://openqasm.com/language/gates.html#built-in-gates>`_ by a global phase of
-        :math:`e^{i\theta/2}`; the built-in ``U`` gate of OpenQASM 3.0 is equal to
-        :math:`e^{i\theta/2} U(\theta, \phi, \lambda)`.  It also differs from the
-        `OpenQASM 2.0 specification <https://doi.org/10.48550/arXiv.1707.03429>`_ by a
-        global phase of :math:`e^{i(\phi+\lambda)/2}`.
+        :math:`e^{-i\theta/2}`.  It differs from the
+        `OpenQASM 2.0 specification <https://doi.org/10.48550/arXiv.1707.03429>`_ 
+        by a global phase of :math:`e^{i(\phi+\lambda)/2}`.
 
     Examples:
 


### PR DESCRIPTION
### Summary

Fixes #15830.

The `UGate` docstring says its matrix is the same as the built-in `U` gate in the OpenQASM 3.0 specification. The current spec defines `U(θ, φ, λ)` as that matrix multiplied by a global phase $e^{i\theta/2}$, so the note now states the phase difference instead, using the wording suggested in the issue thread. The existing statement about the OpenQASM 2.0 phase difference is kept, since it is still correct relative to Qiskit's matrix.

### Details and comments

Verified numerically: for 200 random angle triples, the spec's matrix $\tfrac{1}{2}\begin{pmatrix}1+e^{i\theta} & -ie^{i\lambda}(1-e^{i\theta})\\ ie^{i\phi}(1-e^{i\theta}) & e^{i(\phi+\lambda)}(1+e^{i\theta})\end{pmatrix}$ equals $e^{i\theta/2}$ times `Operator(UGate(θ, φ, λ))`, and the OpenQASM 2.0 relation $U_{\text{Qiskit}} = e^{i(\phi+\lambda)/2} U_{\text{OQ2}}$ also holds. Docs-only change, so no release note.

AI disclosure: this PR was prepared with the assistance of Claude Code (Anthropic's Claude); I review and test all changes.