### PR TITLE
Enable CTest MemCheck support for C API tests

### DIFF
--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -6,6 +6,7 @@ cmake_minimum_required (VERSION 3.20)
 # Since we only use CMake to scaffold `ctest`, we just have the whole
 # configuration here.
 project (qiskit-test)
+include(CTest)
 # These variables need to be fed into the file during the build.
 # "Setting" them empty here is for documentation purposes.
 set (


### PR DESCRIPTION
Fixes #14639

This PR is a proof of concept for enabling CTest MemCheck support for the C API tests.

Changes:
- Add `include(CTest)` to `test/c/CMakeLists.txt`.

Validation:
- `ctest -T MemCheck` successfully runs all 30 C API tests under Valgrind.
- DynamicAnalysis reports are generated.
- MemCheck reports actionable findings with stack traces into Qiskit code.

Observations:
- MemCheck reports defects (Memory Leak and Potential Memory Leak findings).
- `ctest -T MemCheck` still exits successfully (`0`) despite reporting defects.

This PR is being opened as a draft to discuss the preferred CI integration approach and how MemCheck findings should be handled.

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description:
  - Microsoft Copilot
- [ ] I used the following tool to generate or modify code:
``