### PR TITLE
Refactor `coupling.py` to use Rustworkxs `make_symmetric` implementation

### DIFF
--- a/qiskit/transpiler/coupling.py
+++ b/qiskit/transpiler/coupling.py
@@ -241,13 +241,7 @@ class CouplingMap:
         """
         Convert uni-directional edges into bi-directional.
         """
-        # TODO: replace with PyDiGraph.make_symmetric() after rustworkx
-        # 0.13.0 is released.
-        edges = self.get_edges()
-        edge_set = set(edges)
-        for src, dest in edges:
-            if (dest, src) not in edge_set:
-                self.graph.add_edge(dest, src, None)
+        self.graph.make_symmetric()
         self._dist_matrix = None  # invalidate
         self._is_symmetric = None  # invalidate
 


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->
### Summary
This PR removes an outdated TODO in `qiskit/transpiler/coupling.py` where used a python implementation to be replaced when `Rustworkx`s version reaches at least 0.13.0.
The current version of Qiskit uses `Rustworkx>=0.15.0`, both Python and Rust implementation achieves the same logic.

### Testing
- `tox -elint`
- `tox -epy310`

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
