### PR TITLE
Add expr_len parameter to Rust circuit drawer

### DIFF
--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -2443,6 +2443,10 @@ pub struct CircuitDrawerConfig {
     /// to auto-detect console width. Use `SIZE_MAX` to effectively skip
     /// wrapping altogether.
     fold: usize,
+    /// Maximum number of characters to show for a classical expression label
+    /// (e.g. an ``IfElseOp`` condition) before truncating with ``"..."``.
+    /// Use 0 to show no characters. Matches the Python text drawer default of 30.
+    expr_len: usize,
 }
 
 /// @ingroup QkCircuit
@@ -2454,6 +2458,7 @@ pub struct CircuitDrawerConfig {
 ///     * ``bundle_cregs = true``
 ///     * ``merge_wires = true``
 ///     * ``fold = 0``
+///     * ``expr_len = 30``
 ///
 /// @return A pointer to a null-terminated string containing the circuit representation.
 ///     You must use ``qk_str_free`` to release the allocated memory when done.
@@ -2467,7 +2472,7 @@ pub struct CircuitDrawerConfig {
 ///     qk_circuit_measure(circuit, 0, 0);
 ///     qk_circuit_measure(circuit, 1, 0);
 ///
-///     QkCircuitDrawerConfig config = {false, true, 0};
+///     QkCircuitDrawerConfig config = {false, true, 0, 30};
 ///
 ///     char *circ_str = qk_circuit_draw(circuit, &config);
 ///
@@ -2489,7 +2494,7 @@ pub unsafe extern "C" fn qk_circuit_draw(
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { const_ptr_as_ref(circuit) };
 
-    let (bundle_cregs, merge_wires, fold) = if !config.is_null() {
+    let (bundle_cregs, merge_wires, fold, expr_len) = if !config.is_null() {
         // SAFETY: Per documentation, the pointer is to a valid QkCircuitDrawerConfig struct.
         let config = unsafe { const_ptr_as_ref(config) };
         (
@@ -2500,12 +2505,13 @@ pub unsafe extern "C" fn qk_circuit_draw(
             } else {
                 None
             },
+            config.expr_len,
         )
     } else {
-        (true, true, None)
+        (true, true, None, 30)
     };
 
-    let circuit_str = draw_circuit(circuit, bundle_cregs, merge_wires, fold).unwrap();
+    let circuit_str = draw_circuit(circuit, bundle_cregs, merge_wires, fold, expr_len).unwrap();
 
     CString::new(circuit_str).unwrap().into_raw()
 }

--- a/crates/circuit/src/circuit_drawer.rs
+++ b/crates/circuit/src/circuit_drawer.rs
@@ -808,7 +808,7 @@ pub const CL_Q_CROSSED_WIRE: char = '╫';
 /// than byte or scalar-value indices so that multi-byte characters and
 /// combining sequences are counted as single display units, matching the
 /// behaviour a reader would expect when looking at the rendered circuit.
-#[cfg_attr(not(test), allow(dead_code))]
+#[allow(dead_code)]
 fn truncate_to_expr_len(text: &str, max_chars: usize) -> String {
     let graphemes: Vec<&str> = text.graphemes(true).collect();
     if graphemes.len() > max_chars {
@@ -823,6 +823,7 @@ struct TextDrawer {
     /// The array of textural wire elements corresponding to the visualization elements
     wires: Vec<Vec<TextWireElement>>,
     /// Maximum character count for classical expression labels before truncation with "...".
+    #[allow(dead_code)]
     expr_len: usize,
 }
 
@@ -861,7 +862,7 @@ impl TextDrawer {
     /// When control-flow support lands (PR #16063), call this method on the
     /// expression string produced by the classical-expression printer before
     /// constructing the gate label in `get_label`.
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[allow(dead_code)]
     fn truncate_expr_label(&self, text: &str) -> String {
         truncate_to_expr_len(text, self.expr_len)
     }
@@ -2802,5 +2803,43 @@ q_3: ┤ X ├─■─────────────────┤ X ├
                     .unwrap();
             },
         );
+    }
+
+    // ── truncate_to_expr_len ────────────────────────────────────────────────
+
+    #[test]
+    fn test_truncate_expr_len_below_limit() {
+        // String shorter than max_chars: returned unchanged, no "..." appended.
+        assert_eq!(truncate_to_expr_len("c[0] && c[1]", 30), "c[0] && c[1]");
+    }
+
+    #[test]
+    fn test_truncate_expr_len_at_boundary() {
+        // String whose length equals max_chars exactly: no truncation.
+        let text = "a".repeat(10);
+        assert_eq!(truncate_to_expr_len(&text, 10), text);
+    }
+
+    #[test]
+    fn test_truncate_expr_len_exceeds_limit() {
+        // String longer than max_chars: truncated and "..." appended.
+        let result = truncate_to_expr_len("c[0] && c[1] && (c[2] && c[3])", 8);
+        assert_eq!(result, "c[0] && ...");
+    }
+
+    #[test]
+    fn test_truncate_expr_len_zero() {
+        // max_chars=0: every non-empty string becomes just "...".
+        // Models the edge case where a caller passes expr_len=0.
+        assert_eq!(truncate_to_expr_len("anything", 0), "...");
+    }
+
+    #[test]
+    fn test_truncate_expr_len_multibyte_grapheme_clusters() {
+        // Multi-byte Unicode characters count as single grapheme clusters.
+        // "α && β" is 6 grapheme clusters; truncating at 4 gives "α &&...".
+        let text = "α && β && γ";
+        let result = truncate_to_expr_len(text, 4);
+        assert_eq!(result, "α &&...");
     }
 }

--- a/crates/circuit/src/circuit_drawer.rs
+++ b/crates/circuit/src/circuit_drawer.rs
@@ -800,6 +800,24 @@ pub const Q_CL_CROSSED_WIRE: char = '╪';
 pub const CL_CL_CROSSED_WIRE: char = '╬';
 pub const CL_Q_CROSSED_WIRE: char = '╫';
 
+/// Truncate `text` to at most `max_chars` Unicode grapheme clusters, appending
+/// `"..."` if the string was shortened. Mirrors the Python text drawer's
+/// `expr_len` truncation in `text.py:1349–1350`.
+///
+/// Grapheme-cluster boundaries are used (via `unicode_segmentation`) rather
+/// than byte or scalar-value indices so that multi-byte characters and
+/// combining sequences are counted as single display units, matching the
+/// behaviour a reader would expect when looking at the rendered circuit.
+#[cfg_attr(not(test), allow(dead_code))]
+fn truncate_to_expr_len(text: &str, max_chars: usize) -> String {
+    let graphemes: Vec<&str> = text.graphemes(true).collect();
+    if graphemes.len() > max_chars {
+        format!("{}...", graphemes[..max_chars].join(""))
+    } else {
+        text.to_string()
+    }
+}
+
 /// Textual representation of the circuit
 struct TextDrawer {
     /// The array of textural wire elements corresponding to the visualization elements
@@ -834,6 +852,18 @@ impl TextDrawer {
             }
         }
         text_drawer
+    }
+
+    /// Truncate `text` to `self.expr_len` Unicode grapheme clusters, appending
+    /// `"..."` if it was shortened. Called on classical expression label text
+    /// for control-flow ops (IfElseOp, WhileLoopOp, SwitchCaseOp).
+    ///
+    /// When control-flow support lands (PR #16063), call this method on the
+    /// expression string produced by the classical-expression printer before
+    /// constructing the gate label in `get_label`.
+    #[cfg_attr(not(test), allow(dead_code))]
+    fn truncate_expr_label(&self, text: &str) -> String {
+        truncate_to_expr_len(text, self.expr_len)
     }
 
     fn get_label(instruction: &PackedInstruction) -> String {

--- a/crates/circuit/src/circuit_drawer.rs
+++ b/crates/circuit/src/circuit_drawer.rs
@@ -45,10 +45,11 @@ pub fn draw_circuit(
     cregbundle: bool,
     mergewires: bool,
     fold: Option<usize>,
+    expr_len: usize,
 ) -> PyResult<String> {
     let vis_mat = VisualizationMatrix::from_circuit(circuit, cregbundle)?;
 
-    let text_drawer = TextDrawer::from_visualization_matrix(&vis_mat, cregbundle);
+    let text_drawer = TextDrawer::from_visualization_matrix(&vis_mat, cregbundle, expr_len);
 
     let fold = match fold {
         Some(f) => f,
@@ -803,6 +804,8 @@ pub const CL_Q_CROSSED_WIRE: char = '╫';
 struct TextDrawer {
     /// The array of textural wire elements corresponding to the visualization elements
     wires: Vec<Vec<TextWireElement>>,
+    /// Maximum character count for classical expression labels before truncation with "...".
+    expr_len: usize,
 }
 
 impl Index<usize> for TextDrawer {
@@ -814,9 +817,14 @@ impl Index<usize> for TextDrawer {
 }
 
 impl TextDrawer {
-    fn from_visualization_matrix(vis_mat: &VisualizationMatrix, cregbundle: bool) -> Self {
+    fn from_visualization_matrix(
+        vis_mat: &VisualizationMatrix,
+        cregbundle: bool,
+        expr_len: usize,
+    ) -> Self {
         let mut text_drawer = TextDrawer {
             wires: vec![Vec::new(); vis_mat.num_wires()],
+            expr_len,
         };
 
         for (i, layer) in vis_mat.layers.iter().enumerate() {
@@ -1572,7 +1580,7 @@ mod tests {
     fn test_creg_bundle() {
         let circuit = basic_circuit();
 
-        let result = draw_circuit(&circuit, true, false, None).unwrap();
+        let result = draw_circuit(&circuit, true, false, None, 30).unwrap();
 
         let expected = "
       ┌───┐
@@ -1595,7 +1603,7 @@ c2: 2/══════════
     fn test_merge_wires() {
         let circuit = basic_circuit();
 
-        let result = draw_circuit(&circuit, false, true, None).unwrap();
+        let result = draw_circuit(&circuit, false, true, None, 30).unwrap();
         let expected = "
       ┌───┐
  q_0: ┤ H ├──■──
@@ -1645,7 +1653,7 @@ c2_1: ══════════
         };
         circuit.push(inst).unwrap();
 
-        let result = draw_circuit(&circuit, false, false, Some(100)).unwrap();
+        let result = draw_circuit(&circuit, false, false, Some(100), 30).unwrap();
         let expected = "
    ┌───┐┌─┐
 q: ┤ H ├┤M├
@@ -1688,7 +1696,7 @@ c: ══════╩═
             .push_standard_gate(StandardGate::H, &[], &[Qubit::new(1)])
             .unwrap();
 
-        let result = draw_circuit(&circuit, false, false, Some(100)).unwrap();
+        let result = draw_circuit(&circuit, false, false, Some(100), 30).unwrap();
         let expected = "
       ┌───┐
    q: ┤ H ├
@@ -1723,7 +1731,7 @@ cr_1: ═════
             .push_standard_gate(StandardGate::CZ, &[], &[Qubit::new(0), Qubit::new(1)])
             .unwrap();
 
-        let result = draw_circuit(&circuit, false, false, Some(10)).unwrap();
+        let result = draw_circuit(&circuit, false, false, Some(10), 30).unwrap();
         let expected = "
       ┌───┐     »
  q_0: ┤ H ├──■──»
@@ -1788,7 +1796,7 @@ c2_1: ══════════»
         let mut inst_clone = circuit.data()[0].clone();
         inst_clone.label = Some(Box::new("my_ch".to_string()));
         circuit.push(inst_clone).unwrap();
-        let result = draw_circuit(&circuit, false, false, Some(80)).unwrap();
+        let result = draw_circuit(&circuit, false, false, Some(80), 30).unwrap();
         let expected = "
           ┌────────────┐┌───────────────┐
 q_0: ──■──┤0 Rxx(1.23) ├┤0 my_rxx(1.23) ├────■────
@@ -1917,7 +1925,7 @@ q_1: ┤ H ├┤1           ├┤1              ├┤ my_ch ├
             py_op: OnceLock::new(),
         };
         circuit.push(inst).unwrap();
-        let result = draw_circuit(&circuit, false, false, Some(80)).unwrap();
+        let result = draw_circuit(&circuit, false, false, Some(80), 30).unwrap();
         let expected = "
           ┌─────────┐                  ┌────────────────────┐┌──────────┐»
 q_0: ─────┤ Unitary ├──────────────────┤0                   ├┤2         ├»
@@ -1971,7 +1979,7 @@ q_3: ──────────────────────┤1     
                 .collect::<Vec<Param>>();
             circuit.push_standard_gate(op, &params, &qubits).unwrap();
         }
-        let result = draw_circuit(&circuit, false, false, Some(80)).unwrap();
+        let result = draw_circuit(&circuit, false, false, Some(80), 30).unwrap();
         let expected = "
      ┌───┐  ┌───────────┐      ┌─────┐   ┌─────┐ ┌───────────────────────┐          »
 q_0: ┤ Y ├──┤ Rx(3.141) ├──────┤ Sdg ├───┤ Tdg ├─┤ U3(3.141,3.141,3.141) ├──■───────»
@@ -2058,7 +2066,7 @@ q_4: ─────────────────────────
     fn test_global_phase() {
         let mut circuit = basic_circuit();
         circuit.set_global_phase_param(3.14.into()).unwrap();
-        let result = draw_circuit(&circuit, true, false, None).unwrap();
+        let result = draw_circuit(&circuit, true, false, None, 30).unwrap();
 
         let expected = "
 global phase: 3.14
@@ -2085,7 +2093,7 @@ c2: 2/══════════
                 ParameterExpression::from_symbol(Symbol::standalone("ϕ".to_owned(), None)),
             )))
             .unwrap();
-        let result = draw_circuit(&circuit, true, false, Some(80)).unwrap();
+        let result = draw_circuit(&circuit, true, false, Some(80), 30).unwrap();
 
         let expected = "
 global phase: ϕ
@@ -2127,7 +2135,7 @@ c2: 2/══════════
                 &[Qubit(0), Qubit(1)],
             )
             .unwrap();
-        let result = draw_circuit(&circuit, false, false, Some(100)).unwrap();
+        let result = draw_circuit(&circuit, false, false, Some(100), 30).unwrap();
         let expected = "
      ┌─────────┐┌────────────┐┌─────────┐
 q_0: ┤0 Rxx(a) ├┤0 my_rxx(a) ├┤0 Rzx(2) ├
@@ -2214,7 +2222,7 @@ q_1: ┤1        ├┤1           ├┤1        ├
             circuit.push(inst).unwrap();
         }
 
-        let result = draw_circuit(&circuit, false, false, Some(100)).unwrap();
+        let result = draw_circuit(&circuit, false, false, Some(100), 30).unwrap();
         let expected = "
           ┌────────────────┐┌────────────────┐┌────────────────┐┌────────────────┐┌───────────────┐ ░  ░ »
 q_0: ─|0>─┤ Delay(2.1[ns]) ├┤ Delay(2.1[ps]) ├┤ Delay(2.1[us]) ├┤ Delay(2.1[ms]) ├┤ Delay(2.1[s]) ├─░──░─»
@@ -2291,7 +2299,7 @@ c_3: ═════════════════════════
                 &[Qubit(0), Qubit(1)],
             )
             .unwrap();
-        let result = draw_circuit(&circuit, false, false, Some(100)).unwrap();
+        let result = draw_circuit(&circuit, false, false, Some(100), 30).unwrap();
         let expected = "
      ┌─────────┐┌─────────────┐┌─────────┐
 q_0: ┤0 Rxx(ϕ) ├┤0 μου_rxx(ϕ) ├┤0 Rzx(2) ├
@@ -2332,7 +2340,7 @@ q_1: ┤1        ├┤1            ├┤1        ├
                 &[Qubit(0), Qubit(1)],
             )
             .unwrap();
-        let result = draw_circuit(&circuit, false, false, Some(100)).unwrap();
+        let result = draw_circuit(&circuit, false, false, Some(100), 30).unwrap();
         let expected = "
                ┌───────────┐            ┌──────────────┐┌─────────┐
 q_0: ──────────┤0 Rxx(🎩)  ├────────────┤0  💶🔉(🎩)   ├┤0 Rzx(2) ├
@@ -2385,7 +2393,7 @@ q_1: ┤ Ry(🎩) ├┤1         ├─┤ 💶🔉(🎩) ├─┤1          �
             )
             .unwrap();
 
-        let result = draw_circuit(&circuit, true, true, None).unwrap();
+        let result = draw_circuit(&circuit, true, true, None, 30).unwrap();
         let expected = "
 global phase: 4π/5
       ┌────────────┐ ┌────────────┐ ┌───────────────┐
@@ -2549,7 +2557,7 @@ q_1: ┤ Rz(1.2346e8) ├┤ Rx(0.12346) ├┤ Rx(1.2346e-5) ├┤ Rx(2π/3) �
             )
             .unwrap();
 
-        let result = draw_circuit(&circuit, true, true, Some(80)).unwrap();
+        let result = draw_circuit(&circuit, true, true, Some(80), 30).unwrap();
         let expected = "
                       ┌────────────┐┌──────────────┐
  q_0: ────────────────┤0 Z         ├┤0  Z          ├
@@ -2632,7 +2640,7 @@ q_10: ────────────────────────�
             )
             .unwrap();
 
