### PR TITLE
Reject multi-qubit Solovay-Kitaev basis gates

### DIFF
--- a/qiskit/synthesis/discrete_basis/solovay_kitaev.py
+++ b/qiskit/synthesis/discrete_basis/solovay_kitaev.py
@@ -66,7 +66,7 @@ class SolovayKitaevDecomposition:
 
                 Either this parameter, or ``basis_gates`` and ``depth`` can be specified.
             basis_gates: A list of discrete (i.e., non-parameterized) standard gates.
-                Defaults to ``["h", "t", "tdg"]``.
+                All gates must be single-qubit gates. Defaults to ``["h", "t", "tdg"]``.
             depth: The number of basis gate combinations to consider in the basis set. This
                 determines how fast (and if) the algorithm converges and should be chosen
                 sufficiently high.
@@ -279,9 +279,17 @@ def normalize_gates(gates: list[Gate | str]) -> list[Gate]:
 
     def normalize(gate: Gate | str) -> Gate:
         if isinstance(gate, Gate):
-            return gate
-        if gate in name_to_gate:
-            return name_to_gate[gate]
-        raise ValueError(f"Unsupported gate: {gate}")
+            normalized = gate
+        elif gate in name_to_gate:
+            normalized = name_to_gate[gate]
+        else:
+            raise ValueError(f"Unsupported gate: {gate}")
+
+        if normalized.num_qubits != 1:
+            raise ValueError(
+                "Solovay-Kitaev synthesis only supports single-qubit basis gates, "
+                f"but '{normalized.name}' acts on {normalized.num_qubits} qubits."
+            )
+        return normalized
 
     return list(map(normalize, gates))

--- a/releasenotes/notes/reject-multiqubit-solovay-kitaev-basis-6d10cb26984093b5.yaml
+++ b/releasenotes/notes/reject-multiqubit-solovay-kitaev-basis-6d10cb26984093b5.yaml
@@ -3,5 +3,5 @@ fixes:
   - |
     :class:`.SolovayKitaevDecomposition` now raises a clear ``ValueError`` when
     its ``basis_gates`` contain a multi-qubit gate. Previously, such gates could
-    cause an internal Rust panic during synthesis. This fixes
-    `#16691 <https://github.com/Qiskit/qiskit/issues/16691>`__.
+    cause an internal Rust panic during synthesis. 
+    Fixes `#16691 <https://github.com/Qiskit/qiskit/issues/16691>`__.

--- a/releasenotes/notes/reject-multiqubit-solovay-kitaev-basis-6d10cb26984093b5.yaml
+++ b/releasenotes/notes/reject-multiqubit-solovay-kitaev-basis-6d10cb26984093b5.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    :class:`.SolovayKitaevDecomposition` now raises a clear ``ValueError`` when
+    its ``basis_gates`` contain a multi-qubit gate. Previously, such gates could
+    cause an internal Rust panic during synthesis. This fixes
+    `#16691 <https://github.com/Qiskit/qiskit/issues/16691>`__.

--- a/test/python/transpiler/test_solovay_kitaev.py
+++ b/test/python/transpiler/test_solovay_kitaev.py
@@ -27,6 +27,7 @@ from qiskit.circuit.library import (
     TGate,
     TdgGate,
     HGate,
+    CXGate,
     SGate,
     SdgGate,
     QFTGate,
@@ -493,6 +494,16 @@ class TestSolovayKitaevDecomposition(QiskitTestCase):
         expected.h(0)
 
         self.assertEqual(synth, expected)
+
+    @data("cx", CXGate())
+    def test_rejects_multi_qubit_basis_gate(self, gate):
+        """Test that multi-qubit basis gates are rejected before calling into Rust."""
+        with self.assertRaisesRegex(
+            ValueError,
+            "Solovay-Kitaev synthesis only supports single-qubit basis gates, "
+            "but 'cx' acts on 2 qubits",
+        ):
+            SolovayKitaevDecomposition(basis_gates=["h", "t", "tdg", gate], depth=1)
 
 
 def _convert_u2_to_su2(u2_matrix: np.ndarray) -> tuple[np.ndarray, float]:


### PR DESCRIPTION
`SolovayKitaevDecomposition` currently accepts multi-qubit gates in `basis_gates` and passes them to the Rust synthesizer, which expects single-qubit matrices. A gate such as `"cx"` can consequently produce invalid matrix data and trigger an internal Rust panic.

This validates each normalized basis gate before crossing the Python/Rust boundary and raises a descriptive `ValueError` if it does not act on exactly one qubit. The `basis_gates` documentation now states this constraint, and regression tests cover both the string and `Gate` input forms.

Fix #16691

Tests:

- `python -m unittest -q test.python.transpiler.test_solovay_kitaev` (32 tests)
- `black --check qiskit/synthesis/discrete_basis/solovay_kitaev.py test/python/transpiler/test_solovay_kitaev.py`
- `ruff check qiskit/synthesis/discrete_basis/solovay_kitaev.py test/python/transpiler/test_solovay_kitaev.py`
- `reno -q lint`
- `git diff --check`

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description: OpenAI Codex (GPT-5)
- [x] I used the following tool to generate or modify code: OpenAI Codex (GPT-5). I reviewed and tested the complete change and can explain its behavior and design.
