### PR TITLE
Bump to the latest bugfix release of faer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "faer"
-version = "0.24.0"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d2ecfb80b6f8b0c569e36988a052e64b14d8def9d372390b014e8bf79f299a"
+checksum = "5ab6df3dd147fe8d702a288b95bcd8fcc499ab572fc80da6828f60cd4d524d67"
 dependencies = [
  "bytemuck",
  "dyn-stack",


### PR DESCRIPTION
This commit bumps the faer version we use for building qiskit from 0.24.0 to 0.24.4. There does not appear to be a changelog on what changed in these releases, but looking at the git log between the releases [1] it is mainly small bugfixes. As faer is explicitly ignored by dependabot [2] this needs to be done manually.

[1] https://codeberg.org/sarah-quinones/faer/compare/8dfcceee8eb3d81231366acc9d3f157ac5e7057a...faer-v0.24.4
[2] https://github.com/Qiskit/qiskit/pull/16721#issuecomment-5240907414

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