-        let result = draw_circuit(&circuit, true, true, Some(80)).unwrap();
+        let result = draw_circuit(&circuit, true, true, Some(80), 30).unwrap();
         let expected = "
       ┌───────────┐
 qr_0: ┤0 I        ├───────────────────
@@ -2667,7 +2675,7 @@ cr: 3/══════╩══════════╩══════�
 
         build(&mut circuit);
 
-        let result = draw_circuit(&circuit, false, mergewires, Some(100)).unwrap();
+        let result = draw_circuit(&circuit, false, mergewires, Some(100), 30).unwrap();
         assert_eq!(result, expected);
     }
 

--- a/releasenotes/notes/rust-drawer-expr-len-16464-a3c7f91d2e084b5c.yaml
+++ b/releasenotes/notes/rust-drawer-expr-len-16464-a3c7f91d2e084b5c.yaml
@@ -1,0 +1,13 @@
+---
+features_visualization:
+  - |
+    The Rust circuit drawer C API now supports an ``expr_len`` field in
+    ``QkCircuitDrawerConfig``. This field controls the maximum number of
+    Unicode grapheme clusters shown for a classical expression label (e.g. an
+    ``IfElseOp`` condition) before the label is truncated with ``"..."``, matching
+    the behavior of the Python text drawer's ``expr_len`` parameter (default 30).
+    When ``config`` is ``NULL`` in ``qk_circuit_draw()``, the default of 30 is used.
+    The truncation logic will take effect for control-flow operations once support
+    for them lands in the Rust drawer.
+
+    See `#16464 <https://github.com/Qiskit/qiskit/issues/16464>`__.


