### PR TITLE
Migrate synth_mcx_1_clean_b95 synthesis to Rust

### DIFF
--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -471,6 +471,10 @@ pub fn synth_mcx_noaux_v24(
 /// # Arguments
 /// - num_controls: the number of control qubits.
 ///
+/// # Returns
+///
+/// The synthesized quantum circuit.
+///
 /// # References
 ///
 /// 1. Barenco et al., *Elementary gates for quantum computation*, Phys. Rev. A52 3457 (1995),

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -499,11 +499,11 @@ pub fn synth_mcx_1_clean_b95(num_controls: usize) -> Result<CircuitData, Circuit
     } else {
         // k >= 5: 1-clean-ancilla construction (Barenco et al. 1995, Lemma 7.3)
         // decompose the gate into two halves and add 2 qubits, target and ancilla
-        let num_qubits = (num_controls + 2) as u32;
+        let nc = num_controls as u32;
+        let num_qubits = nc + 2;
         let q_ancilla = num_qubits - 1;
         let q_target = num_qubits - 2;
-        let middle = ((num_controls + 1).div_ceil(2)) as u32;
-        let nc = num_controls as u32;
+        let middle = (nc + 1).div_ceil(2);
         let nc2: u32 = nc - middle + 1; // second half, plus the ancilla
 
         // Qubit layout (num_controls + 2 qubits total):

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -461,6 +461,94 @@ pub fn synth_mcx_noaux_v24(
     }
 }
 
+/// Synthesize a multi-controlled X gate with :math:`k` controls using a single clean
+/// ancillary qubit, by Barenco et al. [1] and Iten et al. [2].
+///
+/// For :math:`k \ge 5` the method uses 1 clean ancillary qubit, producing a circuit with
+/// :math:`k + 2` qubits and at most :math:`16 * k - 24` CX gates. For :math:`k \le 4`
+/// explicit efficient circuits that require no ancillary qubits are used instead.
+///
+/// # Arguments
+/// - num_controls: the number of control qubits.
+///
+/// # References
+///
+/// 1. Barenco et al., *Elementary gates for quantum computation*, Phys. Rev. A52 3457 (1995),
+///    [arXiv:quant-ph/9503016] (https://arxiv.org/abs/quant-ph/9503016).
+/// 2. Iten et al., *Quantum Circuits for Isometries*, Phys. Rev. A 93, 032318 (2016),
+///    [arXiv:1501.06911] (https://arxiv.org/abs/1501.06911).
+pub fn synth_mcx_1_clean_b95(num_controls: usize) -> Result<CircuitData, CircuitDataError> {
+    if num_controls == 0 {
+        let mut circuit = CircuitData::with_capacity(1, 0, 1, Param::Float(0.0))?;
+        circuit.x(0)?;
+        Ok(circuit)
+    } else if num_controls == 1 {
+        let mut circuit = CircuitData::with_capacity(2, 0, 1, Param::Float(0.0))?;
+        circuit.cx(0, 1)?;
+        Ok(circuit)
+    } else if num_controls == 2 {
+        Ok(ccx())
+    } else if num_controls == 3 {
+        Ok(c3x().into())
+    } else if num_controls == 4 {
+        Ok(c4x()?.into())
+    } else {
+        // k >= 5: 1-clean-ancilla construction (Barenco et al. 1995, Lemma 7.3)
+        // decompose the gate into two halves and add 2 qubits, target and ancilla
+        let num_qubits = (num_controls + 2) as u32;
+        let q_ancilla = num_qubits - 1;
+        let q_target = num_qubits - 2;
+        let middle = ((num_controls + 1).div_ceil(2)) as u32;
+        let nc = num_controls as u32;
+        let nc2: u32 = nc - middle + 1; // second half, plus the ancilla
+
+        // Qubit layout (num_controls + 2 qubits total):
+        //   nc = num_controls
+        //   [0 .. middle-1]   controls1 (first half)
+        //   [middle .. nc-1]  controls2 (second half)
+        //   [nc]              target
+        //   [nc+1]            ancilla (clean)
+        //
+        // mcx1: controls1 -> ancilla , up to relative phase
+        //   drives the ancilla using the first-half controls;
+        //   borrows second-half control qubits as dirty ancillas.
+        //
+        // mcx2: controls2, ancilla -> target, exact
+        //   drives the target using second-half controls + ancilla;
+        //   borrows first-half control qubits as dirty ancillas.
+
+        let mcx1 = synth_mcx_n_dirty_i15(middle as usize, true, false)?;
+        let mcx2 = synth_mcx_n_dirty_i15(nc2 as usize, false, false)?;
+
+        let num_dirty1 = (mcx1.num_qubits() as u32) - middle - 1;
+        let qubits1: Vec<Qubit> = (0..middle)
+            .chain([q_ancilla])
+            .chain(middle..middle + num_dirty1)
+            .map(Qubit)
+            .collect();
+
+        let num_dirty2 = (mcx2.num_qubits() as u32) - nc2 - 1;
+        let qubits2: Vec<Qubit> = (middle..nc)
+            .chain([q_ancilla, q_target])
+            .chain(0..num_dirty2)
+            .map(Qubit)
+            .collect();
+
+        // Compose pattern: mcx1 · mcx2 · mcx1† · mcx2  (Lemma 7.3 [1], Lemma 9 [2]).
+        // mcx1/mcx1† are synthesized up to relative phase (Lemma 7 [2]): the relative
+        // phase commutes with mcx2 and cancels between mcx1 and mcx1†. mcx2 must be exact.
+        let mut circuit: CircuitData =
+            CircuitData::with_capacity(num_qubits, 0, 0, Param::Float(0.0))?;
+        let mcx1_inv = mcx1.inverse()?;
+        circuit.compose(&mcx1, &qubits1, &[])?;
+        circuit.compose(&mcx2, &qubits2, &[])?;
+        circuit.compose(&mcx1_inv, &qubits1, &[])?;
+        circuit.compose(&mcx2, &qubits2, &[])?;
+
+        Ok(circuit)
+    }
+}
+
 // The following synth_mcx_noaux_hp24 algorithm is based on the work by Huang and Palsberg.
 //
 // # References

