### PR TITLE
Fix matplotlib drawing for empty boxes

### DIFF
--- a/qiskit/visualization/circuit/matplotlib.py
+++ b/qiskit/visualization/circuit/matplotlib.py
@@ -1605,9 +1605,15 @@ class MatplotlibDrawer:
         ypos = min(y[1] for y in xy)
         ypos_max = max(y[1] for y in xy)
 
-        # If a BoxOp, bring the right side back tight against the gates to allow for
-        # better spacing
-        if_width = node_data[node].width[0] + (WID if not isinstance(node.op, BoxOp) else -0.19)
+        if not isinstance(node.op, BoxOp):
+            node_data[node].width[0] + WID
+        elif node_data[node].width[0] > 0.0:
+            # Bring the right side back tight gates to allow for better spacing
+            if_width = node_data[node].width[0] - 0.19
+        else:
+            # Empty BoxOp has no contents so default to single-qubit gate width
+            if_width = WID
+
         box_width = if_width
         # Add the else and case widths to the if_width
         for ewidth in node_data[node].width[1:]:
@@ -1626,11 +1632,12 @@ class MatplotlibDrawer:
             self._style["cc"],
         ]
         # To fold box onto next lines, draw it repeatedly, shifting
-        # it left by x_shift and down by y_shift
+        # it left by x_shift and down by y_shift. Must be drawn at least once
+        # before testing to ensure narrow box in first column does not end at
+        # negative x, resulting in it not being drawn
         fold_level = 0
-        end_x = xpos + box_width
 
-        while end_x > 0.0:
+        while True:
             x_shift = fold_level * self._fold
             y_shift = fold_level * (glob_data["n_lines"] + 1)
             end_x = xpos + box_width - x_shift if self._fold > 0 else 0.0
@@ -1780,6 +1787,8 @@ class MatplotlibDrawer:
                 ewidth_incr += ewidth + 1
 
             fold_level += 1
+            if end_x <= 0.0:
+                break
 
     def _control_gate(self, node, node_data, glob_data, mod_control):
         """Draw a controlled gate"""

--- a/qiskit/visualization/circuit/matplotlib.py
+++ b/qiskit/visualization/circuit/matplotlib.py
@@ -1606,7 +1606,7 @@ class MatplotlibDrawer:
         ypos_max = max(y[1] for y in xy)
 
         if not isinstance(node.op, BoxOp):
-            node_data[node].width[0] + WID
+            if_width =node_data[node].width[0] + WID
         elif node_data[node].width[0] > 0.0:
             # Bring the right side back tight gates to allow for better spacing
             if_width = node_data[node].width[0] - 0.19

--- a/qiskit/visualization/circuit/matplotlib.py
+++ b/qiskit/visualization/circuit/matplotlib.py
@@ -1606,7 +1606,7 @@ class MatplotlibDrawer:
         ypos_max = max(y[1] for y in xy)
 
         if not isinstance(node.op, BoxOp):
-            if_width =node_data[node].width[0] + WID
+            if_width = node_data[node].width[0] + WID
         elif node_data[node].width[0] > 0.0:
             # Bring the right side back tight gates to allow for better spacing
             if_width = node_data[node].width[0] - 0.19

--- a/releasenotes/notes/mpl-empty-box-width-445c151e8ec10f47.yaml
+++ b/releasenotes/notes/mpl-empty-box-width-445c151e8ec10f47.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed the ``"mpl"`` circuit drawer collapsing an empty :class:`.BoxOp` to zero width, which
+    made it invisible. An empty box is now drawn with a the single-qubit gate width.
+  - |
+    Fixed the ``"mpl"`` circuit drawer omitting a control-flow box entirely when the box was
+    narrow enough to end at a negative x coordinate, which happened for an empty
+    :class:`.BoxOp` at the start of a circuit.

--- a/releasenotes/notes/mpl-empty-box-width-445c151e8ec10f47.yaml
+++ b/releasenotes/notes/mpl-empty-box-width-445c151e8ec10f47.yaml
@@ -2,7 +2,7 @@
 fixes:
   - |
     Fixed the ``"mpl"`` circuit drawer collapsing an empty :class:`.BoxOp` to zero width, which
-    made it invisible. An empty box is now drawn with a the single-qubit gate width.
+    made render incorrectly An empty box is now drawn with a the single-qubit gate width.
   - |
     Fixed the ``"mpl"`` circuit drawer omitting a control-flow box entirely when the box was
     narrow enough to end at a negative x coordinate, which happened for an empty

