### PR TITLE
Add _vertical_compression_to_mergewires mapping for Rust drawer integration

### DIFF
--- a/qiskit/visualization/circuit/circuit_visualization.py
+++ b/qiskit/visualization/circuit/circuit_visualization.py
@@ -399,6 +399,28 @@ def circuit_drawer(
 # -----------------------------------------------------------------------------
 
 
+def _vertical_compression_to_mergewires(vertical_compression):
+    """Map the ``vertical_compression`` string to a boolean ``mergewires`` value.
+
+    The Rust circuit drawer uses a boolean ``mergewires`` parameter to control
+    whether adjacent wires are merged when rendered. This helper maps the
+    ``vertical_compression`` string values (``"high"``, ``"medium"``, ``"low"``)
+    to the corresponding ``mergewires`` boolean:
+
+    * ``"high"`` / ``"medium"`` → ``True``
+    * ``"low"`` → ``False``
+
+    Args:
+        vertical_compression (str): One of ``"high"``, ``"medium"``, or ``"low"``.
+
+    Returns:
+        bool: ``True`` if wires should be merged, ``False`` otherwise.
+    """
+    if vertical_compression == "low":
+        return False
+    return True
+
+
 def _text_circuit_drawer(
     circuit,
     filename=None,

--- a/test/python/visualization/test_circuit_drawer.py
+++ b/test/python/visualization/test_circuit_drawer.py
@@ -288,3 +288,31 @@ class TestCircuitDrawer(QiskitTestCase):
         circuit.draw("latex_source")
         if optionals.HAS_MATPLOTLIB and optionals.HAS_PYLATEX:
             circuit.draw("mpl")
+
+
+class TestVerticalCompressionToMergewires(QiskitTestCase):
+    """Test _vertical_compression_to_mergewires mapping for Rust drawer integration."""
+
+    def test_high_returns_true(self):
+        """Test that 'high' maps to mergewires=True."""
+        from qiskit.visualization.circuit.circuit_visualization import (
+            _vertical_compression_to_mergewires,
+        )
+
+        self.assertTrue(_vertical_compression_to_mergewires("high"))
+
+    def test_medium_returns_true(self):
+        """Test that 'medium' maps to mergewires=True."""
+        from qiskit.visualization.circuit.circuit_visualization import (
+            _vertical_compression_to_mergewires,
+        )
+
+        self.assertTrue(_vertical_compression_to_mergewires("medium"))
+
+    def test_low_returns_false(self):
+        """Test that 'low' maps to mergewires=False."""
+        from qiskit.visualization.circuit.circuit_visualization import (
+            _vertical_compression_to_mergewires,
+        )
+
+        self.assertFalse(_vertical_compression_to_mergewires("low"))


### PR DESCRIPTION
## Summary

This PR adds a `_vertical_compression_to_mergewires` helper function that maps the `vertical_compression` string parameter (`"high"`, `"medium"`, `"low"`) to the boolean `mergewires` parameter used by the Rust circuit drawer.

This is part of the Rust drawer feature parity tracking in #16464.

## Changes

- Added `_vertical_compression_to_mergewires()` helper in `circuit_visualization.py`
- `"high"` / `"medium"` → `mergewires=True`
- `"low"` → `mergewires=False`
- Added unit tests for the mapping function

## Motivation

The Rust circuit drawer uses a boolean `mergewires` parameter to control whether adjacent wires are merged when rendered. The Python `_text_circuit_drawer` uses a `vertical_compression` string with three levels. This helper bridges the two APIs so the Rust drawer can eventually replace the Python text drawer.

See #16464 for the full feature parity tracking issue.

## AI/LLM Disclosure

- [x] I used AI tooling (opencode CLI) for this contribution.