### PR TITLE
Fix ConsolidateBlocks treating approximation_degree=0.0 as 1.0

### DIFF
--- a/qiskit/transpiler/passes/optimization/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/optimization/consolidate_blocks.py
@@ -142,7 +142,7 @@ class ConsolidateBlocks(TransformationPass):
             elif kak_gate is not None:
                 self.decomposer = TwoQubitBasisDecomposer(
                     KAK_GATE_NAMES[kak_gate],
-                    basis_fidelity=approximation_degree or 1.0,
+                    basis_fidelity=1.0 if approximation_degree is None else approximation_degree,
                 )
                 self.basis_gate_name = kak_gate
             else:

--- a/releasenotes/notes/fix-consolidate-blocks-approx-degree-zero-1f8e6a2d4c9b0e37.yaml
+++ b/releasenotes/notes/fix-consolidate-blocks-approx-degree-zero-1f8e6a2d4c9b0e37.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`.ConsolidateBlocks` where setting
+    ``approximation_degree=0.0`` was treated as if it were ``1.0`` (no
+    approximation) when the pass was constructed with loose ``basis_gates``.
+    The two-qubit decomposer used to estimate the size of consolidated blocks
+    now receives the requested approximation degree exactly.
+    Fixed `#8642 <https://github.com/Qiskit/qiskit/issues/8642>`__.

--- a/test/python/transpiler/test_consolidate_blocks.py
+++ b/test/python/transpiler/test_consolidate_blocks.py
@@ -447,6 +447,23 @@ class TestConsolidateBlocks(QiskitTestCase):
             out = pm.run(qc)
             self.assertEqual(out, QuantumCircuit(1))
 
+    def test_approximation_degree_zero(self):
+        """Test that approximation degree 0 is not mistaken for the default 1.0.
+
+        Regression test of gh-8642.
+        """
+        qc = QuantumCircuit(2)
+        qc.cx(0, 1)
+
+        pm = PassManager(
+            [
+                Collect2qBlocks(),
+                ConsolidateBlocks(basis_gates=["cx", "u"], approximation_degree=0.0),
+            ]
+        )
+        out = pm.run(qc)
+        self.assertNotIn("cx", out.count_ops())
+
     def test_identity_1q_unitary_is_removed(self):
         """Test that a 1q identity unitary is removed without a basis."""
         qc = QuantumCircuit(5)


### PR DESCRIPTION
Fixes #8642

`ConsolidateBlocks` built its internal `TwoQubitBasisDecomposer` with `basis_fidelity=approximation_degree or 1.0` on the loose-`basis_gates` path, so the valid value `0.0` (maximal approximation) was silently treated as `1.0` (no approximation). The other consumers of `approximation_degree` (the Rust entry points and `UnitarySynthesis`) already distinguish `0.0` from `None`; this was the last remaining conflation.

The fix replaces the falsy check with an explicit `None` check, so `0.0` passes through and `None` keeps defaulting to `1.0`.

Verified: on `main`, `Collect2qBlocks` + `ConsolidateBlocks(basis_gates=['cx','u'], approximation_degree=0.0)` leaves a lone CX untouched while `approximation_degree=1e-9` approximates it away; with this fix `0.0` matches the continuous limit. Added a regression test; all 49 tests in `test_consolidate_blocks.py` and the 25 approximation-related transpiler tests pass, `ruff`/`black` clean.

AI disclosure: this PR was prepared with the assistance of Claude Code (Anthropic's Claude); I review and test all changes.