### PR TITLE
Sum VF2Layout average errors in a deterministic order

### DIFF
--- a/crates/transpiler/src/passes/vf2/vf2_layout.rs
+++ b/crates/transpiler/src/passes/vf2/vf2_layout.rs
@@ -230,10 +230,17 @@ fn build_average_error_map(target: &Target) -> Option<ErrorMap> {
         };
         let mut qarg_error: f64 = 0.;
         let mut count: usize = 0;
-        for op in target
+        // `operation_names_for_qargs` returns a `HashSet`, whose iteration order is randomised
+        // per call.  Summing the per-operation errors in that order makes `qarg_error` depend on a
+        // non-deterministic floating-point summation order, which can produce tie-break differences
+        // between otherwise-symmetric layouts.  Sort the names so the sum is reproducible.
+        let mut op_names: Vec<&str> = target
             .operation_names_for_qargs(QargsRef::Concrete(qargs))
             .expect("these qargs came from `target.qargs()`")
-        {
+            .into_iter()
+            .collect();
+        op_names.sort_unstable();
+        for op in op_names {
             count += 1;
             // If the `target` has no error recorded for an operation, we treat it as errorless.
             qarg_error += target

--- a/releasenotes/notes/fix-vf2layout-nondeterminism-error-sum-2b8d4e6f0a1c3d57.yaml
+++ b/releasenotes/notes/fix-vf2layout-nondeterminism-error-sum-2b8d4e6f0a1c3d57.yaml
@@ -2,6 +2,6 @@
 fixes:
   - |
     Fixed non-deterministic :class:`.VF2Layout` output at ``optimization_level=2`` on a
-    :class:`.Target` with control flow and a symmetric coupling map. The pass previously
+    :class:`.Target` a symmetric coupling map. The pass previously
     could tie-break differently between runs due to non-deterministic float summation.
     Fixed `#16490 <https://github.com/Qiskit/qiskit/issues/16490>`__.

--- a/releasenotes/notes/fix-vf2layout-nondeterminism-error-sum-2b8d4e6f0a1c3d57.yaml
+++ b/releasenotes/notes/fix-vf2layout-nondeterminism-error-sum-2b8d4e6f0a1c3d57.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed non-deterministic :class:`.VF2Layout` output at ``optimization_level=2`` on a
+    :class:`.Target` with control flow and a symmetric coupling map. The pass summed per-qubit
+    gate errors in a non-deterministic order; as floating-point addition is not associative, two
+    symmetric layouts could tie-break differently between runs, so the chosen layout -- and thus
+    the single-qubit gate count and depth of the output -- varied. The errors are now summed in a
+    deterministic order.
+    Fixed `#16490 <https://github.com/Qiskit/qiskit/issues/16490>`__.

--- a/releasenotes/notes/fix-vf2layout-nondeterminism-error-sum-2b8d4e6f0a1c3d57.yaml
+++ b/releasenotes/notes/fix-vf2layout-nondeterminism-error-sum-2b8d4e6f0a1c3d57.yaml
@@ -2,9 +2,6 @@
 fixes:
   - |
     Fixed non-deterministic :class:`.VF2Layout` output at ``optimization_level=2`` on a
-    :class:`.Target` with control flow and a symmetric coupling map. The pass summed per-qubit
-    gate errors in a non-deterministic order; as floating-point addition is not associative, two
-    symmetric layouts could tie-break differently between runs, so the chosen layout -- and thus
-    the single-qubit gate count and depth of the output -- varied. The errors are now summed in a
-    deterministic order.
+    :class:`.Target` with control flow and a symmetric coupling map. The pass previously
+    could tie-break differently between runs due to non-deterministic float summation.
     Fixed `#16490 <https://github.com/Qiskit/qiskit/issues/16490>`__.


### PR DESCRIPTION
### Summary

Fixes the non-deterministic `optimization_level=2` transpiler output reported in #16490: with a
fixed circuit, backend, and `seed_transpiler`, the **1-qubit gate count and depth varied run-to-run**
(the 2-qubit count stayed stable) on a `Target` that has **control flow** and a **symmetric coupling
map**.

### Details and comments

Root cause (full analysis in #16490): `build_average_error_map` in `VF2Layout` summed each qubit's
per-operation gate errors while iterating the `HashSet` returned by
`Target::operation_names_for_qargs`, whose iteration order is randomized per call. Floating-point
addition is not associative, so two symmetric layouts scored ε-apart in a non-deterministic
direction, and VF2's strictly-decreasing comparison then picked one of the two symmetric embeddings
~50/50 per run. The chosen layout deterministically fixes the resulting 1q-gate count and depth
(which is why the 2q count — unaffected by a symmetric relabel — stayed stable, and why both
`control_flow=True` and `make_symmetric()` are required to trigger it).

The fix is the short-term direct VF2 change preferred by @jakelishman and @mtreinish in the issue
(commit 8ea89ab): collect the operation names into a `Vec`, `sort_unstable()`, and sum in that stable
order. No public API change — `operation_names_for_qargs` still returns a set.

Per the issue discussion, this is a candidate for backport to 2.5.2.

Fixes #16490.

### AI/LLM disclosure

- [x] The root-cause analysis (see #16490) and this fix were developed with the assistance of Claude
  Code; a human authored and reviewed the change. The fix was validated locally with the Rust and
  Python transpiler test suites (no regressions) when developed, and cherry-picks cleanly onto
  current `main` for this PR.
