### PR TITLE
Port synth_mcp_noaux_sp22 to Rust

### DIFF
--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -90,6 +90,9 @@ trait CircuitDataForSynthesis {
     /// Appends RCCX to the circuit.
     fn rccx(&mut self, q1: u32, q2: u32, q3: u32) -> Result<(), CircuitDataError>;
 
+    /// Appends CRX to the circuit.
+    fn crx(&mut self, theta: f64, q1: u32, q2: u32) -> Result<(), CircuitDataError>;
+
     /// Compose ``other`` into ``self``, while remapping the qubits
     /// over which ``other`` is defined. The operations are added in-place.
     fn compose(
@@ -145,6 +148,16 @@ impl CircuitDataForSynthesis for CircuitData {
     fn cp(&mut self, theta: f64, q1: u32, q2: u32) -> Result<(), CircuitDataError> {
         self.push_standard_gate(
             StandardGate::CPhase,
+            &[Param::Float(theta)],
+            &[Qubit(q1), Qubit(q2)],
+        )
+    }
+
+    /// Appends CRX to the circuit.
+    #[inline]
+    fn crx(&mut self, theta: f64, q1: u32, q2: u32) -> Result<(), CircuitDataError> {
+        self.push_standard_gate(
+            StandardGate::CRX,
             &[Param::Float(theta)],
             &[Qubit(q1), Qubit(q2)],
         )
@@ -1130,6 +1143,132 @@ pub fn synth_mcx_noaux_hp24(num_controls: usize) -> PyResult<CircuitData> {
     }
 
     Ok(circuit)
+}
+
+/// Synthesize a multi-controlled phase gate with :math:`n` controls based on the paper
+/// by da Silva et al. [1] and the implementation in qclib [2].
+///
+/// For :math:`n \ge 2`, the method produces a circuit with :math:`4n^2-4n+2` CX gates
+/// and requires :math:`O(n)` depth.
+/// For :math:`n \le 4`, it is more efficient to use [`synth_mcp_noaux_v24`],
+/// which produces a circuit with less CX gates.
+///
+/// The circuit breaks down into four steps, each applying a specific pattern of controlled gates.
+///
+/// - Step 1: Apply :math:`n` controlled phase gates and :math:`n(n-1)/2` controlled RX gates.
+/// - Step 2: Apply :math:`n-1` controlled phase gates and :math:`(n-1)(n-2)/2` controlled RX gates.
+///
+///   This is the initial phase. It applies angle rotations (e.g., :math:`R_X(\pi/k)`) and
+///   the :math:`k`-th roots of the target unitary (:math:`U^{1/k}`) in a cascading V-shape pattern.
+///   This step systematically accumulates the partitioned components of the unitary
+///   operation on the target qubit based on the control states.
+///
+/// - Step 3: Apply :math:`n(n-1)/2` controlled RX gates.
+/// - Step 4: Apply :math:`(n-1)(n-2)/2` controlled RX gates.
+///
+///   Steps 3 and 4 together constitute the uncomputation process. By applying only the inverse of
+///   the angle rotation operations in steps 1 and 2, these steps reverse the unwanted
+///   entanglement and phase shifts generated in the first two steps. This cancellation ensures
+///   that the target qubit undergoes the full unitary operation :math:`U`
+///   if and only if all control qubits are in the :math:`|1\rangle` state.
+///
+/// Each controlled RX gate and controlled phase gate requires two CX gates,
+/// resulting in a total of :math:`4n^2-4n+2` CX gates.
+///
+/// # Arguments
+///
+/// - num_ctrl_qubits: the number of control qubits.
+/// - phase: the phase angle for the multi-controlled phase gate.
+///
+/// # Returns
+///
+/// A quantum circuit implementing the multi-controlled phase gate with :math:`4n^2-4n+2` CX gates.
+///
+/// # References
+///
+/// 1. A. J. da Silva and D. K. Park, *Linear-depth quantum circuits for multiqubit controlled gates*,
+///    [Phys. Rev. A 106, 042602](https://journals.aps.org/pra/abstract/10.1103/PhysRevA.106.042602).
+///
+/// 2. <https://github.com/qclib/qclib/blob/master/qclib/gates/ldmcu.py>
+pub fn synth_mcp_noaux_sp22(
+    num_ctrl_qubits: usize,
+    phase: f64,
+) -> Result<CircuitData, CircuitDataError> {
+    // The following code is a derivative work of qclib
+    // (https://github.com/qclib/qclib/blob/master/qclib/gates/ldmcu.py).
+    // Copyright 2021 qclib project.
+    // Licensed under the Apache License, Version 2.0.
+    let mut circuit =
+        CircuitData::with_capacity((num_ctrl_qubits + 1) as u32, 0, 0, Param::Float(0.0))?;
+
+    if num_ctrl_qubits == 0 {
+        circuit.p(phase, 0)?;
+    } else if num_ctrl_qubits == 1 {
+        circuit.cp(phase, 0, 1)?;
+    } else {
+        apply_controlled_gates(&mut circuit, phase, num_ctrl_qubits + 1, 1)?;
+        apply_controlled_gates(&mut circuit, phase, num_ctrl_qubits + 1, 2)?;
+        apply_controlled_gates(&mut circuit, phase, num_ctrl_qubits, 3)?;
+        apply_controlled_gates(&mut circuit, phase, num_ctrl_qubits, 4)?;
+    }
+    Ok(circuit)
+}
+
+/// Helper function to apply controlled gates in a specific pattern based on the step
+/// in [`synth_mcp_noaux_sp22`].
+///
+/// The following code is a derivative work of qclib
+/// (<https://github.com/qclib/qclib/blob/master/qclib/gates/ldmcu.py>).
+/// Copyright 2021 qclib project. Licensed under the Apache License, Version 2.0.
+fn apply_controlled_gates(
+    circuit: &mut CircuitData,
+    phi: f64,
+    n_qubits: usize,
+    step: usize,
+) -> Result<(), CircuitDataError> {
+    let (start, reverse) = if step == 1 || step == 3 {
+        (0usize, true)
+    } else {
+        (1usize, false)
+    };
+
+    // all pairs (control, target) where control<target
+    let mut qubit_pairs: Vec<(usize, usize)> = (start..n_qubits)
+        .flat_map(|target| (start..target).map(move |control| (control, target)))
+        .collect();
+
+    if reverse {
+        qubit_pairs.sort_by(|a, b| (b.0 + b.1).cmp(&(a.0 + a.1)));
+    } else {
+        qubit_pairs.sort_by(|a, b| (a.0 + a.1).cmp(&(b.0 + b.1)));
+    }
+
+    for &(control, target) in &qubit_pairs {
+        let exponent = if control == 0 {
+            target - control - 1
+        } else {
+            target - control
+        };
+
+        let param = (1usize << exponent) as f64; // 2^exponent, using bit shift
+        if target == n_qubits - 1 && (step == 1 || step == 2) {
+            let sign: i32 = if step == 1 { 1 } else { -1 };
+            circuit.cp((sign as f64) * phi / param, control as u32, target as u32)?;
+        } else {
+            let sign: i32 = if step == 1 {
+                1
+            } else if step == 2 {
+                -1
+            } else if step == 3 {
+                if control == 0 { -1 } else { 1 }
+            } else {
+                #[allow(clippy::collapsible_else_if)]
+                if control == 0 { 1 } else { -1 }
+            };
+            circuit.crx((sign as f64) * PI / param, control as u32, target as u32)?;
+        }
+    }
+    Ok(())
 }
 
 #[cfg(all(test, not(miri)))]

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -1145,7 +1145,7 @@ pub fn synth_mcx_noaux_hp24(num_controls: usize) -> PyResult<CircuitData> {
     Ok(circuit)
 }
 
-// The following code (synth_mcp_noaux_sp22 and its helpers) is a derivative work of qclib
+// The following code (synth_mcp_noaux_sp22 and mod sp22) is a derivative work of qclib
 // (https://github.com/qclib/qclib/blob/master/qclib/gates/ldmcu.py).
 // Copyright 2021 qclib project. Licensed under the Apache License, Version 2.0.
 
@@ -1194,124 +1194,139 @@ pub fn synth_mcp_noaux_sp22(
     } else if num_ctrl_qubits == 1 {
         circuit.cp(phase, 0, 1)?;
     } else {
-        step_1(&mut circuit, &phase, num_ctrl_qubits)?;
-        step_2(&mut circuit, &phase, num_ctrl_qubits)?;
-        step_3(&mut circuit, num_ctrl_qubits)?;
-        step_4(&mut circuit, num_ctrl_qubits)?;
+        sp22::step_1(&mut circuit, &phase, num_ctrl_qubits)?;
+        sp22::step_2(&mut circuit, &phase, num_ctrl_qubits)?;
+        sp22::step_3(&mut circuit, num_ctrl_qubits)?;
+        sp22::step_4(&mut circuit, num_ctrl_qubits)?;
     }
     Ok(circuit)
 }
-// ---- SP22 helper functions -----
-/// Returns all `(control, target)` index pairs with `0 <= control < target < n_qubits`,
-/// sorted by `control + target` descending.
-fn pairs_high_sum_first(n_qubits: usize) -> Vec<(usize, usize)> {
-    let mut pairs: Vec<(usize, usize)> = (0..n_qubits)
-        .flat_map(|target| (0..target).map(move |control| (control, target)))
-        .collect();
-    pairs.sort_by(|a, b| (b.0 + b.1).cmp(&(a.0 + a.1)));
-    pairs
-}
 
-/// Returns all `(control, target)` index pairs with `1 <= control < target < n_qubits`,
-/// sorted by `control + target` ascending.
-fn pairs_low_sum_first(n_qubits: usize) -> Vec<(usize, usize)> {
-    let mut pairs: Vec<(usize, usize)> = (1..n_qubits)
-        .flat_map(|target| (1..target).map(move |control| (control, target)))
-        .collect();
-    pairs.sort_by(|a, b| (a.0 + a.1).cmp(&(b.0 + b.1)));
-    pairs
-}
+mod sp22 {
+    use std::f64::consts::PI;
 
-/// Returns `2^exponent` where `exponent = (target - control) - 1` if `control == 0`,
-/// or `(target - control)` otherwise. This is the divisor of the fractional angle
-/// (`φ / divisor` for CP gates, `π / divisor` for CRX gates) applied to each qubit pair.
-/// Uses `f64::exp2` rather than a bit shift to avoid overflow for `n > 64` controls.
-/// Note that target > control by design, no need to assert for.
-fn angle_divisor(control: usize, target: usize) -> f64 {
-    let exponent = if control == 0 {
-        target - control - 1
-    } else {
-        target - control
-    };
-    (exponent as f64).exp2()
-}
+    use qiskit_circuit::circuit_data::{CircuitData, CircuitDataError};
+    use qiskit_circuit::operations::{Param, multiply_param};
 
-/// SP22 Step 1 — forward phase accumulation on controls and target.
-///
-/// Iterates over all pairs `0 <= c < t <= num_ctrl_qubits`, high-sum first.
-/// Emits CP(+φ/divisor, c, t) when `t` is the target qubit, CRX(+π/divisor, c, t) otherwise.
-/// The CP gates accumulate phase on the target; the CRX gates entangle the controls
-/// so that the phases cancel for all input states except |11…1⟩.
-fn step_1(
-    circuit: &mut CircuitData,
-    phi: &Param,
-    num_ctrl_qubits: usize,
-) -> Result<(), CircuitDataError> {
-    for (control, target) in pairs_high_sum_first(num_ctrl_qubits + 1) {
-        let divisor = angle_divisor(control, target);
-        if target == num_ctrl_qubits {
-            circuit.cp(
-                multiply_param(phi, 1.0 / divisor),
-                control as u32,
-                target as u32,
-            )?;
-        } else {
-            circuit.crx(PI / divisor, control as u32, target as u32)?;
-        }
+    use super::CircuitDataForSynthesis;
+
+    /// Returns all `(control, target)` index pairs with `0 <= control < target < n_qubits`,
+    /// sorted by `control + target` descending.
+    fn pairs_high_sum_first(n_qubits: usize) -> Vec<(usize, usize)> {
+        let mut pairs: Vec<(usize, usize)> = (0..n_qubits)
+            .flat_map(|target| (0..target).map(move |control| (control, target)))
+            .collect();
+        pairs.sort_by(|a, b| (b.0 + b.1).cmp(&(a.0 + a.1)));
+        pairs
     }
-    Ok(())
-}
 
-/// SP22 Step 2 — reverse sweep on controls and target.
-///
-/// Iterates over all pairs `1 <= c < t <= num_ctrl_qubits`, low-sum first.
-/// Emits CP(−φ/divisor, c, t) when `t` is the target qubit, CRX(−π/divisor, c, t) otherwise.
-/// Mirrors step 1 in reverse order to complete the phase accumulation pattern.
-fn step_2(
-    circuit: &mut CircuitData,
-    phi: &Param,
-    num_ctrl_qubits: usize,
-) -> Result<(), CircuitDataError> {
-    for (control, target) in pairs_low_sum_first(num_ctrl_qubits + 1) {
-        let divisor = angle_divisor(control, target);
-        if target == num_ctrl_qubits {
-            circuit.cp(
-                multiply_param(phi, -1.0 / divisor),
-                control as u32,
-                target as u32,
-            )?;
+    /// Returns all `(control, target)` index pairs with `1 <= control < target < n_qubits`,
+    /// sorted by `control + target` ascending.
+    fn pairs_low_sum_first(n_qubits: usize) -> Vec<(usize, usize)> {
+        let mut pairs: Vec<(usize, usize)> = (1..n_qubits)
+            .flat_map(|target| (1..target).map(move |control| (control, target)))
+            .collect();
+        pairs.sort_by(|a, b| (a.0 + a.1).cmp(&(b.0 + b.1)));
+        pairs
+    }
+
+    /// Returns `2^exponent` where `exponent = (target - control) - 1` if `control == 0`,
+    /// or `(target - control)` otherwise. This is the divisor of the fractional angle
+    /// (`φ / divisor` for CP gates, `π / divisor` for CRX gates) applied to each qubit pair.
+    /// Uses `f64::exp2` rather than a bit shift to avoid overflow for `n > 64` controls.
+    /// Note that target > control by design, no need to assert for.
+    fn angle_divisor(control: usize, target: usize) -> f64 {
+        let exponent = if control == 0 {
+            target - control - 1
         } else {
+            target - control
+        };
+        (exponent as f64).exp2()
+    }
+
+    /// SP22 Step 1 — forward phase accumulation on controls and target.
+    ///
+    /// Iterates over all pairs `0 <= c < t <= num_ctrl_qubits`, high-sum first.
+    /// Emits CP(+φ/divisor, c, t) when `t` is the target qubit, CRX(+π/divisor, c, t) otherwise.
+    /// The CP gates accumulate phase on the target; the CRX gates entangle the controls
+    /// so that the phases cancel for all input states except |11…1⟩.
+    pub fn step_1(
+        circuit: &mut CircuitData,
+        phi: &Param,
+        num_ctrl_qubits: usize,
+    ) -> Result<(), CircuitDataError> {
+        for (control, target) in pairs_high_sum_first(num_ctrl_qubits + 1) {
+            let divisor = angle_divisor(control, target);
+            if target == num_ctrl_qubits {
+                circuit.cp(
+                    multiply_param(phi, 1.0 / divisor),
+                    control as u32,
+                    target as u32,
+                )?;
+            } else {
+                circuit.crx(PI / divisor, control as u32, target as u32)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// SP22 Step 2 — reverse sweep on controls and target.
+    ///
+    /// Iterates over all pairs `1 <= c < t <= num_ctrl_qubits`, low-sum first.
+    /// Emits CP(−φ/divisor, c, t) when `t` is the target qubit, CRX(−π/divisor, c, t) otherwise.
+    /// Mirrors step 1 in reverse order to complete the phase accumulation pattern.
+    pub fn step_2(
+        circuit: &mut CircuitData,
+        phi: &Param,
+        num_ctrl_qubits: usize,
+    ) -> Result<(), CircuitDataError> {
+        for (control, target) in pairs_low_sum_first(num_ctrl_qubits + 1) {
+            let divisor = angle_divisor(control, target);
+            if target == num_ctrl_qubits {
+                circuit.cp(
+                    multiply_param(phi, -1.0 / divisor),
+                    control as u32,
+                    target as u32,
+                )?;
+            } else {
+                circuit.crx(-PI / divisor, control as u32, target as u32)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// SP22 Step 3 — uncomputation on controls only, forward order.
+    ///
+    /// Iterates over all pairs `0 <= c < t < num_ctrl_qubits`, high-sum first.
+    /// Emits CRX(−π/divisor, c, t) when `c == 0`, CRX(+π/divisor, c, t) otherwise.
+    /// The sign alternation here and in step 4 cancels the CRX entanglement from steps 1 and 2.
+    pub fn step_3(
+        circuit: &mut CircuitData,
+        num_ctrl_qubits: usize,
+    ) -> Result<(), CircuitDataError> {
+        for (control, target) in pairs_high_sum_first(num_ctrl_qubits) {
+            let divisor = angle_divisor(control, target);
+            let sign = if control == 0 { -1.0 } else { 1.0 };
+            circuit.crx(sign * PI / divisor, control as u32, target as u32)?;
+        }
+        Ok(())
+    }
+
+    /// SP22 Step 4 — uncomputation on controls only, reverse order.
+    ///
+    /// Iterates over all pairs `1 <= c < t < num_ctrl_qubits`, low-sum first.
+    /// Emits CRX(−π/divisor, c, t) for all pairs (`c == 0` never occurs in this range).
+    /// Mirrors step 3 in reverse order to complete the uncomputation.
+    pub fn step_4(
+        circuit: &mut CircuitData,
+        num_ctrl_qubits: usize,
+    ) -> Result<(), CircuitDataError> {
+        for (control, target) in pairs_low_sum_first(num_ctrl_qubits) {
+            let divisor = angle_divisor(control, target);
             circuit.crx(-PI / divisor, control as u32, target as u32)?;
         }
+        Ok(())
     }
-    Ok(())
-}
-
-/// SP22 Step 3 — uncomputation on controls only, forward order.
-///
-/// Iterates over all pairs `0 <= c < t < num_ctrl_qubits`, high-sum first.
-/// Emits CRX(−π/divisor, c, t) when `c == 0`, CRX(+π/divisor, c, t) otherwise.
-/// The sign alternation here and in step 4 cancels the CRX entanglement from steps 1 and 2.
-fn step_3(circuit: &mut CircuitData, num_ctrl_qubits: usize) -> Result<(), CircuitDataError> {
-    for (control, target) in pairs_high_sum_first(num_ctrl_qubits) {
-        let divisor = angle_divisor(control, target);
-        let sign = if control == 0 { -1.0 } else { 1.0 };
-        circuit.crx(sign * PI / divisor, control as u32, target as u32)?;
-    }
-    Ok(())
-}
-
-/// SP22 Step 4 — uncomputation on controls only, reverse order.
-///
-/// Iterates over all pairs `1 <= c < t < num_ctrl_qubits`, low-sum first.
-/// Emits CRX(−π/divisor, c, t) for all pairs (`c == 0` never occurs in this range).
-/// Mirrors step 3 in reverse order to complete the uncomputation.
-fn step_4(circuit: &mut CircuitData, num_ctrl_qubits: usize) -> Result<(), CircuitDataError> {
-    for (control, target) in pairs_low_sum_first(num_ctrl_qubits) {
-        let divisor = angle_divisor(control, target);
-        circuit.crx(-PI / divisor, control as u32, target as u32)?;
-    }
-    Ok(())
 }
 
 #[cfg(all(test, not(miri)))]

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -73,13 +73,13 @@ trait CircuitDataForSynthesis {
 
     /// Appends Phase to the circuit.
     #[allow(dead_code)]
-    fn p(&mut self, theta: f64, q: u32) -> Result<(), CircuitDataError>;
+    fn p(&mut self, theta: impl Into<Param>, q: u32) -> Result<(), CircuitDataError>;
 
     /// Appends CX to the circuit.
     fn cx(&mut self, q1: u32, q2: u32) -> Result<(), CircuitDataError>;
 
     /// Appends CPhase to the circuit.
-    fn cp(&mut self, theta: f64, q1: u32, q2: u32) -> Result<(), CircuitDataError>;
+    fn cp(&mut self, theta: impl Into<Param>, q1: u32, q2: u32) -> Result<(), CircuitDataError>;
 
     /// Appends CCPhase to the circuit.
     fn ccp(&mut self, theta: f64, q1: u32, q2: u32, q3: u32) -> Result<(), CircuitDataError>;
@@ -133,8 +133,8 @@ impl CircuitDataForSynthesis for CircuitData {
 
     /// Appends Phase to the circuit.
     #[inline]
-    fn p(&mut self, theta: f64, q: u32) -> Result<(), CircuitDataError> {
-        self.push_standard_gate(StandardGate::Phase, &[Param::Float(theta)], &[Qubit(q)])
+    fn p(&mut self, theta: impl Into<Param>, q: u32) -> Result<(), CircuitDataError> {
+        self.push_standard_gate(StandardGate::Phase, &[theta.into()], &[Qubit(q)])
     }
 
     /// Appends CX to the circuit.
@@ -145,10 +145,10 @@ impl CircuitDataForSynthesis for CircuitData {
 
     /// Appends CPhase to the circuit.
     #[inline]
-    fn cp(&mut self, theta: f64, q1: u32, q2: u32) -> Result<(), CircuitDataError> {
+    fn cp(&mut self, theta: impl Into<Param>, q1: u32, q2: u32) -> Result<(), CircuitDataError> {
         self.push_standard_gate(
             StandardGate::CPhase,
-            &[Param::Float(theta)],
+            &[theta.into()],
             &[Qubit(q1), Qubit(q2)],
         )
     }
@@ -1196,7 +1196,7 @@ pub fn synth_mcx_noaux_hp24(num_controls: usize) -> PyResult<CircuitData> {
 /// 2. <https://github.com/qclib/qclib/blob/master/qclib/gates/ldmcu.py>
 pub fn synth_mcp_noaux_sp22(
     num_ctrl_qubits: usize,
-    phase: f64,
+    phase: Param,
 ) -> Result<CircuitData, CircuitDataError> {
     // For n>1 steps 1-4 emit 2n-1 CP gates and 2(n-1)^2 CRX gates, i.e. 2n^2-2n+1 instructions
     // in total (later each of which decomposes into two CX gates, giving the 4n^2-4n+2 of the
@@ -1221,8 +1221,8 @@ pub fn synth_mcp_noaux_sp22(
         // Apply da Silva and Park algorithm for MCP decomposition in four steps:
         // Step 1 & 2: accumulate phase φ on the target qubit via CP gates;
         //             entangle controls via CRX gates.
-        step_1(&mut circuit, phase, num_ctrl_qubits)?;
-        step_2(&mut circuit, phase, num_ctrl_qubits)?;
+        step_1(&mut circuit, &phase, num_ctrl_qubits)?;
+        step_2(&mut circuit, &phase, num_ctrl_qubits)?;
         // Step 3 & 4: uncompute control entanglement via inverse CRX gates.
         step_3(&mut circuit, num_ctrl_qubits)?;
         step_4(&mut circuit, num_ctrl_qubits)?;
@@ -1251,13 +1251,13 @@ fn pairs_low_sum_first(n_qubits: usize) -> Vec<(usize, usize)> {
 }
 
 /// Returns `2^exponent` where `exponent = (target - control) - 1` if `control == 0`,
-/// or `(target - control)` otherwise. This is the denominator of the fractional angle
-/// (`φ / param` for CP gates, `π / param` for CRX gates) applied to each qubit pair.
+/// or `(target - control)` otherwise. This is the divisor of the fractional angle
+/// (`φ / divisor` for CP gates, `π / divisor` for CRX gates) applied to each qubit pair.
 /// Uses `f64::exp2` rather than a bit shift to avoid overflow for `n > 64` controls.
 /// Note that target > control by design, no need to assert for.
-fn gate_param(control: usize, target: usize) -> f64 {
+fn angle_divisor(control: usize, target: usize) -> f64 {
     let exponent = if control == 0 {
-    target - control - 1
+        target - control - 1
     } else {
         target - control
     };
@@ -1267,19 +1267,23 @@ fn gate_param(control: usize, target: usize) -> f64 {
 /// SP22 Step 1 — phase accumulation (on controls+target)
 ///
 /// Pairs sorted high-sum first, starting from qubit 0.
-/// Target qubit (`num_ctrl_qubits`): CP(+φ / param, c, t).
-/// All other pairs:                  CRX(+π / param, c, t).
+/// Target qubit (`num_ctrl_qubits`): CP(+φ / divisor, c, t).
+/// All other pairs:                  CRX(+π / divisor, c, t).
 fn step_1(
     circuit: &mut CircuitData,
-    phi: f64,
+    phi: &Param,
     num_ctrl_qubits: usize,
 ) -> Result<(), CircuitDataError> {
     for (control, target) in pairs_high_sum_first(num_ctrl_qubits + 1) {
-        let param = gate_param(control, target);
+        let divisor = angle_divisor(control, target);
         if target == num_ctrl_qubits {
-            circuit.cp(phi / param, control as u32, target as u32)?;
+            circuit.cp(
+                multiply_param(phi, 1.0 / divisor),
+                control as u32,
+                target as u32,
+            )?;
         } else {
-            circuit.crx(PI / param, control as u32, target as u32)?;
+            circuit.crx(PI / divisor, control as u32, target as u32)?;
         }
     }
     Ok(())
@@ -1288,19 +1292,23 @@ fn step_1(
 /// SP22 Step 2 — phase accumulation (reverse order, on controls+target).
 ///
 /// Pairs sorted low-sum first, starting from qubit 1.
-/// Target qubit (`num_ctrl_qubits`): CP(−φ / param, c, t).
-/// All other pairs:                  CRX(−π / param, c, t).
+/// Target qubit (`num_ctrl_qubits`): CP(−φ / divisor, c, t).
+/// All other pairs:                  CRX(−π / divisor, c, t).
 fn step_2(
     circuit: &mut CircuitData,
-    phi: f64,
+    phi: &Param,
     num_ctrl_qubits: usize,
 ) -> Result<(), CircuitDataError> {
     for (control, target) in pairs_low_sum_first(num_ctrl_qubits + 1) {
-        let param = gate_param(control, target);
+        let divisor = angle_divisor(control, target);
         if target == num_ctrl_qubits {
-            circuit.cp(-phi / param, control as u32, target as u32)?;
+            circuit.cp(
+                multiply_param(phi, -1.0 / divisor),
+                control as u32,
+                target as u32,
+            )?;
         } else {
-            circuit.crx(-PI / param, control as u32, target as u32)?;
+            circuit.crx(-PI / divisor, control as u32, target as u32)?;
         }
     }
     Ok(())
@@ -1309,12 +1317,12 @@ fn step_2(
 /// SP22 Step 3 — uncomputation (on controls only).
 ///
 /// Pairs sorted high-sum first, starting from qubit 0.
-/// CRX(−π / param, c, t) when c == 0, else CRX(+π / param, c, t).
+/// CRX(−π / divisor, c, t) when c == 0, else CRX(+π / divisor, c, t).
 fn step_3(circuit: &mut CircuitData, num_ctrl_qubits: usize) -> Result<(), CircuitDataError> {
     for (control, target) in pairs_high_sum_first(num_ctrl_qubits) {
-        let param = gate_param(control, target);
+        let divisor = angle_divisor(control, target);
         let sign = if control == 0 { -1.0 } else { 1.0 };
-        circuit.crx(sign * PI / param, control as u32, target as u32)?;
+        circuit.crx(sign * PI / divisor, control as u32, target as u32)?;
     }
     Ok(())
 }
@@ -1322,11 +1330,11 @@ fn step_3(circuit: &mut CircuitData, num_ctrl_qubits: usize) -> Result<(), Circu
 /// SP22 Step 4 — uncomputation (reverse order, controls only).
 ///
 /// Pairs sorted low-sum first, starting from qubit 1.
-/// Sign: CRX(−π / param, c, t).
+/// Sign: CRX(−π / divisor, c, t).
 fn step_4(circuit: &mut CircuitData, num_ctrl_qubits: usize) -> Result<(), CircuitDataError> {
     for (control, target) in pairs_low_sum_first(num_ctrl_qubits) {
-        let param = gate_param(control, target);
-        circuit.crx(-PI / param, control as u32, target as u32)?;
+        let divisor = angle_divisor(control, target);
+        circuit.crx(-PI / divisor, control as u32, target as u32)?;
     }
     Ok(())
 }

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -1145,6 +1145,10 @@ pub fn synth_mcx_noaux_hp24(num_controls: usize) -> PyResult<CircuitData> {
     Ok(circuit)
 }
 
+// The following code (synth_mcp_noaux_sp22 and its helpers) is a derivative work of qclib
+// (https://github.com/qclib/qclib/blob/master/qclib/gates/ldmcu.py).
+// Copyright 2021 qclib project. Licensed under the Apache License, Version 2.0.
+
 /// Synthesize a multi-controlled phase gate with :math:`n` controls based on the paper
 /// by da Silva et al. [1] and the implementation in qclib [2].
 ///
@@ -1194,92 +1198,135 @@ pub fn synth_mcp_noaux_sp22(
     num_ctrl_qubits: usize,
     phase: f64,
 ) -> Result<CircuitData, CircuitDataError> {
-    // The following code is a derivative work of qclib
-    // (https://github.com/qclib/qclib/blob/master/qclib/gates/ldmcu.py).
-    // Copyright 2021 qclib project.
-    // Licensed under the Apache License, Version 2.0.
-    let mut circuit =
-        CircuitData::with_capacity((num_ctrl_qubits + 1) as u32, 0, 0, Param::Float(0.0))?;
+    // For n>1 steps 1-4 emit 2n-1 CP gates and 2(n-1)^2 CRX gates, i.e. 2n^2-2n+1 instructions
+    // in total (later each of which decomposes into two CX gates, giving the 4n^2-4n+2 of the
+    // doc comment).
+    let num_instructions = if num_ctrl_qubits < 2 {
+        1
+    } else {
+        2 * num_ctrl_qubits * num_ctrl_qubits - 2 * num_ctrl_qubits + 1
+    };
+    let mut circuit = CircuitData::with_capacity(
+        (num_ctrl_qubits + 1) as u32,
+        0,
+        num_instructions,
+        Param::Float(0.0),
+    )?;
 
     if num_ctrl_qubits == 0 {
         circuit.p(phase, 0)?;
     } else if num_ctrl_qubits == 1 {
         circuit.cp(phase, 0, 1)?;
     } else {
-        apply_controlled_gates(&mut circuit, phase, num_ctrl_qubits + 1, 1)?;
-        apply_controlled_gates(&mut circuit, phase, num_ctrl_qubits + 1, 2)?;
-        apply_controlled_gates(&mut circuit, phase, num_ctrl_qubits, 3)?;
-        apply_controlled_gates(&mut circuit, phase, num_ctrl_qubits, 4)?;
+        // Apply da Silva and Park algorithm for MCP decomposition in four steps:
+        // Step 1 & 2: accumulate phase φ on the target qubit via CP gates;
+        //             entangle controls via CRX gates.
+        step_1(&mut circuit, phase, num_ctrl_qubits)?;
+        step_2(&mut circuit, phase, num_ctrl_qubits)?;
+        // Step 3 & 4: uncompute control entanglement via inverse CRX gates.
+        step_3(&mut circuit, num_ctrl_qubits)?;
+        step_4(&mut circuit, num_ctrl_qubits)?;
     }
     Ok(circuit)
 }
+// ---- SP22 helper functions -----
+/// Returns all `(control, target)` index pairs with `0 <= control < target < n_qubits`,
+/// sorted by `control + target` descending.
+fn pairs_high_sum_first(n_qubits: usize) -> Vec<(usize, usize)> {
+    let mut pairs: Vec<(usize, usize)> = (0..n_qubits)
+        .flat_map(|target| (0..target).map(move |control| (control, target)))
+        .collect();
+    pairs.sort_by(|a, b| (b.0 + b.1).cmp(&(a.0 + a.1)));
+    pairs
+}
 
-/// Helper function to apply controlled gates in a specific pattern based on the step
-/// in [`synth_mcp_noaux_sp22`].
+/// Returns all `(control, target)` index pairs with `1 <= control < target < n_qubits`,
+/// sorted by `control + target` ascending.
+fn pairs_low_sum_first(n_qubits: usize) -> Vec<(usize, usize)> {
+    let mut pairs: Vec<(usize, usize)> = (1..n_qubits)
+        .flat_map(|target| (1..target).map(move |control| (control, target)))
+        .collect();
+    pairs.sort_by(|a, b| (a.0 + a.1).cmp(&(b.0 + b.1)));
+    pairs
+}
+
+/// Returns `2^exponent` where `exponent = (target - control) - 1` if `control == 0`,
+/// or `(target - control)` otherwise. This is the denominator of the fractional angle
+/// (`φ / param` for CP gates, `π / param` for CRX gates) applied to each qubit pair.
+/// Uses `f64::exp2` rather than a bit shift to avoid overflow for `n > 64` controls.
+/// Note that target > control by design, no need to assert for.
+fn gate_param(control: usize, target: usize) -> f64 {
+    let exponent = if control == 0 {
+    target - control - 1
+    } else {
+        target - control
+    };
+    (exponent as f64).exp2()
+}
+
+/// SP22 Step 1 — phase accumulation (on controls+target)
 ///
-/// The following code is a derivative work of qclib
-/// (<https://github.com/qclib/qclib/blob/master/qclib/gates/ldmcu.py>).
-/// Copyright 2021 qclib project. Licensed under the Apache License, Version 2.0.
-fn apply_controlled_gates(
+/// Pairs sorted high-sum first, starting from qubit 0.
+/// Target qubit (`num_ctrl_qubits`): CP(+φ / param, c, t).
+/// All other pairs:                  CRX(+π / param, c, t).
+fn step_1(
     circuit: &mut CircuitData,
     phi: f64,
-    n_qubits: usize,
-    step: usize,
+    num_ctrl_qubits: usize,
 ) -> Result<(), CircuitDataError> {
-    let (start, reverse) = if step == 1 || step == 3 {
-        (0usize, true)
-    } else {
-        (1usize, false)
-    };
-
-    // all index pairs (control, target) where control<target
-    let mut qubit_pairs: Vec<(usize, usize)> = (start..n_qubits)
-        .flat_map(|target| (start..target).map(move |control| (control, target)))
-        .collect();
-
-    if reverse {
-        qubit_pairs.sort_by(|a, b| (b.0 + b.1).cmp(&(a.0 + a.1)));
-    } else {
-        qubit_pairs.sort_by(|a, b| (a.0 + a.1).cmp(&(b.0 + b.1)));
-    }
-
-    for &(control, target) in &qubit_pairs {
-        let exponent = if control == 0 {
-            target - control - 1
+    for (control, target) in pairs_high_sum_first(num_ctrl_qubits + 1) {
+        let param = gate_param(control, target);
+        if target == num_ctrl_qubits {
+            circuit.cp(phi / param, control as u32, target as u32)?;
         } else {
-            target - control
-        };
-
-        let param = (1usize << exponent) as f64; // 2^exponent, using bit shift
-        if target == n_qubits - 1 && (step == 1 || step == 2) {
-            let sign: i32 = match step {
-                1 => 1,
-                2 => -1,
-                _ => unreachable!(),
-            };
-            circuit.cp((sign as f64) * phi / param, control as u32, target as u32)?;
-        } else {
-            let sign: i32 = match step {
-                1 => 1,
-                2 => -1,
-                3 => {
-                    if control == 0 {
-                        -1
-                    } else {
-                        1
-                    }
-                }
-                4 => {
-                    if control == 0 {
-                        1
-                    } else {
-                        -1
-                    }
-                }
-                _ => unreachable!(),
-            };
-            circuit.crx((sign as f64) * PI / param, control as u32, target as u32)?;
+            circuit.crx(PI / param, control as u32, target as u32)?;
         }
+    }
+    Ok(())
+}
+
+/// SP22 Step 2 — phase accumulation (reverse order, on controls+target).
+///
+/// Pairs sorted low-sum first, starting from qubit 1.
+/// Target qubit (`num_ctrl_qubits`): CP(−φ / param, c, t).
+/// All other pairs:                  CRX(−π / param, c, t).
+fn step_2(
+    circuit: &mut CircuitData,
+    phi: f64,
+    num_ctrl_qubits: usize,
+) -> Result<(), CircuitDataError> {
+    for (control, target) in pairs_low_sum_first(num_ctrl_qubits + 1) {
+        let param = gate_param(control, target);
+        if target == num_ctrl_qubits {
+            circuit.cp(-phi / param, control as u32, target as u32)?;
+        } else {
+            circuit.crx(-PI / param, control as u32, target as u32)?;
+        }
+    }
+    Ok(())
+}
+
+/// SP22 Step 3 — uncomputation (on controls only).
+///
+/// Pairs sorted high-sum first, starting from qubit 0.
+/// CRX(−π / param, c, t) when c == 0, else CRX(+π / param, c, t).
+fn step_3(circuit: &mut CircuitData, num_ctrl_qubits: usize) -> Result<(), CircuitDataError> {
+    for (control, target) in pairs_high_sum_first(num_ctrl_qubits) {
+        let param = gate_param(control, target);
+        let sign = if control == 0 { -1.0 } else { 1.0 };
+        circuit.crx(sign * PI / param, control as u32, target as u32)?;
+    }
+    Ok(())
+}
+
+/// SP22 Step 4 — uncomputation (reverse order, controls only).
+///
+/// Pairs sorted low-sum first, starting from qubit 1.
+/// Sign: CRX(−π / param, c, t).
+fn step_4(circuit: &mut CircuitData, num_ctrl_qubits: usize) -> Result<(), CircuitDataError> {
+    for (control, target) in pairs_low_sum_first(num_ctrl_qubits) {
+        let param = gate_param(control, target);
+        circuit.crx(-PI / param, control as u32, target as u32)?;
     }
     Ok(())
 }

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -1154,30 +1154,6 @@ pub fn synth_mcx_noaux_hp24(num_controls: usize) -> PyResult<CircuitData> {
 ///
 /// For :math:`n \ge 2`, the method produces a circuit with :math:`4n^2-4n+2` CX gates
 /// and requires :math:`O(n)` depth.
-/// For :math:`n \le 4`, it is more efficient to use [`synth_mcp_noaux_v24`],
-/// which produces a circuit with less CX gates.
-///
-/// The circuit breaks down into four steps, each applying a specific pattern of controlled gates.
-///
-/// - Step 1: Apply :math:`n` controlled phase gates and :math:`n(n-1)/2` controlled RX gates.
-/// - Step 2: Apply :math:`n-1` controlled phase gates and :math:`(n-1)(n-2)/2` controlled RX gates.
-///
-///   This is the initial phase. It applies angle rotations (e.g., :math:`R_X(\pi/k)`) and
-///   the :math:`k`-th roots of the target unitary (:math:`U^{1/k}`) in a cascading V-shape pattern.
-///   This step systematically accumulates the partitioned components of the unitary
-///   operation on the target qubit based on the control states.
-///
-/// - Step 3: Apply :math:`n(n-1)/2` controlled RX gates.
-/// - Step 4: Apply :math:`(n-1)(n-2)/2` controlled RX gates.
-///
-///   Steps 3 and 4 together constitute the uncomputation process. By applying only the inverse of
-///   the angle rotation operations in steps 1 and 2, these steps reverse the unwanted
-///   entanglement and phase shifts generated in the first two steps. This cancellation ensures
-///   that the target qubit undergoes the full unitary operation :math:`U`
-///   if and only if all control qubits are in the :math:`|1\rangle` state.
-///
-/// Each controlled RX gate and controlled phase gate requires two CX gates,
-/// resulting in a total of :math:`4n^2-4n+2` CX gates.
 ///
 /// # Arguments
 ///
@@ -1199,7 +1175,7 @@ pub fn synth_mcp_noaux_sp22(
     phase: Param,
 ) -> Result<CircuitData, CircuitDataError> {
     // For n>1 steps 1-4 emit 2n-1 CP gates and 2(n-1)^2 CRX gates, i.e. 2n^2-2n+1 instructions
-    // in total (later each of which decomposes into two CX gates, giving the 4n^2-4n+2 of the
+    // in total (later each of which decomposes into two CX gates, giving total of 4n^2-4n+2 of the
     // doc comment).
     let num_instructions = if num_ctrl_qubits < 2 {
         1
@@ -1218,12 +1194,8 @@ pub fn synth_mcp_noaux_sp22(
     } else if num_ctrl_qubits == 1 {
         circuit.cp(phase, 0, 1)?;
     } else {
-        // Apply da Silva and Park algorithm for MCP decomposition in four steps:
-        // Step 1 & 2: accumulate phase φ on the target qubit via CP gates;
-        //             entangle controls via CRX gates.
         step_1(&mut circuit, &phase, num_ctrl_qubits)?;
         step_2(&mut circuit, &phase, num_ctrl_qubits)?;
-        // Step 3 & 4: uncompute control entanglement via inverse CRX gates.
         step_3(&mut circuit, num_ctrl_qubits)?;
         step_4(&mut circuit, num_ctrl_qubits)?;
     }
@@ -1264,11 +1236,12 @@ fn angle_divisor(control: usize, target: usize) -> f64 {
     (exponent as f64).exp2()
 }
 
-/// SP22 Step 1 — phase accumulation (on controls+target)
+/// SP22 Step 1 — forward phase accumulation on controls and target.
 ///
-/// Pairs sorted high-sum first, starting from qubit 0.
-/// Target qubit (`num_ctrl_qubits`): CP(+φ / divisor, c, t).
-/// All other pairs:                  CRX(+π / divisor, c, t).
+/// Iterates over all pairs `0 <= c < t <= num_ctrl_qubits`, high-sum first.
+/// Emits CP(+φ/divisor, c, t) when `t` is the target qubit, CRX(+π/divisor, c, t) otherwise.
+/// The CP gates accumulate phase on the target; the CRX gates entangle the controls
+/// so that the phases cancel for all input states except |11…1⟩.
 fn step_1(
     circuit: &mut CircuitData,
     phi: &Param,
@@ -1289,11 +1262,11 @@ fn step_1(
     Ok(())
 }
 
-/// SP22 Step 2 — phase accumulation (reverse order, on controls+target).
+/// SP22 Step 2 — reverse sweep on controls and target.
 ///
-/// Pairs sorted low-sum first, starting from qubit 1.
-/// Target qubit (`num_ctrl_qubits`): CP(−φ / divisor, c, t).
-/// All other pairs:                  CRX(−π / divisor, c, t).
+/// Iterates over all pairs `1 <= c < t <= num_ctrl_qubits`, low-sum first.
+/// Emits CP(−φ/divisor, c, t) when `t` is the target qubit, CRX(−π/divisor, c, t) otherwise.
+/// Mirrors step 1 in reverse order to complete the phase accumulation pattern.
 fn step_2(
     circuit: &mut CircuitData,
     phi: &Param,
@@ -1314,10 +1287,11 @@ fn step_2(
     Ok(())
 }
 
-/// SP22 Step 3 — uncomputation (on controls only).
+/// SP22 Step 3 — uncomputation on controls only, forward order.
 ///
-/// Pairs sorted high-sum first, starting from qubit 0.
-/// CRX(−π / divisor, c, t) when c == 0, else CRX(+π / divisor, c, t).
+/// Iterates over all pairs `0 <= c < t < num_ctrl_qubits`, high-sum first.
+/// Emits CRX(−π/divisor, c, t) when `c == 0`, CRX(+π/divisor, c, t) otherwise.
+/// The sign alternation here and in step 4 cancels the CRX entanglement from steps 1 and 2.
 fn step_3(circuit: &mut CircuitData, num_ctrl_qubits: usize) -> Result<(), CircuitDataError> {
     for (control, target) in pairs_high_sum_first(num_ctrl_qubits) {
         let divisor = angle_divisor(control, target);
@@ -1327,10 +1301,11 @@ fn step_3(circuit: &mut CircuitData, num_ctrl_qubits: usize) -> Result<(), Circu
     Ok(())
 }
 
-/// SP22 Step 4 — uncomputation (reverse order, controls only).
+/// SP22 Step 4 — uncomputation on controls only, reverse order.
 ///
-/// Pairs sorted low-sum first, starting from qubit 1.
-/// Sign: CRX(−π / divisor, c, t).
+/// Iterates over all pairs `1 <= c < t < num_ctrl_qubits`, low-sum first.
+/// Emits CRX(−π/divisor, c, t) for all pairs (`c == 0` never occurs in this range).
+/// Mirrors step 3 in reverse order to complete the uncomputation.
 fn step_4(circuit: &mut CircuitData, num_ctrl_qubits: usize) -> Result<(), CircuitDataError> {
     for (control, target) in pairs_low_sum_first(num_ctrl_qubits) {
         let divisor = angle_divisor(control, target);

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -1232,7 +1232,7 @@ fn apply_controlled_gates(
         (1usize, false)
     };
 
-    // all pairs (control, target) where control<target
+    // all index pairs (control, target) where control<target
     let mut qubit_pairs: Vec<(usize, usize)> = (start..n_qubits)
         .flat_map(|target| (start..target).map(move |control| (control, target)))
         .collect();
@@ -1252,18 +1252,31 @@ fn apply_controlled_gates(
 
         let param = (1usize << exponent) as f64; // 2^exponent, using bit shift
         if target == n_qubits - 1 && (step == 1 || step == 2) {
-            let sign: i32 = if step == 1 { 1 } else { -1 };
+            let sign: i32 = match step {
+                1 => 1,
+                2 => -1,
+                _ => unreachable!(),
+            };
             circuit.cp((sign as f64) * phi / param, control as u32, target as u32)?;
         } else {
-            let sign: i32 = if step == 1 {
-                1
-            } else if step == 2 {
-                -1
-            } else if step == 3 {
-                if control == 0 { -1 } else { 1 }
-            } else {
-                #[allow(clippy::collapsible_else_if)]
-                if control == 0 { 1 } else { -1 }
+            let sign: i32 = match step {
+                1 => 1,
+                2 => -1,
+                3 => {
+                    if control == 0 {
+                        -1
+                    } else {
+                        1
+                    }
+                }
+                4 => {
+                    if control == 0 {
+                        1
+                    } else {
+                        -1
+                    }
+                }
+                _ => unreachable!(),
             };
             circuit.crx((sign as f64) * PI / param, control as u32, target as u32)?;
         }

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -1250,6 +1250,7 @@ mod sp22 {
     /// Emits CP(+φ/divisor, c, t) when `t` is the target qubit, CRX(+π/divisor, c, t) otherwise.
     /// The CP gates accumulate phase on the target; the CRX gates entangle the controls
     /// so that the phases cancel for all input states except |11…1⟩.
+    /// Gate count: :math:`n` CP and :math:`n(n-1)/2` CRX.
     pub fn step_1(
         circuit: &mut CircuitData,
         phi: &Param,
@@ -1275,6 +1276,7 @@ mod sp22 {
     /// Iterates over all pairs `1 <= c < t <= num_ctrl_qubits`, low-sum first.
     /// Emits CP(−φ/divisor, c, t) when `t` is the target qubit, CRX(−π/divisor, c, t) otherwise.
     /// Mirrors step 1 in reverse order to complete the phase accumulation pattern.
+    /// Gate count: :math:`n-1` CP and :math:`(n-1)(n-2)/2` CRX.
     pub fn step_2(
         circuit: &mut CircuitData,
         phi: &Param,
@@ -1300,6 +1302,7 @@ mod sp22 {
     /// Iterates over all pairs `0 <= c < t < num_ctrl_qubits`, high-sum first.
     /// Emits CRX(−π/divisor, c, t) when `c == 0`, CRX(+π/divisor, c, t) otherwise.
     /// The sign alternation here and in step 4 cancels the CRX entanglement from steps 1 and 2.
+    /// Gate count: :math:`n(n-1)/2` CRX.
     pub fn step_3(
         circuit: &mut CircuitData,
         num_ctrl_qubits: usize,
@@ -1317,6 +1320,7 @@ mod sp22 {
     /// Iterates over all pairs `1 <= c < t < num_ctrl_qubits`, low-sum first.
     /// Emits CRX(−π/divisor, c, t) for all pairs (`c == 0` never occurs in this range).
     /// Mirrors step 3 in reverse order to complete the uncomputation.
+    /// Gate count: :math:`(n-1)(n-2)/2` CRX.
     pub fn step_4(
         circuit: &mut CircuitData,
         num_ctrl_qubits: usize,

--- a/crates/synthesis/src/multi_controlled/mod.rs
+++ b/crates/synthesis/src/multi_controlled/mod.rs
@@ -57,7 +57,7 @@ fn py_synth_mcx_1_clean_b95(num_controls: usize) -> PyResult<PyCircuitData> {
 }
 
 #[pyfunction]
-#[pyo3(name="synth_mcp_noaux_sp22", signature = (num_controls, phase))]
+#[pyo3(name = "synth_mcp_noaux_sp22")]
 fn py_synth_mcp_noaux_sp22(num_controls: usize, phase: Param) -> PyResult<PyCircuitData> {
     // Reject unsupported types early: PyO3 silently maps unrecognised Python objects to
     // ``Param::Obj``, which would later panic.

--- a/crates/synthesis/src/multi_controlled/mod.rs
+++ b/crates/synthesis/src/multi_controlled/mod.rs
@@ -14,8 +14,10 @@ use mcx::{
     c3x, c4x, synth_mcp_noaux_sp22, synth_mcx_1_clean_b95, synth_mcx_n_clean_m15,
     synth_mcx_n_dirty_i15, synth_mcx_noaux_hp24, synth_mcx_noaux_v24,
 };
+use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use qiskit_circuit::circuit_data::PyCircuitData;
+use qiskit_circuit::operations::Param;
 
 mod mcmt;
 mod mcx;
@@ -56,7 +58,14 @@ fn py_synth_mcx_1_clean_b95(num_controls: usize) -> PyResult<PyCircuitData> {
 
 #[pyfunction]
 #[pyo3(name="synth_mcp_noaux_sp22", signature = (num_controls, phase))]
-fn py_synth_mcp_noaux_sp22(num_controls: usize, phase: f64) -> PyResult<PyCircuitData> {
+fn py_synth_mcp_noaux_sp22(num_controls: usize, phase: Param) -> PyResult<PyCircuitData> {
+    // Reject unsupported types early: PyO3 silently maps unrecognised Python objects to
+    // ``Param::Obj``, which would later panic.
+    if matches!(phase, Param::Obj(_)) {
+        return Err(PyTypeError::new_err(
+            "synth_mcp_noaux_sp22 requires phase to be a float or a ParameterExpression.",
+        ));
+    }
     Ok(synth_mcp_noaux_sp22(num_controls, phase)?.into())
 }
 

--- a/crates/synthesis/src/multi_controlled/mod.rs
+++ b/crates/synthesis/src/multi_controlled/mod.rs
@@ -11,8 +11,8 @@
 // that they have been altered from the originals.
 
 use mcx::{
-    c3x, c4x, synth_mcx_1_clean_b95, synth_mcx_n_clean_m15, synth_mcx_n_dirty_i15,
-    synth_mcx_noaux_hp24, synth_mcx_noaux_v24,
+    c3x, c4x, synth_mcp_noaux_sp22, synth_mcx_1_clean_b95, synth_mcx_n_clean_m15,
+    synth_mcx_n_dirty_i15, synth_mcx_noaux_hp24, synth_mcx_noaux_v24,
 };
 use pyo3::prelude::*;
 use qiskit_circuit::circuit_data::PyCircuitData;
@@ -54,6 +54,12 @@ fn py_synth_mcx_1_clean_b95(num_controls: usize) -> PyResult<PyCircuitData> {
     Ok(synth_mcx_1_clean_b95(num_controls)?.into())
 }
 
+#[pyfunction]
+#[pyo3(name="synth_mcp_noaux_sp22", signature = (num_controls, phase))]
+fn py_synth_mcp_noaux_sp22(num_controls: usize, phase: f64) -> PyResult<PyCircuitData> {
+    Ok(synth_mcp_noaux_sp22(num_controls, phase)?.into())
+}
+
 pub fn multi_controlled(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(c3x, m)?)?;
     m.add_function(wrap_pyfunction!(c4x, m)?)?;
@@ -61,6 +67,7 @@ pub fn multi_controlled(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_synth_mcx_noaux_v24, m)?)?;
     m.add_function(wrap_pyfunction!(py_synth_mcx_noaux_hp24, m)?)?;
     m.add_function(wrap_pyfunction!(py_synth_mcx_1_clean_b95, m)?)?;
+    m.add_function(wrap_pyfunction!(py_synth_mcp_noaux_sp22, m)?)?;
     m.add_function(wrap_pyfunction!(mcmt::mcmt_v_chain, m)?)?;
     m.add_function(wrap_pyfunction!(py_synth_mcx_n_clean_m15, m)?)?;
     Ok(())

--- a/qiskit/synthesis/multi_controlled/mcp_synthesis.py
+++ b/qiskit/synthesis/multi_controlled/mcp_synthesis.py
@@ -134,19 +134,24 @@ def synth_mcp_noaux_sp22(num_ctrl_qubits: int, phase: ParameterValueType) -> Qua
     which produces a circuit with less CX gates.
 
     The circuit breaks down into four steps, each applying a specific pattern of controlled gates.
+
     - Step 1: Apply :math:`n` controlled phase gates and :math:`n(n-1)/2` controlled RX gates.
     - Step 2: Apply :math:`n-1` controlled phase gates and :math:`(n-1)(n-2)/2` controlled RX gates.
+
       This is the initial phase. It applies angle rotations (e.g., :math:`R_X(\pi/k)`) and
       the :math:`k`-th roots of the target unitary (:math:`U^{1/k}`) in a cascading V-shape pattern.
       This step systematically accumulates the partitioned components of the unitary
       operation on the target qubit based on the control states.
+
     - Step 3: Apply :math:`n(n-1)/2` controlled RX gates.
     - Step 4: Apply :math:`(n-1)(n-2)/2` controlled RX gates.
+
       Steps 3 and 4 together constitute the uncomputation process. By applying only the inverse of
       the angle rotation operations in steps 1 and 2, these steps reverse the unwanted
       entanglement and phase shifts generated in the first two steps. This cancellation ensures
       that the target qubit undergoes the full unitary operation :math:`U`
       if and only if all control qubits are in the :math:`|1\rangle` state.
+
     Each controlled RX gate and controlled phase gate requires two CX gates,
     resulting in a total of :math:`4n^2-4n+2` CX gates.
 

--- a/qiskit/synthesis/multi_controlled/mcp_synthesis.py
+++ b/qiskit/synthesis/multi_controlled/mcp_synthesis.py
@@ -133,6 +133,23 @@ def synth_mcp_noaux_sp22(num_ctrl_qubits: int, phase: ParameterValueType) -> Qua
     For :math:`n \le 4`, it is more efficient to use :func:`synth_mcp_noaux_v24`,
     which produces a circuit with less CX gates.
 
+    The circuit breaks down into four steps, each applying a specific pattern of controlled gates.
+    - Step 1: Apply :math:`n` controlled phase gates and :math:`n(n-1)/2` controlled RX gates.
+    - Step 2: Apply :math:`n-1` controlled phase gates and :math:`(n-1)(n-2)/2` controlled RX gates.
+      This is the initial phase. It applies angle rotations (e.g., :math:`R_X(\pi/k)`) and
+      the :math:`k`-th roots of the target unitary (:math:`U^{1/k}`) in a cascading V-shape pattern.
+      This step systematically accumulates the partitioned components of the unitary
+      operation on the target qubit based on the control states.
+    - Step 3: Apply :math:`n(n-1)/2` controlled RX gates.
+    - Step 4: Apply :math:`(n-1)(n-2)/2` controlled RX gates.
+      Steps 3 and 4 together constitute the uncomputation process. By applying only the inverse of
+      the angle rotation operations in steps 1 and 2, these steps reverse the unwanted
+      entanglement and phase shifts generated in the first two steps. This cancellation ensures
+      that the target qubit undergoes the full unitary operation :math:`U`
+      if and only if all control qubits are in the :math:`|1\rangle` state.
+    Each controlled RX gate and controlled phase gate requires two CX gates,
+    resulting in a total of :math:`4n^2-4n+2` CX gates.
+
     Args:
         num_ctrl_qubits: The number of control qubits.
         phase: The phase angle for the multi-controlled phase gate.

--- a/qiskit/synthesis/multi_controlled/mcp_synthesis.py
+++ b/qiskit/synthesis/multi_controlled/mcp_synthesis.py
@@ -11,11 +11,12 @@
 # that they have been altered from the originals.
 """Module containing multi-controlled phase gate synthesis methods."""
 
-import numpy as np
-
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit.exceptions import QiskitError
+from qiskit._accelerate.synthesis.multi_controlled import (
+    synth_mcp_noaux_sp22 as synth_mcp_noaux_sp22_rs,
+)
 
 
 def synth_mcp_noaux_v24(num_ctrl_qubits: int, phase: ParameterValueType) -> QuantumCircuit:
@@ -123,48 +124,6 @@ def synth_mcp_noaux_v24(num_ctrl_qubits: int, phase: ParameterValueType) -> Quan
     return qc
 
 
-def _apply_controlled_gates(
-    circuit: QuantumCircuit, phi: ParameterValueType, n_qubits: int, step: int
-) -> None:
-    """Helper function to apply controlled gates in a specific pattern based on the step in :func:`synth_mcp_noaux_sp22`."""
-    # The following code is a derivative work of qclib
-    # (https://github.com/qclib/qclib/blob/master/qclib/gates/ldmcu.py).
-    # Copyright 2021 qclib project.
-    # Licensed under the Apache License, Version 2.0.
-    if step in [1, 3]:
-        start = 0
-        reverse = True
-    else:
-        start = 1
-        reverse = False
-
-    qubit_pairs = [
-        (control, target) for target in range(n_qubits) for control in range(start, target)
-    ]
-
-    qubit_pairs.sort(key=lambda e: e[0] + e[1], reverse=reverse)
-
-    for control, target in qubit_pairs:
-        exponent = target - control
-        if control == 0:
-            exponent = exponent - 1
-        param = 2**exponent
-
-        if target == n_qubits - 1 and step in [1, 2]:
-            sign = 1 if step == 1 else -1
-            circuit.cp(sign * phi / param, control, target)
-        else:
-            if step == 1:
-                sign = 1
-            elif step == 2:
-                sign = -1
-            elif step == 3:
-                sign = -1 if control == 0 else 1
-            else:
-                sign = 1 if control == 0 else -1
-            circuit.crx(sign * np.pi / param, control, target)
-
-
 def synth_mcp_noaux_sp22(num_ctrl_qubits: int, phase: ParameterValueType) -> QuantumCircuit:
     r"""Synthesize a multi-controlled phase gate with :math:`n` controls based on the paper
     by da Silva et al. [1] and the implementation in qclib [2].
@@ -173,28 +132,6 @@ def synth_mcp_noaux_sp22(num_ctrl_qubits: int, phase: ParameterValueType) -> Qua
     and requires :math:`O(n)` depth.
     For :math:`n \le 4`, it is more efficient to use :func:`synth_mcp_noaux_v24`,
     which produces a circuit with less CX gates.
-
-    The circuit breaks down into four steps, each applying a specific pattern of controlled gates.
-
-    - Step 1: Apply :math:`n` controlled phase gates and :math:`n(n-1)/2` controlled RX gates.
-    - Step 2: Apply :math:`n-1` controlled phase gates and :math:`(n-1)(n-2)/2` controlled RX gates.
-
-      This is the initial phase. It applies angle rotations (e.g., :math:`R_X(\pi/k)`) and
-      the :math:`k`-th roots of the target unitary (:math:`U^{1/k}`) in a cascading V-shape pattern.
-      This step systematically accumulates the partitioned components of the unitary
-      operation on the target qubit based on the control states.
-
-    - Step 3: Apply :math:`n(n-1)/2` controlled RX gates.
-    - Step 4: Apply :math:`(n-1)(n-2)/2` controlled RX gates.
-
-      Steps 3 and 4 together constitute the uncomputation process. By applying only the inverse of
-      the angle rotation operations in steps 1 and 2, these steps reverse the unwanted
-      entanglement and phase shifts generated in the first two steps. This cancellation ensures
-      that the target qubit undergoes the full unitary operation :math:`U`
-      if and only if all control qubits are in the :math:`|1\rangle` state.
-
-    Each controlled RX gate and controlled phase gate requires two CX gates,
-    resulting in a total of :math:`4n^2-4n+2` CX gates.
 
     Args:
         num_ctrl_qubits: The number of control qubits.
@@ -214,27 +151,11 @@ def synth_mcp_noaux_sp22(num_ctrl_qubits: int, phase: ParameterValueType) -> Qua
 
         [2] https://github.com/qclib/qclib/blob/master/qclib/gates/ldmcu.py
     """
-    # The following code is a derivative work of qclib
-    # (https://github.com/qclib/qclib/blob/master/qclib/gates/ldmcu.py).
-    # Copyright 2021 qclib project.
-    # Licensed under the Apache License, Version 2.0.
-    qc = QuantumCircuit(num_ctrl_qubits + 1)
-
     if num_ctrl_qubits < 0:
         raise QiskitError(
             "synth_mcp_noaux_sp22 cannot be called with a negative number of control qubits."
         )
-    elif num_ctrl_qubits == 0:
-        qc.p(phase, 0)
-    elif num_ctrl_qubits == 1:
-        qc.cp(phase, 0, 1)
-    else:
-        _apply_controlled_gates(qc, phase, num_ctrl_qubits + 1, step=1)
-        _apply_controlled_gates(qc, phase, num_ctrl_qubits + 1, step=2)
-        _apply_controlled_gates(qc, phase, num_ctrl_qubits, step=3)
-        _apply_controlled_gates(qc, phase, num_ctrl_qubits, step=4)
-
-    return qc
+    return QuantumCircuit._from_circuit_data(synth_mcp_noaux_sp22_rs(num_ctrl_qubits, phase))
 
 
 def synth_mcp_noaux_default(num_ctrl_qubits: int, phase: ParameterValueType) -> QuantumCircuit:

--- a/releasenotes/notes/synth-mcp-noaux-sp22-rust-7a410766a3a066c2.yaml
+++ b/releasenotes/notes/synth-mcp-noaux-sp22-rust-7a410766a3a066c2.yaml
@@ -1,0 +1,6 @@
+---
+performance:
+  - |
+    Improved runtime of :py:func:`~qiskit.synthesis.synth_mcp_noaux_sp22` synthesis function by migrating implementation to Rust,
+    resulting in approximately 25-34x speedup across circuit sizes (n=50 to n=1000).   
+    See See `#16755 <https://github.com/Qiskit/qiskit/pull/16755>`__ for more details.

--- a/releasenotes/notes/synth-mcp-noaux-sp22-rust-7a410766a3a066c2.yaml
+++ b/releasenotes/notes/synth-mcp-noaux-sp22-rust-7a410766a3a066c2.yaml
@@ -1,6 +1,6 @@
 ---
 performance:
   - |
-    Improved runtime of :py:func:`~qiskit.synthesis.synth_mcp_noaux_sp22` synthesis function by migrating implementation to Rust,
+    Improved runtime of :func:`~qiskit.synthesis.synth_mcp_noaux_sp22` synthesis function by migrating implementation to Rust,
     resulting in approximately 25-34x speedup across circuit sizes (n=50 to n=1000).   
-    See See `#16755 <https://github.com/Qiskit/qiskit/pull/16755>`__ for more details.
+    See `#16755 <https://github.com/Qiskit/qiskit/pull/16755>`__ for more details.

--- a/test/python/synthesis/test_multi_controlled_synthesis.py
+++ b/test/python/synthesis/test_multi_controlled_synthesis.py
@@ -180,7 +180,7 @@ class TestMCSynthesisCorrectness(QiskitTestCase):
         self.assertSynthesisCorrect(
             PhaseGate(val), num_ctrl_qubits, bound_circuit, clean_ancillas=False
         )
-    
+
     def test_mcp_noaux_v24_with_expr_param(self):
         """Test synth_mcp_noaux_v24 works correctly with a parameter expression."""
         a, b = Parameter("a"), Parameter("b")

--- a/test/python/synthesis/test_multi_controlled_synthesis.py
+++ b/test/python/synthesis/test_multi_controlled_synthesis.py
@@ -180,6 +180,36 @@ class TestMCSynthesisCorrectness(QiskitTestCase):
         self.assertSynthesisCorrect(
             PhaseGate(val), num_ctrl_qubits, bound_circuit, clean_ancillas=False
         )
+    
+    def test_mcp_noaux_v24_with_expr_param(self):
+        """Test synth_mcp_noaux_v24 works correctly with a parameter expression."""
+        a, b = Parameter("a"), Parameter("b")
+        val_a, val_b = 0.456, 0.123
+        circuit = synth_mcp_noaux_v24(3, phase=2 * a + b)
+        bound_circuit = circuit.assign_parameters({a: val_a, b: val_b})
+        self.assertSynthesisCorrect(
+            PhaseGate(2 * val_a + val_b), 3, bound_circuit, clean_ancillas=False
+        )
+
+    def test_mcp_noaux_default_with_expr_param(self):
+        """Test synth_mcp_noaux_default works correctly with a parameter expression."""
+        a, b = Parameter("a"), Parameter("b")
+        val_a, val_b = 0.456, 0.123
+        circuit = synth_mcp_noaux_default(3, phase=2 * a + b)
+        bound_circuit = circuit.assign_parameters({a: val_a, b: val_b})
+        self.assertSynthesisCorrect(
+            PhaseGate(2 * val_a + val_b), 3, bound_circuit, clean_ancillas=False
+        )
+
+    def test_mcp_noaux_sp22_with_expr_param(self):
+        """Test synth_mcp_noaux_sp22 works correctly with a parameter expression."""
+        a, b = Parameter("a"), Parameter("b")
+        val_a, val_b = 0.456, 0.123
+        circuit = synth_mcp_noaux_sp22(3, phase=2 * a + b)
+        bound_circuit = circuit.assign_parameters({a: val_a, b: val_b})
+        self.assertSynthesisCorrect(
+            PhaseGate(2 * val_a + val_b), 3, bound_circuit, clean_ancillas=False
+        )
 
     @data(0, 1, 2, 3, 4, 5, 6)
     def test_mcx_n_dirty_i15(self, num_ctrl_qubits: int):


### PR DESCRIPTION
Migrates synth_mcp_noaux_sp22 from a pure-Python implementation to Rust.

- `crates/synthesis/src/multi_controlled/mcx.rs` — added `crx` to the `CircuitDataForSynthesis` trait; new `pub fn synth_mcp_noaux_sp22(num_ctrl_qubits, phase)` and private helper `apply_controlled_gates`, mirroring the Python algorithm (da Silva & Park 2022 / qclib).
- `crates/synthesis/src/multi_controlled/mod.rs` — PyO3 wrapper + registration.
- `qiskit/synthesis/multi_controlled/mcp_synthesis.py` — thin wrapper delegating to Rust; `_apply_controlled_gates` helper removed.
- All existing tests pass, no new tests added.

### Performance

Benchmarked on Apple M-series (release build), n = 50–1000:

| n    | Python (µs)  | Rust (µs) | Speedup |
|-----:|-------------:|----------:|--------:|
|   50 |      15 137  |       439 |  34.5×  |
|  100 |      62 230  |     1 809 |  34.4×  |
|  200 |     264 605  |     7 665 |  34.5×  |
|  500 |   1 682 879  |    55 019 |  30.6×  |
| 1000 |   7 125 489  |   286 924 |  24.8×  |

~34× speedup for small/medium n; compresses to ~25× at n=1000 as O(n²) gate work overtakes interpreter overhead.

### AI/LLM disclosure
- [x] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Bob 2.0.2. 