--- a/crates/synthesis/src/multi_controlled/mod.rs
+++ b/crates/synthesis/src/multi_controlled/mod.rs
@@ -10,7 +10,10 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use mcx::{c3x, c4x, synth_mcx_n_dirty_i15, synth_mcx_noaux_hp24, synth_mcx_noaux_v24};
+use mcx::{
+    c3x, c4x, synth_mcx_1_clean_b95, synth_mcx_n_dirty_i15, synth_mcx_noaux_hp24,
+    synth_mcx_noaux_v24,
+};
 use pyo3::prelude::*;
 use qiskit_circuit::circuit_data::PyCircuitData;
 
@@ -39,12 +42,19 @@ fn py_synth_mcx_noaux_hp24(num_controls: usize) -> PyResult<PyCircuitData> {
     synth_mcx_noaux_hp24(num_controls).map(Into::into)
 }
 
+#[pyfunction]
+#[pyo3(name="synth_mcx_1_clean_b95", signature = (num_controls))]
+fn py_synth_mcx_1_clean_b95(num_controls: usize) -> PyResult<PyCircuitData> {
+    Ok(synth_mcx_1_clean_b95(num_controls)?.into())
+}
+
 pub fn multi_controlled(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(c3x, m)?)?;
     m.add_function(wrap_pyfunction!(c4x, m)?)?;
     m.add_function(wrap_pyfunction!(py_synth_mcx_n_dirty_i15, m)?)?;
     m.add_function(wrap_pyfunction!(py_synth_mcx_noaux_v24, m)?)?;
     m.add_function(wrap_pyfunction!(py_synth_mcx_noaux_hp24, m)?)?;
+    m.add_function(wrap_pyfunction!(py_synth_mcx_1_clean_b95, m)?)?;
     m.add_function(wrap_pyfunction!(mcmt::mcmt_v_chain, m)?)?;
     Ok(())
 }

--- a/qiskit/synthesis/multi_controlled/mcx_synthesis.py
+++ b/qiskit/synthesis/multi_controlled/mcx_synthesis.py
@@ -13,7 +13,6 @@
 """Module containing multi-controlled circuits synthesis with and without ancillary qubits."""
 
 from __future__ import annotations
-from math import ceil
 import numpy as np
 
 from qiskit.exceptions import QiskitError
@@ -25,6 +24,7 @@ from qiskit._accelerate.synthesis.multi_controlled import (
     synth_mcx_n_dirty_i15 as synth_mcx_n_dirty_i15_rs,
     synth_mcx_noaux_v24 as synth_mcx_noaux_v24_rs,
     synth_mcx_noaux_hp24 as synth_mcx_noaux_hp24_rs,
+    synth_mcx_1_clean_b95 as synth_mcx_1_clean_b95_rs,
 )
 from .gray_code import gray_code_chain
 
@@ -177,46 +177,7 @@ def synth_mcx_1_clean_b95(num_ctrl_qubits: int) -> QuantumCircuit:
             "synth_mcx_1_clean_b95 cannot be called with a negative number of control qubits."
         )
 
