### PR TITLE
Clarify SabreLayout error when routing_pass is set with trial args

### DIFF
--- a/qiskit/transpiler/passes/layout/sabre_layout.py
+++ b/qiskit/transpiler/passes/layout/sabre_layout.py
@@ -171,7 +171,7 @@ class SabreLayout(TransformationPass):
             if self._coupling_map is not None:
                 self._coupling_map.make_symmetric()
         if routing_pass is not None and (swap_trials is not None or layout_trials is not None):
-            raise TranspilerError("Both routing_pass and swap_trials can't be set at the same time")
+            raise TranspilerError("The swap_trials and layout_trials arguments are incompatible with routing_pass")
         self.routing_pass = routing_pass
         self.seed = seed
         self.max_iterations = max_iterations

--- a/releasenotes/notes/fix-sabre-layout-routing-pass-error-msg-16632.yaml
+++ b/releasenotes/notes/fix-sabre-layout-routing-pass-error-msg-16632.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Clarified the :class:`.TranspilerError` raised by :class:`.SabreLayout` when
+    ``routing_pass`` is combined with ``swap_trials`` or ``layout_trials``.
+    The previous message only mentioned ``swap_trials``, which was misleading
+    when only ``layout_trials`` was set (see `#16632
+    <https://github.com/Qiskit/qiskit/issues/16632>`__).

--- a/test/python/transpiler/test_sabre_layout.py
+++ b/test/python/transpiler/test_sabre_layout.py
@@ -292,6 +292,17 @@ barrier q18585[5],q18585[2],q18585[8],q18585[3],q18585[6];
         self.assertIsInstance(out, QuantumCircuit)
         self.assertEqual(out.layout.initial_index_layout(), [2, 3, 4, 6, 5, 0, 1, 7])
 
+
+    def test_routing_pass_incompatible_with_trial_args(self):
+        """routing_pass cannot be combined with swap_trials or layout_trials (#16632)."""
+        cm = CouplingMap.from_line(3)
+        routing = BasicSwap(cm, fake_run=True)
+        msg = "swap_trials and layout_trials arguments are incompatible with routing_pass"
+        with self.assertRaisesRegex(TranspilerError, msg):
+            SabreLayout(cm, routing_pass=routing, swap_trials=2)
+        with self.assertRaisesRegex(TranspilerError, msg):
+            SabreLayout(cm, routing_pass=routing, layout_trials=2)
+
     def test_support_var_with_explicit_routing_pass(self):
         """Test that the logic works if an explicit routing pass is given."""
         a = expr.Var.new("a", types.Bool())


### PR DESCRIPTION
## Summary

- Update `SabreLayout` `TranspilerError` text so it names both `swap_trials` and `layout_trials` as incompatible with `routing_pass` (maintainer-suggested wording from #16632).
- Add a unit test covering both trial arguments.
- Add a release note.

## Why

The previous message only mentioned `swap_trials`, so setting `layout_trials` with `routing_pass` produced a confusing error.

Fixes #16632

## Test plan

- [x] Added `test_routing_pass_incompatible_with_trial_args`
- [ ] CI on this PR