### PR TITLE
Fix Rust text drawer for empty circuits

### DIFF
--- a/crates/circuit/src/circuit_drawer.rs
+++ b/crates/circuit/src/circuit_drawer.rs
@@ -1300,6 +1300,10 @@ impl TextDrawer {
     }
 
     fn draw(&self, mergewires: bool, fold: usize) -> String {
+        if self.wires.is_empty() {
+            return String::new();
+        }
+
         // Calculate the layer ranges for each fold of the circuit
         let num_layers = self.wires[0].len();
         // We skip the first (inputs) layer since it's printed for each fold, regardless
@@ -1534,6 +1538,14 @@ mod tests {
 
     #[cfg(feature = "cache_pygates")]
     use std::sync::OnceLock;
+
+    #[test]
+    fn test_empty_circuit() {
+        let circuit = CircuitData::new(None, None, Param::Float(0.5)).unwrap();
+        let result = draw_circuit(&circuit, false, false, None).unwrap();
+
+        assert_eq!("global phase: 0.5", result.trim_end());
+    }
 
     fn basic_circuit() -> CircuitData {
         let qreg = QuantumRegister::new_owning("q", 2);

--- a/releasenotes/notes/fix-empty-rust-text-drawer-4b76e522192ecad8.yaml
+++ b/releasenotes/notes/fix-empty-rust-text-drawer-4b76e522192ecad8.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    Fixed a panic in the Rust text circuit drawer when drawing a circuit with
+    no quantum or classical bits. Empty circuits now produce an empty circuit
+    section while preserving any global-phase output.

--- a/releasenotes/notes/fix-empty-rust-text-drawer-4b76e522192ecad8.yaml
+++ b/releasenotes/notes/fix-empty-rust-text-drawer-4b76e522192ecad8.yaml
@@ -1,3 +1,4 @@
+---
 fixes:
   - |
     Fixed a panic in the Rust text circuit drawer when drawing a circuit with


### PR DESCRIPTION
## Summary

- return an empty circuit section when the Rust text drawer receives no wires
- preserve global-phase output for empty circuits
- add regression coverage and a release note

Fixes #16723.

## Testing

- `cargo test -p qiskit-circuit --lib` (62 passed)
- `cargo clippy -p qiskit-circuit --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- release-note YAML parse
- `git diff --check`

## AI tool disclosure

OpenAI Codex (GPT-5) was used while preparing this contribution. I reviewed and validated the complete change.