### PR TITLE
docs: fix comment in high_level_synthesis.py regarding `plugin_evaluation_fn`

### DIFF
--- a/qiskit/transpiler/passes/synthesis/high_level_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/high_level_synthesis.py
@@ -105,7 +105,7 @@ class HLSConfig:
                 all the specified methods will be considered, and the best synthesized circuit,
                 according to ``plugin_evaluation_fn`` will be chosen.
             plugin_evaluation_fn: a callable that evaluates the quality of the synthesized
-                quantum circuit in the case that ``plugin_selection="sequential"``;
+                quantum circuit in the case that ``plugin_selection="all"``;
                 a smaller value means a better circuit. If ``None``, the
                 quality of the circuit is its size (i.e. the number of gates that it contains).
             kwargs: a dictionary mapping higher-level-objects to lists of synthesis methods.


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

The comment should be ` ``plugin_selection="all"`` `

https://github.com/Qiskit/qiskit/blob/25955368cf14fb4f1b614a4fcd1dabf4b3c02e36/qiskit/transpiler/passes/synthesis/high_level_synthesis.py#L398-L411

The `plugin_evaluation_fn` is only called when it's not sequential, i.e. "all" or `run everything` mode as the comment at row 405 said.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description: N/A
- [ ] I used the following tool to generate or modify code: N/A

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
