### PR TITLE
Preserve MCPhase parameters in MCX synthesis

### DIFF
--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -450,7 +450,7 @@ pub fn synth_mcx_noaux_v24(
         };
         circuit.push_packed_operation(
             inst.into(),
-            None,
+            Some(Parameters::Params(smallvec::smallvec![Param::Float(PI)])),
             &(0..num_qubits).map(Qubit).collect::<Vec<Qubit>>(),
             &[],
         )?;

--- a/releasenotes/notes/fix-qasm3-nested-gate-parameters-a7c3d8e21f6b9042.yaml
+++ b/releasenotes/notes/fix-qasm3-nested-gate-parameters-a7c3d8e21f6b9042.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    Fixed :func:`.synth_mcx_noaux_v24` omitting the parameter metadata from
+    Fixed :func:`.synth_mcx_noaux_v24` omitting the parameters from
     its nested :class:`.MCPhaseGate` instruction when synthesizing five or
     more controls. This also fixes the resulting :class:`.MCXGate` definition
     producing invalid OpenQASM 3 output.

--- a/releasenotes/notes/fix-qasm3-nested-gate-parameters-a7c3d8e21f6b9042.yaml
+++ b/releasenotes/notes/fix-qasm3-nested-gate-parameters-a7c3d8e21f6b9042.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed :func:`.synth_mcx_noaux_v24` omitting the parameter metadata from
+    its nested :class:`.MCPhaseGate` instruction when synthesizing five or
+    more controls. This also fixes the resulting :class:`.MCXGate` definition
+    producing invalid OpenQASM 3 output.

--- a/test/python/synthesis/test_multi_controlled_synthesis.py
+++ b/test/python/synthesis/test_multi_controlled_synthesis.py
@@ -221,6 +221,14 @@ class TestMCSynthesisCorrectness(QiskitTestCase):
             XGate(), num_ctrl_qubits, synthesized_circuit, clean_ancillas=False
         )
 
+    def test_mcx_noaux_v24_preserves_mcphase_parameters(self):
+        """Test the MCPhase parameter is stored on its circuit instruction."""
+        synthesized_circuit = synth_mcx_noaux_v24(5)
+        mcphase_instruction = synthesized_circuit.data[1]
+
+        self.assertEqual(mcphase_instruction.params, [np.pi])
+        self.assertEqual(mcphase_instruction.params, mcphase_instruction.operation.params)
+
     @data(0, 1, 2, 3, 4, 5, 6, 7, 8)
     def test_mcx_noaux_hp24(self, num_ctrl_qubits: int):
         """Test synth_mcx_noaux_hp24 by comparing synthesized and expected matrices."""


### PR DESCRIPTION
`synth_mcx_noaux_v24` creates an `MCPhaseGate(pi, ...)` when synthesizing
five or more controls, but previously inserted the packed operation without
its parameter metadata. This left `CircuitInstruction.params` empty while
`CircuitInstruction.operation.params` contained `pi`.

The mismatch produced invalid OpenQASM 3 output because the generated
`mcphase` gate was declared with a parameter and called without one.

Store `pi` on the packed instruction and add a synthesis regression test that
checks the instruction and operation parameters remain consistent.

The problem was reported downstream in
https://github.com/munich-quantum-toolkit/bench/issues/903.

### Testing

- `python -m unittest test.python.synthesis.test_multi_controlled_synthesis`
- `python -m unittest discover -s test/python/qasm3 -t .`
- MQT Bench Grover-10 QASM3 export/import reproducer
- Rust formatting, Black, Ruff, Reno, and `git diff --check`

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description: OpenAI Codex (GPT-5)
- [x] I used the following tool to generate or modify code: OpenAI Codex (GPT-5). I reviewed and tested the complete change and can explain its behavior and design.