--- a/releasenotes/notes/mpl-empty-box-width-445c151e8ec10f47.yaml
+++ b/releasenotes/notes/mpl-empty-box-width-445c151e8ec10f47.yaml
@@ -2,7 +2,7 @@
 fixes:
   - |
     Fixed the ``"mpl"`` circuit drawer collapsing an empty :class:`.BoxOp` to zero width, which
-    made render incorrectly An empty box is now drawn with a the single-qubit gate width.
+    made it render incorrectly. An empty box is now drawn with the default gate width.
   - |
     Fixed the ``"mpl"`` circuit drawer omitting a control-flow box entirely when the box was
     narrow enough to end at a negative x coordinate, which happened for an empty

--- a/test/python/visualization/test_circuit_drawer.py
+++ b/test/python/visualization/test_circuit_drawer.py
@@ -21,6 +21,7 @@ import warnings
 from unittest.mock import patch
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister, visualization
+from qiskit.circuit import BoxOp
 from qiskit.utils import optionals
 from qiskit.visualization.circuit import styles, text
 from qiskit.visualization.exceptions import VisualizationError
@@ -28,6 +29,7 @@ from test import QiskitTestCase
 
 if optionals.HAS_MATPLOTLIB:
     from matplotlib import figure
+    from matplotlib.patches import FancyBboxPatch, Rectangle
 if optionals.HAS_PIL:
     from PIL import Image
 
@@ -84,6 +86,24 @@ class TestCircuitDrawer(QiskitTestCase):
                 with self.assertWarnsRegex(UserWarning, "Style JSON file.*not found"):
                     fig = visualization.circuit_drawer(circuit)
                 self.assertIsInstance(fig, figure.Figure)
+
+    @unittest.skipUnless(optionals.HAS_MATPLOTLIB, "Skipped because matplotlib is not available")
+    def test_mpl_empty_box_width(self):
+        """Test an empty `box` with no content is still drawn and has the same footprint as a
+        single-qubit gate."""
+        circuit = QuantumCircuit(1)
+        circuit.append(BoxOp(QuantumCircuit(1)), [0])
+        circuit.x(0)
+
+        ax = visualization.circuit_drawer(circuit, output="mpl").axes[0]
+        # Flow ops (the box) are drawn as `FanceBboxPatch`, plain gates as `Rectangle`. The
+        # axes holds a large negatively-sized background rectangle that is filtered out.
+        boxes = [patch for patch in ax.patches if isinstance(patch, FancyBboxPatch)]
+        gates = [patch for patch in ax.patches if isinstance(patch, Rectangle) and patch.get_width() > 0.0]
+        self.assertEqual(len(boxes), 1)
+        self.assertEqual(len(gates), 1)
+        self.assertAlmostEqual(boxes[0].get_width(), gates[0].get_width())
+        self.assertAlmostEqual(boxes[0].get_height(), gates[0].get_height())
 
     @unittest.skipUnless(optionals.HAS_MATPLOTLIB, "Skipped because matplotlib is not available")
     def test_user_config_default_output(self):

--- a/test/python/visualization/test_circuit_drawer.py
+++ b/test/python/visualization/test_circuit_drawer.py
@@ -99,7 +99,11 @@ class TestCircuitDrawer(QiskitTestCase):
         # Flow ops (the box) are drawn as `FanceBboxPatch`, plain gates as `Rectangle`. The
         # axes holds a large negatively-sized background rectangle that is filtered out.
         boxes = [patch for patch in ax.patches if isinstance(patch, FancyBboxPatch)]
-        gates = [patch for patch in ax.patches if isinstance(patch, Rectangle) and patch.get_width() > 0.0]
+        gates = [
+            patch
+            for patch in ax.patches
+            if isinstance(patch, Rectangle) and patch.get_width() > 0.0
+        ]
         self.assertEqual(len(boxes), 1)
         self.assertEqual(len(gates), 1)
         self.assertAlmostEqual(boxes[0].get_width(), gates[0].get_width())


### PR DESCRIPTION
This PR fixes two bugs when drawing empty boxes with matplotlib. Previously, the function set the width of an empty box to 0 resulting in the box rendering oddly. It now uses the default gate width. It also omitted narrow boxes at the start of the circuit. As the first operation can have a negative x-coordinate, the while loop that draws the operation was skipped entirely. It now always runs at least once.

Before and after:
<img width="210" height="250" alt="Screenshot 2026-08-13 at 4 15 38 PM" src="https://github.com/user-attachments/assets/7cf9b485-39d0-4d81-8ae7-7f7faa228d5e" /> <img width="210" height="250" alt="Screenshot 2026-08-13 at 4 23 28 PM" src="https://github.com/user-attachments/assets/52a388c7-d9a2-48f0-9a06-98f5fca39de4" />


### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Claude Opus 5

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