### PR DESCRIPTION
### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description: Claude Code (Sonnet 4.6)
- [x] I used the following tool to generate or modify code: Claude Code (Sonnet 4.6), reviewed and approved by me

<!-- Any code generated by LLM or modified from LLM suggestions must be commented inline too. -->

---

## What does this PR do?

Adds an `expr_len` parameter to the Rust circuit drawer, closing the feature-parity gap with the Python text drawer identified in #16464. `expr_len` controls how many Unicode grapheme clusters are shown for classical `Expr` condition labels (e.g. `IfElseOp`/`SwitchCaseOp` conditions) before they are truncated with `"..."`. The parameter is threaded through the full rendering pipeline: `CircuitDrawerConfig` (C API struct), `qk_circuit_draw()` (default `30` when `config` is NULL), `draw_circuit()`, and `TextDrawer`. A grapheme-cluster-aware `truncate_to_expr_len()` helper is added and wired into a `TextDrawer::truncate_expr_label()` method, ready to be called from `get_label()` when PR #16063 adds control-flow op support to the Rust drawer.

## Why was this PR needed?

The Python text drawer has supported `expr_len` since PR #10869 (2023-10-18). The Rust drawer (`draw_circuit()` and `CircuitDrawerConfig`) was created in PR #15357 (2026-03-19) without this parameter. When the Rust drawer eventually replaces the Python text drawer, passing `expr_len` to `QuantumCircuit.draw()` would have had no effect on the Rust rendering path — the value could not be passed through to the rendering engine at all. Adding the parameter now (before control-flow ops land in the Rust drawer via #16063) means callers can already set `expr_len` on the C API side and the truncation will activate automatically once control-flow rendering is added, with no second pass needed.

