### PR TITLE
Add a unit test for build_average_error_map order stability

### DIFF
--- a/crates/transpiler/src/passes/vf2/vf2_layout.rs
+++ b/crates/transpiler/src/passes/vf2/vf2_layout.rs
@@ -919,3 +919,61 @@ pub fn vf2_layout_mod(m: &Bound<PyModule>) -> PyResult<()> {
     m.add("VF2PassReturn", m.py().get_type::<VF2PassReturn>())?;
     Ok(())
 }
+
+#[cfg(test)]
+mod test {
+    use qiskit_circuit::PhysicalQubit;
+    use qiskit_circuit::operations::StandardGate;
+    use qiskit_util::IndexMap;
+    use smallvec::smallvec;
+
+    use crate::target::{InstructionProperties, Qargs, Target};
+
+    use super::build_average_error_map;
+
+    /// The average error of a qarg is a floating-point sum over the operations defined on it.
+    /// Floating-point addition is not associative, and a `Target` makes no ordering guarantee about
+    /// the operations it reports for a qarg, so the average is only reproducible if the summation
+    /// order is canonicalised.
+    ///
+    /// Regression test for https://github.com/Qiskit/qiskit/issues/16490
+    #[test]
+    fn average_error_is_summed_in_a_canonical_order() {
+        // The four small errors together are more than half an ulp of the large one, but each is
+        // less than half an ulp on its own, so the total depends on the order of the summation.
+        let mut target = Target::default();
+        for (gate, error) in [
+            (StandardGate::H, 5e-17),
+            (StandardGate::S, 5e-17),
+            (StandardGate::SX, 5e-17),
+            (StandardGate::T, 5e-17),
+            (StandardGate::X, 0.5),
+        ] {
+            target
+                .add_instruction(
+                    gate.into(),
+                    None,
+                    None,
+                    Some(IndexMap::from_iter([(
+                        Qargs::Concrete(smallvec![PhysicalQubit(0)]),
+                        Some(InstructionProperties::new(None, Some(error))),
+                    )])),
+                )
+                .expect("gate is valid on this qubit");
+        }
+
+        // Sorted name order is `h`, `s`, `sx`, `t`, `x`, so the large error is added last.
+        let expected = (5e-17 + 5e-17 + 5e-17 + 5e-17 + 0.5) / 5.0;
+        assert_ne!(expected, (0.5 + 5e-17 + 5e-17 + 5e-17 + 5e-17) / 5.0);
+
+        // Check with multiple hash seeds.
+        for _ in 0..100 {
+            let error_map = build_average_error_map(&target).expect("the target has 1q errors");
+            assert_eq!(error_map.error_map.len(), 1);
+            assert_eq!(
+                error_map.error_map[&[PhysicalQubit(0), PhysicalQubit(0)]],
+                expected
+            );
+        }
+    }
+}

--- a/crates/transpiler/src/passes/vf2/vf2_layout.rs
+++ b/crates/transpiler/src/passes/vf2/vf2_layout.rs
@@ -230,10 +230,17 @@ fn build_average_error_map(target: &Target) -> Option<ErrorMap> {
         };
         let mut qarg_error: f64 = 0.;
         let mut count: usize = 0;
-        for op in target
+        // `operation_names_for_qargs` returns a `HashSet`, whose iteration order is randomised
+        // per call.  Summing the per-operation errors in that order makes `qarg_error` depend on a
+        // non-deterministic floating-point summation order, which can produce tie-break differences
+        // between otherwise-symmetric layouts.  Sort the names so the sum is reproducible.
+        let mut op_names: Vec<&str> = target
             .operation_names_for_qargs(QargsRef::Concrete(qargs))
             .expect("these qargs came from `target.qargs()`")
-        {
+            .into_iter()
+            .collect();
+        op_names.sort_unstable();
+        for op in op_names {
             count += 1;
             // If the `target` has no error recorded for an operation, we treat it as errorless.
             qarg_error += target

--- a/crates/transpiler/src/passes/vf2/vf2_layout.rs
+++ b/crates/transpiler/src/passes/vf2/vf2_layout.rs
@@ -230,17 +230,10 @@ fn build_average_error_map(target: &Target) -> Option<ErrorMap> {
         };
         let mut qarg_error: f64 = 0.;
         let mut count: usize = 0;
-        // `operation_names_for_qargs` returns a `HashSet`, whose iteration order is randomised
-        // per call.  Summing the per-operation errors in that order makes `qarg_error` depend on a
-        // non-deterministic floating-point summation order, which can produce tie-break differences
-        // between otherwise-symmetric layouts.  Sort the names so the sum is reproducible.
-        let mut op_names: Vec<&str> = target
+        for op in target
             .operation_names_for_qargs(QargsRef::Concrete(qargs))
             .expect("these qargs came from `target.qargs()`")
-            .into_iter()
-            .collect();
-        op_names.sort_unstable();
-        for op in op_names {
+        {
             count += 1;
             // If the `target` has no error recorded for an operation, we treat it as errorless.
             qarg_error += target

--- a/releasenotes/notes/fix-vf2layout-nondeterminism-error-sum-2b8d4e6f0a1c3d57.yaml
+++ b/releasenotes/notes/fix-vf2layout-nondeterminism-error-sum-2b8d4e6f0a1c3d57.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed non-deterministic :class:`.VF2Layout` output at ``optimization_level=2`` on a
+    :class:`.Target` a symmetric coupling map. The pass previously
+    could tie-break differently between runs due to non-deterministic float summation.
+    Fixed `#16490 <https://github.com/Qiskit/qiskit/issues/16490>`__.

--- a/releasenotes/notes/fix-vf2layout-nondeterminism-error-sum-2b8d4e6f0a1c3d57.yaml
+++ b/releasenotes/notes/fix-vf2layout-nondeterminism-error-sum-2b8d4e6f0a1c3d57.yaml
@@ -1,7 +1,0 @@
----
-fixes:
-  - |
-    Fixed non-deterministic :class:`.VF2Layout` output at ``optimization_level=2`` on a
-    :class:`.Target` a symmetric coupling map. The pass previously
-    could tie-break differently between runs due to non-deterministic float summation.
-    Fixed `#16490 <https://github.com/Qiskit/qiskit/issues/16490>`__.


### PR DESCRIPTION
This PR adds a unit test for #16732. This is a bit fiddly because it relies on floating point arithmetic not being associative, unlike actual arithmetic. However, I figured if claude can find counter examples to Jacobi, it can probably find this fiddly test we know must exist.

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Claude Opus 5

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
