### PR TITLE
Install Rust in CI explicitly and directly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,3 @@ updates:
       # This semi-reliably requires us to make manual changes to the wheel-build rules, so it's more
       # convenient to do it all ourselves.
       - { dependency-name: "pypa/cibuildwheel", versions: [">3.0.1"] }
-      # The version of this is used as a cutesy way to select the Rust version instead of doing
-      # things with an Actions input.
-      - { dependency-name: "dtolnay/rust-toolchain", versions: [">1.7.0"] }

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,10 +24,13 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools-preview
+      - name: Install Rust
+        run:
+          rustup toolchain install stable
+            --override
+            --profile minimal
+            --component llvm-tools-preview
+            --no-self-update
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ctests.yml
+++ b/.github/workflows/ctests.yml
@@ -28,6 +28,8 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: ${{ inputs.python-version }}
+      - name: Install Rust
+        run: rustup toolchain install --profile minimal --no-self-update
       - name: Run tests
         run: make ctest
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,8 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: ${{ inputs.python-version }}
+      - name: Install Rust
+        run: rustup toolchain install --profile minimal --no-self-update
       - name: Install ubuntu docs dependencies
         run: tools/install_ubuntu_docs_dependencies.sh
         env:

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -24,6 +24,8 @@ jobs:
         name: Install Python
         with:
           python-version: "3.14"
+      - name: Install Rust
+        run: rustup toolchain install --profile minimal --no-self-update
 
       - name: Install dependencies
         run: tools/install_ubuntu_docs_dependencies.sh

--- a/.github/workflows/image-tests.yml
+++ b/.github/workflows/image-tests.yml
@@ -27,6 +27,8 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: ${{ inputs.python-version }}
+      - name: Install Rust
+        run: rustup toolchain install --profile minimal --no-self-update
       - name: Install Image dependencies
         run: |
           set -e

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,15 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: ${{ inputs.python-version }}
+
+      - name: Install Rust
+        run:
+          rustup toolchain install
+            --profile minimal
+            --component rustfmt
+            --component clippy
+            --no-self-update
+
       - name: Install dependencies
         run: python -m pip install --upgrade tox
       - name: Run lint

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -18,11 +18,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
-          components: miri
+      - name: Install Rust
+        run:
+          rustup toolchain install ${{ env.RUSTUP_TOOLCHAIN }}
+            --override
+            --profile minimal
+            --component miri
+            --no-self-update
 
       - name: Prepare Miri
         run: |

--- a/.github/workflows/qpy.yml
+++ b/.github/workflows/qpy.yml
@@ -29,7 +29,8 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust
+        run: rustup toolchain install --profile minimal --no-self-update
 
       - uses: actions/cache@v6
         with:

--- a/.github/workflows/randomized_tests.yml
+++ b/.github/workflows/randomized_tests.yml
@@ -14,6 +14,8 @@ jobs:
         name: Install Python
         with:
           python-version: '3.11'
+      - name: Install Rust
+        run: rustup toolchain install --profile minimal --no-self-update
       - name: Install dependencies
         run: |
           python -m pip install -U pip

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v7
+      - name: Install Rust
+        run: rustup toolchain install --profile minimal --no-self-update
       - name: Standalone checks for all crates
         run: |
           set -e
@@ -25,6 +27,4 @@ jobs:
               popd
           done
       - name: Run Rust Tests
-        run: |
-          set -e
-          cargo test
+        run: cargo test

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -14,6 +14,8 @@ jobs:
         name: Install Python
         with:
           python-version: '3.10'
+      - name: Install Rust
+        run: rustup toolchain install --profile minimal --no-self-update
       - name: Install dependencies
         run: |
           python -m pip install -U pip

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -48,6 +48,8 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: ${{ inputs.python-version }}
+      - name: Install Rust
+        run: rustup toolchain install --profile minimal --no-self-update
       - name: Cache stestr
         uses: actions/cache@v6
         with:

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -37,6 +37,8 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: ${{ inputs.python-version }}
+      - name: Install Rust
+        run: rustup toolchain install --profile minimal --no-self-update
       - name: Cache stestr
         uses: actions/cache@v6
         with:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -36,6 +36,8 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: ${{ inputs.python-version }}
+      - name: Install Rust
+        run: rustup toolchain install --profile minimal --no-self-update
       - name: Cache stestr
         uses: actions/cache@v6
         with:

--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -88,9 +88,13 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: ${{ inputs.python-version }}
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools-preview
+      - name: Install Rust
+        run:
+          rustup toolchain install stable
+            --override
+            --profile minimal
+            --component llvm-tools-preview
+            --no-self-update
       - name: Configure PGO
         shell: bash
         if: inputs.pgo
@@ -130,7 +134,8 @@ jobs:
         name: Install Python
         with:
           python-version: ${{ inputs.python-version }}
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust
+        run: rustup toolchain install stable --override --profile minimal --no-self-update
       - uses: pypa/cibuildwheel@v3.4.0
       - uses: actions/upload-artifact@v7
         with:
@@ -144,7 +149,8 @@ jobs:
     runs-on: ubuntu-24.04-s390x
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust
+        run: rustup toolchain install stable --override --profile minimal --no-self-update
       - name: Install cibuildwheel
         run: python3 -m pip install --user cibuildwheel==3.4.0
       - name: Run cibuildwheel
@@ -160,7 +166,8 @@ jobs:
     runs-on: ubuntu-24.04-ppc64le
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust
+        run: rustup toolchain install stable --override --profile minimal --no-self-update
       - name: Install cibuildwheel
         run: python3 -m pip install --user cibuildwheel==3.4.0
       - name: Run cibuildwheel


### PR DESCRIPTION
We have been having annoying CI problems where the automatic installation of the Rust compiler via Rustup during Qiskit installation failed in unusual ways.  This instead installs only the necessary components for any particular job, and makes all installations explicit.

This removes the use of the `dtolnay/rust-toolchain` action because:

1. it's not providing any value beyond manual `rustup`, which is pre-installed on all relevant CI images

2. it uses a "creative" tagging scheme that's deliberately mutable, which isn't a great indication of security consciousness

This may or may not improve stability of the CI jobs, but there's an audit/logging benefit in being explicit about the dependencies of any given job, and separating out the Rust-installation steps from the general "build" steps anyway.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
