### PR TITLE
QPY: Bug fix in Rust implementation of `SparsePauliObservableElemPack`

### DIFF
--- a/crates/qpy/src/formats.rs
+++ b/crates/qpy/src/formats.rs
@@ -506,6 +506,7 @@ pub struct SparsePauliOpListElemPack {
 #[derive(Debug)]
 pub struct SparsePauliObservableElemPack {
     pub num_qubits: u32,
+    // coeffs are Complex64 numbers, stored as a vector of f64 in the format [re1, im1, re2, im2,...]
     #[bw(calc = (coeff_data.len() * std::mem::size_of::<f64>()) as u64)]
     pub coeff_data_size: u64,
     #[bw(calc = (bitterm_data.len() * std::mem::size_of::<u16>()) as u64)]

--- a/crates/qpy/src/formats.rs
+++ b/crates/qpy/src/formats.rs
@@ -506,21 +506,21 @@ pub struct SparsePauliOpListElemPack {
 #[derive(Debug)]
 pub struct SparsePauliObservableElemPack {
     pub num_qubits: u32,
-    #[bw(calc = coeff_data.len() as u64)]
+    #[bw(calc = (coeff_data.len() * std::mem::size_of::<f64>()) as u64)]
     pub coeff_data_size: u64,
-    #[bw(calc = bitterm_data.len() as u64)]
+    #[bw(calc = (bitterm_data.len() * std::mem::size_of::<u16>()) as u64)]
     pub bitterm_data_size: u64,
-    #[bw(calc = inds_data.len() as u64)]
+    #[bw(calc = (inds_data.len() * std::mem::size_of::<u32>()) as u64)]
     pub inds_data_size: u64,
-    #[bw(calc = bounds_data.len() as u64)]
+    #[bw(calc = (bounds_data.len() * std::mem::size_of::<u64>()) as u64)]
     pub bounds_data_size: u64,
-    #[br(count = coeff_data_size)]
+    #[br(count = coeff_data_size / std::mem::size_of::<f64>() as u64)]
     pub coeff_data: Vec<f64>, // complex numbers stored in format [re1, im1, re2, im2,...]
-    #[br(count = bitterm_data_size)]
+    #[br(count = bitterm_data_size / std::mem::size_of::<u16>() as u64)]
     pub bitterm_data: Vec<u16>,
-    #[br(count = inds_data_size)]
+    #[br(count = inds_data_size / std::mem::size_of::<u32>() as u64)]
     pub inds_data: Vec<u32>,
-    #[br(count = bounds_data_size)]
+    #[br(count = bounds_data_size / std::mem::size_of::<u64>() as u64)]
     pub bounds_data: Vec<u64>,
 }
 

--- a/releasenotes/notes/fix-qpy-sparse_pauli-095b5c3e6ef4f5e8.yaml
+++ b/releasenotes/notes/fix-qpy-sparse_pauli-095b5c3e6ef4f5e8.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a bug with the QPY serialization and deserialization of instructions
+    containing :class:`.SparseObservable` data.
+    Fixed `#16722 <https://github.com/Qiskit/qiskit/issues/16722>`__.

--- a/test/python/qpy/test_roundtrip.py
+++ b/test/python/qpy/test_roundtrip.py
@@ -22,7 +22,7 @@ from qiskit.circuit.library import PauliEvolutionGate
 from qiskit.circuit.random import random_circuit
 from qiskit.circuit.parameter import Parameter
 from qiskit.circuit.parametervector import ParameterVector
-from qiskit.quantum_info import SparsePauliOp
+from qiskit.quantum_info import SparsePauliOp, SparseObservable
 from qiskit.circuit.classical import expr
 from qiskit.synthesis import LieTrotter
 from qiskit.qpy.common import QPY_RUST_READ_MIN_VERSION, QPY_RUST_WRITE_MIN_VERSION, QPY_VERSION
@@ -282,4 +282,17 @@ class TestQPYRoundtrip(QiskitTestCase):
         qc = QuantumCircuit(1)
         with qc.for_loop((2, 5, (1 << 60))) as _:
             qc.x(0)
+        self.assert_roundtrip_equal(qc, version=version, read_with=read_with, write_with=write_with)
+
+    @all_qpy_combinations(17)
+    def test_evolutiongate_sparse_observable(self, version, write_with, read_with):
+        """Test loading a circuit with an evolution gate over a SparseObservable works.
+
+        ``SparseObservable`` support was added to QPY in version 17.
+        """
+        op = SparseObservable.from_list([("XIX", 0.1), ("ZIZ", 0.3)])
+        evo = PauliEvolutionGate(op, time=2, synthesis=LieTrotter(reps=2))
+
+        qc = QuantumCircuit(op.num_qubits)
+        qc.append(evo, range(op.num_qubits))
         self.assert_roundtrip_equal(qc, version=version, read_with=read_with, write_with=write_with)


### PR DESCRIPTION
# Summary
Fixes a bug in the way Rust QPY serializes and deserializes `SparsePauliObservableElemPack`.

Fixes #16722

# Details
When serializing `SparsePauliObservableElemPack`, there are several lists of elements being serialized. While Rust stored the lengths of the lists, Python stored the actual sizes of the serialized lists. It is possible to make sure Rust conforms to this serialization by dividing and multiplying by the correct factors (dependent on the known sizes of the stored elements).

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