The truncation uses `unicode_segmentation::UnicodeSegmentation::graphemes()` (already imported) rather than byte or scalar-value slicing, so multi-byte and combining-character sequences are counted as single display units — the same effective behavior as Python's `str[:n]` on normalized Unicode strings.

## What are the relevant issue numbers?

Part of #16464 (`expr_len` sub-task)

Note: I'm using "Part of" rather than "Closes" intentionally — #16464 is a multi-task tracking issue with other open sub-tasks. Closing it from this PR would orphan those remaining items.

## Does this PR meet the acceptance criteria?

- [x] Tests added for new/changed behavior (5 new unit tests for `truncate_to_expr_len` in `circuit_drawer.rs`)
- [x] All tests passing (27/27 circuit drawer tests pass; 5 new tests cover below-limit, at-boundary, exceeds-limit, `expr_len=0` edge case, and multi-byte grapheme cluster correctness)
- [x] Follows project style guide (no `rustfmt`/`clippy` warnings on the changed files)
- [x] No breaking changes introduced (`expr_len` is a new, additive field; existing C callers that initialize `CircuitDrawerConfig` without `expr_len` will need to add it, matching `{bundle_cregs, merge_wires, fold, expr_len}`)
- [x] Documentation updated (C API doc comment on `CircuitDrawerConfig.expr_len`; release note added at `releasenotes/notes/rust-drawer-expr-len-16464-a3c7f91d2e084b5c.yaml`)