-    if num_ctrl_qubits <= 2:
-        return _synth_mcx_special_cases(num_ctrl_qubits)
-
-    if num_ctrl_qubits == 3:
-        return synth_c3x()
-
-    elif num_ctrl_qubits == 4:
-        return synth_c4x()
-
-    num_qubits = num_ctrl_qubits + 2
-    q = QuantumRegister(num_qubits, name="q")
-    qc = QuantumCircuit(q)
-
-    num_ctrl_qubits = len(q) - 1
-    q_ancilla = q[-1]
-    q_target = q[-2]
-    middle = ceil(num_ctrl_qubits / 2)
-
-    # The construction involving 4 MCX gates is described in Lemma 7.3 of [1], and also
-    # appears as Lemma 9 in [2]. The optimization that the first and third MCX gates
-    # can be synthesized up to relative phase follows from Lemma 7 in [2], as a diagonal
-    # gate following the first MCX gate commutes with the second MCX gate, and
-    # thus cancels with the inverse diagonal gate preceding the third MCX gate. The
-    # same optimization cannot be applied to the second MCX gate, since a diagonal
-    # gate following the second MCX gate would not satisfy the preconditions of Lemma 7,
-    # and would not necessarily commute with the third MCX gate.
-    controls1 = [*q[:middle]]
-    mcx1 = synth_mcx_n_dirty_i15(num_ctrl_qubits=len(controls1), relative_phase=True)
-    qubits1 = [*controls1, q_ancilla, *q[middle : middle + mcx1.num_qubits - len(controls1) - 1]]
-
-    controls2 = [*q[middle : num_ctrl_qubits - 1], q_ancilla]
-    mcx2 = synth_mcx_n_dirty_i15(num_ctrl_qubits=len(controls2))
-    qc2_qubits = [*controls2, q_target, *q[0 : mcx2.num_qubits - len(controls2) - 1]]
-
-    qc.compose(mcx1, qubits1, inplace=True)
-    qc.compose(mcx2, qc2_qubits, inplace=True)
-    qc.compose(mcx1.inverse(), qubits1, inplace=True)
-    qc.compose(mcx2, qc2_qubits, inplace=True)
-
-    return qc
+    return QuantumCircuit._from_circuit_data(synth_mcx_1_clean_b95_rs(num_ctrl_qubits))
 
 
 def synth_mcx_gray_code(num_ctrl_qubits: int) -> QuantumCircuit:

--- a/releasenotes/notes/synth_mcx_1_clean_b95_rust-e5a4493219df72aa.yaml
+++ b/releasenotes/notes/synth_mcx_1_clean_b95_rust-e5a4493219df72aa.yaml
@@ -1,0 +1,6 @@
+---
+performance:
+  - |
+    Improved runtime of :py:func:`~qiskit.synthesis.synth_mcx_1_clean_b95` synthesis function by migrating implementation to Rust,
+    resulting in approximately 6x speedup across circuit sizes (k=50 to k=1000).
+

--- a/releasenotes/notes/synth_mcx_1_clean_b95_rust-e5a4493219df72aa.yaml
+++ b/releasenotes/notes/synth_mcx_1_clean_b95_rust-e5a4493219df72aa.yaml
@@ -2,5 +2,6 @@
 performance:
   - |
     Improved runtime of :py:func:`~qiskit.synthesis.synth_mcx_1_clean_b95` synthesis function by migrating implementation to Rust,
-    resulting in approximately 6x speedup across circuit sizes (k=50 to k=1000).
+    resulting in approximately 6x speedup across circuit sizes (k=50 to k=1000).   
+    See `#16710 <https://github.com/Qiskit/qiskit/pull/16710>`__ for more details.
 


### PR DESCRIPTION
Migrates `synth_mcx_1_clean_b95` from a pure-Python implementation to Rust.

- `crates/synthesis/src/multi_controlled/mcx.rs` — new `pub fn synth_mcx_1_clean_b95(num_controls: usize)`:
  - `k = 0..4`: explicit efficient circuits (X, CX, CCX, C3X, C4X), no ancilla
  - `k >= 5`: 4-compose construction using a single clean ancilla qubit (Barenco 1995, Lemma 7.3 / Iten 2016, Lemma 9): 
- `qiskit/synthesis/multi_controlled/mcx_synthesis.py` — thin wrapper delegating to Rust
- All existing tests pass, no new tests added.


### Performance

Benchmarked on Apple M-series (release build), k = 50–1000:

| k    | Python (µs) | Rust (µs) | Speedup |
|-----:|------------:|----------:|--------:|
|   50 |      1199.5 |     220.0 |   5.45× |
|  100 |      2208.8 |     328.4 |   6.73× |
|  200 |      4056.5 |     643.3 |   6.31× |
|  500 |     10271.2 |    1726.7 |   5.95× |
| 1000 |     19346.5 |    3250.4 |   5.95× |

~6× speedup consistent across all sizes.





### AI/LLM disclosure
- [ x] I used the following tool to generate or modify code: IBM Bob
Bob 2.0.1 was used to generate initial versions of the rust code  and documentation.
