### PR TITLE
Fix the type of the angle in `MCPhaseGate` synthesis functions to `ParameterValueType`

### DIFF
--- a/qiskit/synthesis/multi_controlled/mcp_synthesis.py
+++ b/qiskit/synthesis/multi_controlled/mcp_synthesis.py
@@ -14,10 +14,11 @@
 import numpy as np
 
 from qiskit.circuit import QuantumCircuit
+from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit.exceptions import QiskitError
 
 
-def synth_mcp_noaux_v24(num_ctrl_qubits: int, phase: float) -> QuantumCircuit:
+def synth_mcp_noaux_v24(num_ctrl_qubits: int, phase: ParameterValueType) -> QuantumCircuit:
     r"""Synthesize a multi-controlled phase gate with no auxiliary qubits.
 
     This method implements the synthesis of a multi-controlled phase gate
@@ -122,7 +123,9 @@ def synth_mcp_noaux_v24(num_ctrl_qubits: int, phase: float) -> QuantumCircuit:
     return qc
 
 
-def _apply_controlled_gates(circuit: QuantumCircuit, phi: float, n_qubits: int, step: int) -> None:
+def _apply_controlled_gates(
+    circuit: QuantumCircuit, phi: ParameterValueType, n_qubits: int, step: int
+) -> None:
     """Helper function to apply controlled gates in a specific pattern based on the step in :func:`synth_mcp_noaux_sp22`."""
     # The following code is a derivative work of qclib
     # (https://github.com/qclib/qclib/blob/master/qclib/gates/ldmcu.py).
@@ -162,7 +165,7 @@ def _apply_controlled_gates(circuit: QuantumCircuit, phi: float, n_qubits: int, 
             circuit.crx(sign * np.pi / param, control, target)
 
 
-def synth_mcp_noaux_sp22(num_ctrl_qubits: int, phase: float) -> QuantumCircuit:
+def synth_mcp_noaux_sp22(num_ctrl_qubits: int, phase: ParameterValueType) -> QuantumCircuit:
     r"""Synthesize a multi-controlled phase gate with :math:`n` controls based on the paper
     by da Silva et al. [1] and the implementation in qclib [2].
 
@@ -234,7 +237,7 @@ def synth_mcp_noaux_sp22(num_ctrl_qubits: int, phase: float) -> QuantumCircuit:
     return qc
 
 
-def synth_mcp_noaux_default(num_ctrl_qubits: int, phase: float) -> QuantumCircuit:
+def synth_mcp_noaux_default(num_ctrl_qubits: int, phase: ParameterValueType) -> QuantumCircuit:
     """Choose the best synthesis code for :class:`.MCPhaseGate` according to the number of control qubits.
 
     Args:

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -749,7 +749,9 @@ class TestControlledGate(QiskitTestCase):
         dag = circuit_to_dag(circuit)
         self.assertEqual(len(list(dag.idle_wires())), 0)
 
-    @combine(num_controls=[1, 2, 3], base_gate=[RXGate, RYGate, RZGate, CPhaseGate])
+    @combine(
+        num_controls=[1, 2, 3, 4, 5, 6], base_gate=[RXGate, RYGate, RZGate, PhaseGate, CPhaseGate]
+    )
     def test_multi_controlled_rotation_gate_with_parameter(self, num_controls, base_gate):
         """Test multi-controlled rotation gates and MCPhase gate with Parameter synthesis."""
         theta = Parameter("theta")

--- a/test/python/synthesis/test_multi_controlled_synthesis.py
+++ b/test/python/synthesis/test_multi_controlled_synthesis.py
@@ -18,7 +18,7 @@ from test import QiskitTestCase, combine
 import numpy as np
 from ddt import data, ddt
 
-from qiskit.circuit import Gate, QuantumCircuit
+from qiskit.circuit import Gate, QuantumCircuit, Parameter
 from qiskit.circuit._utils import _compute_control_matrix, _ctrl_state_to_int
 from qiskit.circuit.library import (
     C3XGate,
@@ -146,6 +146,39 @@ class TestMCSynthesisCorrectness(QiskitTestCase):
         synthesized_circuit = synth_mcp_noaux_sp22(num_ctrl_qubits, phase=0.123)
         self.assertSynthesisCorrect(
             PhaseGate(0.123), num_ctrl_qubits, synthesized_circuit, clean_ancillas=False
+        )
+
+    @data(0, 1, 2, 3, 4, 5, 6)
+    def test_mcp_noaux_v24_with_params(self, num_ctrl_qubits: int):
+        """Test synth_mcp_noaux_v24 works correctly with parametric angles."""
+        theta = Parameter("theta")
+        val = 0.456
+        circuit = synth_mcp_noaux_v24(num_ctrl_qubits, phase=theta)
+        bound_circuit = circuit.assign_parameters([val])
+        self.assertSynthesisCorrect(
+            PhaseGate(val), num_ctrl_qubits, bound_circuit, clean_ancillas=False
+        )
+
+    @data(0, 1, 2, 3, 4, 5, 6)
+    def test_mcp_noaux_default_with_params(self, num_ctrl_qubits: int):
+        """Test synth_mcp_noaux_default works correctly with parametric angles."""
+        theta = Parameter("theta")
+        val = 0.456
+        circuit = synth_mcp_noaux_default(num_ctrl_qubits, phase=theta)
+        bound_circuit = circuit.assign_parameters([val])
+        self.assertSynthesisCorrect(
+            PhaseGate(val), num_ctrl_qubits, bound_circuit, clean_ancillas=False
+        )
+
+    @data(0, 1, 2, 3, 4, 5, 6)
+    def test_mcp_noaux_sp22_with_params(self, num_ctrl_qubits: int):
+        """Test synth_mcp_noaux_sp22 works correctly with parametric angles."""
+        theta = Parameter("theta")
+        val = 0.456
+        circuit = synth_mcp_noaux_sp22(num_ctrl_qubits, phase=theta)
+        bound_circuit = circuit.assign_parameters([val])
+        self.assertSynthesisCorrect(
+            PhaseGate(val), num_ctrl_qubits, bound_circuit, clean_ancillas=False
         )
 
     @data(0, 1, 2, 3, 4, 5, 6)


### PR DESCRIPTION

In #16550 we introduced synthesis functions to `MCPhaseGate`, `synth_mcp_noaux_v24`, `synth_mcp_noaux_sp22` and `synth_mcp_noaux_default`.
However, the type hints in the documentation state incorrectly that the angle is of type `float` whereas it is actually of type `ParameterValueType`. The code itself work correctly with parametric angles. 
The documentation is now fixed and the tests are extended to check this. 
No release notes are needed since #16550 should be released as part of Qiskit 2.6.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
