### PR TITLE
Fix OptimizeCliffordT producing non-unitarily-equivalent output when basis excludes sx/sxdg

### DIFF
--- a/crates/transpiler/src/passes/optimize_clifford_t.rs
+++ b/crates/transpiler/src/passes/optimize_clifford_t.rs
@@ -184,7 +184,7 @@ fn optimize_clifford_t_1q(
 
     let apply_ty = if basis_gates.is_some_and(|gates| !gates.contains(&StandardGate::SX)) {
         |(sequence, flip): (&mut Vec<StandardGate>, bool)| {
-            sequence.push(StandardGate::S);
+            sequence.push(StandardGate::Sdg);
             sequence.push(StandardGate::H);
             sequence.push(if flip {
                 StandardGate::Tdg
@@ -192,7 +192,7 @@ fn optimize_clifford_t_1q(
                 StandardGate::T
             });
             sequence.push(StandardGate::H);
-            sequence.push(StandardGate::Sdg);
+            sequence.push(StandardGate::S);
         }
     } else {
         |(sequence, flip): (&mut Vec<StandardGate>, bool)| {

--- a/releasenotes/notes/fix-optimize-clifford-t-s-sdg-swap-a1b2c3d4e5f6a7b8.yaml
+++ b/releasenotes/notes/fix-optimize-clifford-t-s-sdg-swap-a1b2c3d4e5f6a7b8.yaml
@@ -1,0 +1,12 @@
+fixes:
+  - |
+    Fixed a bug in :class:`.OptimizeCliffordT` where, for circuits transpiled
+    to a Clifford+T basis that excludes ``sx``/``sxdg`` (for example
+    ``basis_gates=["cx", "s", "sdg", "h", "t", "tdg"]``), the pass could
+    return a circuit that was not unitarily equivalent to its input -- not
+    even up to a global phase -- with no error or warning raised. This
+    affected :func:`~qiskit.compiler.transpile` at ``optimization_level`` 1,
+    2, and 3 (the default ``optimization_level`` is 2, so this was not an
+    opt-in edge case). The bug was a two-token transcription error (``S``
+    and ``Sdg`` swapped) in the pass's internal re-expression of a Y-axis
+    T-rotation for bases without ``sx``/``sxdg``, introduced in #15625.

--- a/releasenotes/notes/fix-optimize-clifford-t-s-sdg-swap-a1b2c3d4e5f6a7b8.yaml
+++ b/releasenotes/notes/fix-optimize-clifford-t-s-sdg-swap-a1b2c3d4e5f6a7b8.yaml
@@ -1,12 +1,6 @@
 fixes:
   - |
     Fixed a bug in :class:`.OptimizeCliffordT` where, for circuits transpiled
-    to a Clifford+T basis that excludes ``sx``/``sxdg`` (for example
-    ``basis_gates=["cx", "s", "sdg", "h", "t", "tdg"]``), the pass could
-    return a circuit that was not unitarily equivalent to its input -- not
-    even up to a global phase -- with no error or warning raised. This
-    affected :func:`~qiskit.compiler.transpile` at ``optimization_level`` 1,
-    2, and 3 (the default ``optimization_level`` is 2, so this was not an
-    opt-in edge case). The bug was a two-token transcription error (``S``
-    and ``Sdg`` swapped) in the pass's internal re-expression of a Y-axis
-    T-rotation for bases without ``sx``/``sxdg``, introduced in #15625.
+    to a Clifford+T basis that exclude :class:`.SXGate` and 
+    :class:`.SXdgGate`, the pass could return a circuit that was not
+    unitarily equivalent to its input.

--- a/test/python/transpiler/test_clifford_t_passmanager.py
+++ b/test/python/transpiler/test_clifford_t_passmanager.py
@@ -193,6 +193,30 @@ class TestCliffordTPassManager(QiskitTestCase):
         transpiled = pm.run(qc)
         self.assertLessEqual(set(transpiled.count_ops()), set(basis_gates))
 
+        @data(0, 1, 2, 3)
+    def test_clifford_t_transpile_is_unitarily_equivalent(self, optimization_level):
+        """Regression test: OptimizeCliffordT previously produced a circuit that
+        was not unitarily equivalent to the input (not even up to global phase)
+        when `basis_gates` excluded `sx`/`sxdg`. This circuit -- a non-Clifford
+        `rz` rotation interleaved with T/CX/X gates -- broke at
+        optimization_level 1, 2, and 3 before the fix.
+        """
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.t(0)
+        qc.t(1)
+        qc.x(0)
+        qc.rz(0.3, 0)
+
+        basis_gates = ["cx", "s", "sdg", "h", "t", "tdg", "x", "y", "z"]
+        pm = generate_preset_clifford_t_pass_manager(
+            basis_gates=basis_gates, optimization_level=optimization_level
+        )
+        transpiled = pm.run(qc)
+        self.assertLessEqual(set(transpiled.count_ops()), set(basis_gates))
+        self.assertTrue(Operator(qc).equiv(Operator(transpiled)))
+
     @data(0, 1, 2, 3)
     def test_multiplier(self, optimization_level):
         """Clifford+T transpilation of a multiplier gate, using different optimization levels."""

--- a/test/python/transpiler/test_clifford_t_passmanager.py
+++ b/test/python/transpiler/test_clifford_t_passmanager.py
@@ -193,7 +193,7 @@ class TestCliffordTPassManager(QiskitTestCase):
         transpiled = pm.run(qc)
         self.assertLessEqual(set(transpiled.count_ops()), set(basis_gates))
 
-        @data(0, 1, 2, 3)
+    @data(0, 1, 2, 3)
     def test_clifford_t_transpile_is_unitarily_equivalent(self, optimization_level):
         """Regression test: OptimizeCliffordT previously produced a circuit that
         was not unitarily equivalent to the input (not even up to global phase)


### PR DESCRIPTION
## Summary

`OptimizeCliffordT`'s `apply_ty` closure re-expresses a Y-axis T-rotation without `sx`/`sxdg` using `S, H, T(dg), H, Sdg` -- but `S` and `Sdg` are swapped relative to the correct decomposition. As a result, the pass can emit a circuit that is not unitarily equivalent to its input (not even up to global phase) whenever `basis_gates` excludes `sx`/`sxdg` -- a normal, common Clifford+T target basis, not an edge case. No exception or warning is raised.

Verified two ways, not just with a custom offdiag computation: Qiskit's own `Operator.equiv()` (handles global phase correctly), and `process_fidelity()` (1.0 expected, 0.067-0.26 observed on affected cases).

## Root cause

In the non-`SX` branch of `apply_ty` (see diff), `S` and `Sdg` are swapped at the two ends of the sequence. Verified numerically: `SX*T*SXdg` matches `Sdg*H*T*H*S` (offdiag 5.5e-17, correct) but not `S*H*T*H*Sdg` (offdiag 0.7071, wrong) -- and the same holds for the `flip=true` (`Tdg`) case.

## Affected versions

Introduced in #15625 (merged 2026-03-19), first released in 2.4.0rc1. Confirmed affected: 2.4.0, 2.4.1, 2.4.2, 2.5.0, 2.5.0rc1, 2.5.1, and `main` prior to this fix. Not affected: 2.3.1 and earlier (the basis-aware Clifford+T pipeline didn't exist yet).

## Fix verified end-to-end

Built from source (not just the algebraic argument) and re-ran every known reproduction at every `optimization_level` (0-3): all now come out `Operator.equiv() == True` (previously `False` at levels 1, 2, and/or 3 depending on the circuit).

## Test plan

Added `test_clifford_t_transpile_is_unitarily_equivalent` to `test_clifford_t_passmanager.py`, parametrized over all four optimization levels, asserting `Operator(qc).equiv(Operator(transpiled))`. None of the existing tests in that file check unitary equivalence (only gate-set membership and T-count), which is consistent with how this went unnoticed across several releases.

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description: Claude (Anthropic), OpenCode, ChatGPT (OpenAI), Gemini (Google)
- [x] I used the following tool to help generate or modify code: Claude (Anthropic), OpenCode, ChatGPT (OpenAI), Gemini (Google)
