### PR TITLE
Fix out-of-date Rust dependabot ignores

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,24 +5,22 @@ updates:
     schedule:
       interval: "weekly"
     groups:
+      # When we use crates that depend on PyO3, we all have to agree on the version used, so they
+      # need to be bumped as one group.  Typically, minor-version bumps of PyO3 will require manual
+      # intervention, but it's still helpful to have Dependabot prod us to do it.
+      pyo3:
+        patterns:
+          - "pyo3"
+          - "numpy"
+        update-types:
+          - "major"
+          - "minor"
       cargo:
         patterns: ['*']
     labels:
       - "Rust"
       - "dependencies"
       - "Changelog: None"
-    ignore:
-      # faer has historically made major breaking changes between minor versions, so it's easier to
-      # do things manually ourselves.
-      - { dependency-name: "faer", versions: [">0.19.4"] }
-      - { dependency-name: "faer-ext", versions: [">0.2.0"] }
-      # nalgebra 0.34 bumped its MSRV to 1.87, which is too high for us.
-      - { dependency-name: "nalgebra", versions: [">0.33.2"] }
-      # Used by the experimental OQ3 exporter at a time when we were expecting to make updates
-      # manually to this.
-      - { dependency-name: "oq3_semantics", versions: [">0.0.7"] }
-      # hashbrown 0.13.0 bumped the MSRV to 1.61
-      - { dependency-name: "hashbrown", versions: [">0.12.3"] }
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
All the comments given in the file are out-of-date: our MSRV is currently 1.89; `faer` development has slowed/somewhat stabilised; `oq3_semantics` development has stopped.

PyO3 and `rust-numpy` need manual intervention when new minor releases are made, so they get their own group.  That group is likely to need manual intervention, but it's good to have the dependabot PR to prompt us to do it, in case we forget.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
