### PR TITLE
Fix panic in Rust circuit drawer for empty circuits

### DIFF
--- a/crates/circuit/src/circuit_drawer.rs
+++ b/crates/circuit/src/circuit_drawer.rs
@@ -1300,6 +1300,7 @@ impl TextDrawer {
     }
 
     fn draw(&self, mergewires: bool, fold: usize) -> String {
+        // Code generated/assisted by LLM
         if self.wires.is_empty() {
             return String::new();
         }

--- a/crates/circuit/src/circuit_drawer.rs
+++ b/crates/circuit/src/circuit_drawer.rs
@@ -1301,11 +1301,10 @@ impl TextDrawer {
 
     fn draw(&self, mergewires: bool, fold: usize) -> String {
         // Code generated/assisted by LLM
-        if self.wires.is_empty() {
+        let Some(num_layers) = self.wires.first().map(|wire| wire.len()) else {
             return String::new();
-        }
+        };
         // Calculate the layer ranges for each fold of the circuit
-        let num_layers = self.wires[0].len();
         // We skip the first (inputs) layer since it's printed for each fold, regardless
         // of screen width limit
         let layer_widths = (1..num_layers).map(|layer| self.get_layer_width(layer));

--- a/crates/circuit/src/circuit_drawer.rs
+++ b/crates/circuit/src/circuit_drawer.rs
@@ -1300,6 +1300,9 @@ impl TextDrawer {
     }
 
     fn draw(&self, mergewires: bool, fold: usize) -> String {
+        if self.wires.is_empty() {
+            return String::new();
+        }
         // Calculate the layer ranges for each fold of the circuit
         let num_layers = self.wires[0].len();
         // We skip the first (inputs) layer since it's printed for each fold, regardless
@@ -1517,6 +1520,12 @@ pub fn format_float_pi(f: f64) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn test_empty_circuit() {
+        let circuit = CircuitData::new(None, None, Param::Float(0.5)).unwrap();
+        let result = draw_circuit(&circuit, false, false, None).unwrap();
+        assert_eq!("global phase: 0.5\n", result);
+    }
     use ndarray::Array2;
     use smallvec::smallvec;
     use std::f64::consts::PI;


### PR DESCRIPTION
This commit fixes an issue where the Rust text circuit drawer would panic when attempting to draw an empty circuit (one with zero qubits and zero clbits).

Closes #16723

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: LLM assistance (Claude 3.5 / Antigravity Agent)
