### PR TITLE
Port the Quantum Fourier Transform (QFT) all-to-all implementation to Rust

### DIFF
--- a/crates/synthesis/src/qft/mod.rs
+++ b/crates/synthesis/src/qft/mod.rs
@@ -16,11 +16,6 @@ mod qft_decompose_lnn;
 use pyo3::prelude::*;
 use qft_decompose_full::synth_qft_full;
 use qft_decompose_lnn::synth_qft_line;
-use qiskit_circuit::Qubit;
-use qiskit_circuit::operations::{Param, StandardGate};
-use smallvec::SmallVec;
-
-pub(super) type QftGatesVec = Vec<(StandardGate, SmallVec<[Param; 3]>, SmallVec<[Qubit; 2]>)>;
 
 pub fn qft(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(synth_qft_full, m)?)?;

--- a/crates/synthesis/src/qft/mod.rs
+++ b/crates/synthesis/src/qft/mod.rs
@@ -10,12 +10,20 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+mod qft_decompose_full;
 mod qft_decompose_lnn;
 
 use pyo3::prelude::*;
+use qft_decompose_full::synth_qft_full;
 use qft_decompose_lnn::synth_qft_line;
+use qiskit_circuit::Qubit;
+use qiskit_circuit::operations::{Param, StandardGate};
+use smallvec::SmallVec;
+
+pub(super) type QftGatesVec = Vec<(StandardGate, SmallVec<[Param; 3]>, SmallVec<[Qubit; 2]>)>;
 
 pub fn qft(m: &Bound<PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(synth_qft_full, m)?)?;
     m.add_function(wrap_pyfunction!(synth_qft_line, m)?)?;
     Ok(())
 }

--- a/crates/synthesis/src/qft/qft_decompose_full.rs
+++ b/crates/synthesis/src/qft/qft_decompose_full.rs
@@ -1,0 +1,152 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use super::QftGatesVec;
+use pyo3::prelude::*;
+use qiskit_circuit::Qubit;
+use qiskit_circuit::circuit_data::{CircuitData, PyCircuitData};
+use qiskit_circuit::operations::{Param, StandardGate, StandardInstruction};
+use qiskit_circuit::packed_instruction::PackedOperation;
+use smallvec::{SmallVec, smallvec};
+use std::f64::consts::PI;
+
+/// Construct a circuit for the Quantum Fourier Transform using all-to-all connectivity.
+///
+/// .. note::
+///
+///     With the default value of ``do_swaps = True``, this synthesis algorithm creates a
+///     circuit that faithfully implements the QFT operation. This circuit contains a sequence
+///     of swap gates at the end, corresponding to reversing the order of its output qubits.
+///     In some applications this reversal permutation can be avoided. Setting ``do_swaps = False``
+///     creates a circuit without this reversal permutation, at the expense that this circuit
+///     implements the "QFT-with-reversal" instead of QFT. Alternatively, the
+///     :class:`~.ElidePermutations` transpiler pass is able to remove these swap gates.
+///
+/// Args:
+///     num_qubits: The number of qubits on which the Quantum Fourier Transform acts.
+///     do_swaps: Whether to synthesize the "QFT" or the "QFT-with-reversal" operation.
+///     approximation_degree: The degree of approximation (0 for no approximation).
+///         It is possible to implement the QFT approximately by ignoring
+///         controlled-phase rotations with the angle beneath a threshold. This is discussed
+///         in more detail in https://arxiv.org/abs/quant-ph/9601018 or
+///         https://arxiv.org/abs/quant-ph/0403071.
+///     insert_barriers: If ``True``, barriers are inserted after each qubit's H+CP block
+///         for improved visualization.
+///
+/// Returns:
+///     A circuit implementing the QFT operation.
+#[pyfunction]
+#[pyo3(signature=(num_qubits, do_swaps=true, approximation_degree=0, insert_barriers=false))]
+pub fn synth_qft_full(
+    num_qubits: usize,
+    do_swaps: bool,
+    approximation_degree: usize,
+    insert_barriers: bool,
+) -> PyResult<PyCircuitData> {
+    // Pre-calculate exact gate count to avoid reallocations.
+    // H gates:    one per qubit = num_qubits
+    // CP gates:   sum_{j=0}^{n-1} num_entanglements(j)
+    //             = (n-1-d) * (n+d) / 2   where d = approximation_degree
+    //               (0 when approximation_degree >= num_qubits - 1)
+    // Barrier:    one after each qubit's H+CP block = num_qubits (only when insert_barriers)
+    // Swap gates: num_qubits / 2  (only when do_swaps)
+    let effective = num_qubits
+        .saturating_sub(1)
+        .saturating_sub(approximation_degree);
+    let no_of_gates = num_qubits
+        + effective * (num_qubits + approximation_degree) / 2
+        + if insert_barriers { num_qubits } else { 0 }
+        + if do_swaps { num_qubits / 2 } else { 0 };
+
+    if insert_barriers {
+        // When barriers are requested we must use the builder API because
+        // `CircuitData::from_standard_gates` only accepts `StandardGate` tuples.
+        let mut circuit =
+            CircuitData::with_capacity(num_qubits as u32, 0, no_of_gates, Param::Float(0.0))?;
+
+        let all_qubits: SmallVec<[Qubit; 32]> = (0..num_qubits).map(Qubit::new).collect();
+
+        for j in (0..num_qubits).rev() {
+            circuit.push_standard_gate(StandardGate::H, &[], &[Qubit::new(j)])?;
+
+            let tail = num_qubits - j - 1;
+            let approx_offset = approximation_degree.saturating_sub(tail);
+            let num_entanglements = j.saturating_sub(approx_offset);
+
+            for k in (j - num_entanglements..j).rev() {
+                let lam = PI * (2.0_f64).powi(k as i32 - j as i32);
+                circuit.push_standard_gate(
+                    StandardGate::CPhase,
+                    &[Param::Float(lam)],
+                    &[Qubit::new(j), Qubit::new(k)],
+                )?;
+            }
+
+            // Barrier across all qubits after each round.
+            circuit.push_packed_operation(
+                PackedOperation::from_standard_instruction(StandardInstruction::Barrier(
+                    num_qubits as u32,
+                )),
+                None,
+                &all_qubits,
+                &[],
+            )?;
+        }
+
+        if do_swaps {
+            for i in 0..num_qubits / 2 {
+                circuit.push_standard_gate(
+                    StandardGate::Swap,
+                    &[],
+                    &[Qubit::new(i), Qubit::new(num_qubits - i - 1)],
+                )?;
+            }
+        }
+
+        Ok(circuit.into())
+    } else {
+        // Fast path: no barriers — use the zero-overhead batch constructor.
+        let mut instructions: QftGatesVec = Vec::with_capacity(no_of_gates);
+
+        for j in (0..num_qubits).rev() {
+            instructions.push((StandardGate::H, smallvec![], smallvec![Qubit::new(j)]));
+
+            let tail = num_qubits - j - 1;
+            let approx_offset = approximation_degree.saturating_sub(tail);
+            let num_entanglements = j.saturating_sub(approx_offset);
+
+            for k in (j - num_entanglements..j).rev() {
+                let lam = PI * (2.0_f64).powi(k as i32 - j as i32);
+                instructions.push((
+                    StandardGate::CPhase,
+                    smallvec![Param::Float(lam)],
+                    smallvec![Qubit::new(j), Qubit::new(k)],
+                ));
+            }
+        }
+
+        if do_swaps {
+            for i in 0..num_qubits / 2 {
+                instructions.push((
+                    StandardGate::Swap,
+                    smallvec![],
+                    smallvec![Qubit::new(i), Qubit::new(num_qubits - i - 1)],
+                ));
+            }
+        }
+
+        Ok(
+            CircuitData::from_standard_gates(num_qubits as u32, instructions, Param::Float(0.0))?
+                .into(),
+        )
+    }
+}

--- a/crates/synthesis/src/qft/qft_decompose_full.rs
+++ b/crates/synthesis/src/qft/qft_decompose_full.rs
@@ -15,10 +15,10 @@ use qiskit_circuit::Qubit;
 use qiskit_circuit::circuit_data::{CircuitData, PyCircuitData};
 use qiskit_circuit::operations::{Param, StandardGate, StandardInstruction};
 use qiskit_circuit::packed_instruction::PackedOperation;
-use smallvec::{SmallVec, smallvec};
+use smallvec::SmallVec;
 use std::f64::consts::PI;
 
-/// Construct a circuit for the Quantum Fourier Transform using all-to-all connectivity.
+/// Construct the textbook Quantum Fourier Transform circuit.
 ///
 /// .. note::
 ///
@@ -35,9 +35,7 @@ use std::f64::consts::PI;
 ///     do_swaps: Whether to synthesize the "QFT" or the "QFT-with-reversal" operation.
 ///     approximation_degree: The degree of approximation (0 for no approximation).
 ///         It is possible to implement the QFT approximately by ignoring
-///         controlled-phase rotations with the angle beneath a threshold. This is discussed
-///         in more detail in https://arxiv.org/abs/quant-ph/9601018 or
-///         https://arxiv.org/abs/quant-ph/0403071.
+///         controlled-phase rotations with the angle beneath a threshold.
 ///     insert_barriers: If ``True``, barriers are inserted after each qubit's H+CP block
 ///         for improved visualization.
 ///
@@ -66,19 +64,20 @@ pub fn synth_qft_full(
         + if insert_barriers { num_qubits } else { 0 }
         + if do_swaps { num_qubits / 2 } else { 0 };
 
-    // Build the H+CP instructions shared by both paths (with barriers and without).
-    // Each round j emits: one H(j) followed by num_entanglements(j) CP gates.
-    // rounds_end[j] is the exclusive end index of round j's gates in `instructions`,
-    // used by the barrier path to know where to insert each barrier.
-    let mut instructions = Vec::with_capacity(no_of_gates);
-    let mut rounds_end: Vec<usize> = if insert_barriers {
-        Vec::with_capacity(num_qubits)
+    let mut circuit =
+        CircuitData::with_capacity(num_qubits as u32, 0, no_of_gates, Param::Float(0.0))?;
+    let (barrier_op, all_qubits) = if insert_barriers {
+        let op = PackedOperation::from_standard_instruction(StandardInstruction::Barrier(
+            num_qubits as u32,
+        ));
+        let qubits: SmallVec<[Qubit; 32]> = (0..num_qubits).map(|q| Qubit(q as u32)).collect();
+        (Some(op), Some(qubits))
     } else {
-        Vec::new() // not used in the fast path
+        (None, None)
     };
 
     for j in (0..num_qubits).rev() {
-        instructions.push((StandardGate::H, smallvec![], smallvec![Qubit::new(j)]));
+        circuit.push_standard_gate(StandardGate::H, &[], &[Qubit(j as u32)])?;
 
         let tail = num_qubits - j - 1;
         let approx_offset = approximation_degree.saturating_sub(tail);
@@ -86,59 +85,27 @@ pub fn synth_qft_full(
 
         for k in (j - num_entanglements..j).rev() {
             let lam = PI * (2.0_f64).powi(k as i32 - j as i32);
-            instructions.push((
+            circuit.push_standard_gate(
                 StandardGate::CPhase,
-                smallvec![Param::Float(lam)],
-                smallvec![Qubit::new(j), Qubit::new(k)],
-            ));
+                &[Param::Float(lam)],
+                &[Qubit(j as u32), Qubit(k as u32)],
+            )?;
         }
 
-        if insert_barriers {
-            rounds_end.push(instructions.len());
+        if let (Some(op), Some(qubits)) = (&barrier_op, &all_qubits) {
+            circuit.push_packed_operation(op.clone(), None, qubits, &[])?;
         }
     }
 
     if do_swaps {
+        // Add a reversal network
         for i in 0..num_qubits / 2 {
-            instructions.push((
+            circuit.push_standard_gate(
                 StandardGate::Swap,
-                smallvec![],
-                smallvec![Qubit::new(i), Qubit::new(num_qubits - i - 1)],
-            ));
+                &[],
+                &[Qubit(i as u32), Qubit((num_qubits - i - 1) as u32)],
+            )?;
         }
     }
-
-    if insert_barriers {
-        // Rebuild as CircuitData using the builder API, interleaving barriers
-        // after each round. `CircuitData::from_standard_gates` cannot be used
-        // here because `Barrier` is a `StandardInstruction`, not a `StandardGate`.
-        let mut circuit =
-            CircuitData::with_capacity(num_qubits as u32, 0, no_of_gates, Param::Float(0.0))?;
-        let all_qubits: SmallVec<[Qubit; 32]> = (0..num_qubits).map(Qubit::new).collect();
-        let barrier_op = PackedOperation::from_standard_instruction(StandardInstruction::Barrier(
-            num_qubits as u32,
-        ));
-
-        let mut prev = 0;
-        for end in rounds_end {
-            for (gate, params, qargs) in &instructions[prev..end] {
-                circuit.push_standard_gate(*gate, params, qargs)?;
-            }
-            circuit.push_packed_operation(barrier_op.clone(), None, &all_qubits, &[])?;
-            prev = end;
-        }
-        // Append any trailing swap gates (beyond the last round boundary).
-        for (gate, params, qargs) in &instructions[prev..] {
-            circuit.push_standard_gate(*gate, params, qargs)?;
-        }
-
-        Ok(circuit.into())
-    } else {
-        // Fast path: no barriers — feed the instruction vec directly into the
-        // zero-overhead batch constructor.
-        Ok(
-            CircuitData::from_standard_gates(num_qubits as u32, instructions, Param::Float(0.0))?
-                .into(),
-        )
-    }
+    Ok(circuit.into())
 }

--- a/crates/synthesis/src/qft/qft_decompose_full.rs
+++ b/crates/synthesis/src/qft/qft_decompose_full.rs
@@ -10,7 +10,6 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use super::QftGatesVec;
 use pyo3::prelude::*;
 use qiskit_circuit::Qubit;
 use qiskit_circuit::circuit_data::{CircuitData, PyCircuitData};
@@ -67,83 +66,76 @@ pub fn synth_qft_full(
         + if insert_barriers { num_qubits } else { 0 }
         + if do_swaps { num_qubits / 2 } else { 0 };
 
-    if insert_barriers {
-        // When barriers are requested we must use the builder API because
-        // `CircuitData::from_standard_gates` only accepts `StandardGate` tuples.
-        let mut circuit =
-            CircuitData::with_capacity(num_qubits as u32, 0, no_of_gates, Param::Float(0.0))?;
+    // Build the H+CP instructions shared by both paths (with barriers and without).
+    // Each round j emits: one H(j) followed by num_entanglements(j) CP gates.
+    // rounds_end[j] is the exclusive end index of round j's gates in `instructions`,
+    // used by the barrier path to know where to insert each barrier.
+    let mut instructions = Vec::with_capacity(no_of_gates);
+    let mut rounds_end: Vec<usize> = if insert_barriers {
+        Vec::with_capacity(num_qubits)
+    } else {
+        Vec::new() // not used in the fast path
+    };
 
-        let all_qubits: SmallVec<[Qubit; 32]> = (0..num_qubits).map(Qubit::new).collect();
+    for j in (0..num_qubits).rev() {
+        instructions.push((StandardGate::H, smallvec![], smallvec![Qubit::new(j)]));
 
-        for j in (0..num_qubits).rev() {
-            circuit.push_standard_gate(StandardGate::H, &[], &[Qubit::new(j)])?;
+        let tail = num_qubits - j - 1;
+        let approx_offset = approximation_degree.saturating_sub(tail);
+        let num_entanglements = j.saturating_sub(approx_offset);
 
-            let tail = num_qubits - j - 1;
-            let approx_offset = approximation_degree.saturating_sub(tail);
-            let num_entanglements = j.saturating_sub(approx_offset);
-
-            for k in (j - num_entanglements..j).rev() {
-                let lam = PI * (2.0_f64).powi(k as i32 - j as i32);
-                circuit.push_standard_gate(
-                    StandardGate::CPhase,
-                    &[Param::Float(lam)],
-                    &[Qubit::new(j), Qubit::new(k)],
-                )?;
-            }
-
-            // Barrier across all qubits after each round.
-            circuit.push_packed_operation(
-                PackedOperation::from_standard_instruction(StandardInstruction::Barrier(
-                    num_qubits as u32,
-                )),
-                None,
-                &all_qubits,
-                &[],
-            )?;
+        for k in (j - num_entanglements..j).rev() {
+            let lam = PI * (2.0_f64).powi(k as i32 - j as i32);
+            instructions.push((
+                StandardGate::CPhase,
+                smallvec![Param::Float(lam)],
+                smallvec![Qubit::new(j), Qubit::new(k)],
+            ));
         }
 
-        if do_swaps {
-            for i in 0..num_qubits / 2 {
-                circuit.push_standard_gate(
-                    StandardGate::Swap,
-                    &[],
-                    &[Qubit::new(i), Qubit::new(num_qubits - i - 1)],
-                )?;
+        if insert_barriers {
+            rounds_end.push(instructions.len());
+        }
+    }
+
+    if do_swaps {
+        for i in 0..num_qubits / 2 {
+            instructions.push((
+                StandardGate::Swap,
+                smallvec![],
+                smallvec![Qubit::new(i), Qubit::new(num_qubits - i - 1)],
+            ));
+        }
+    }
+
+    if insert_barriers {
+        // Rebuild as CircuitData using the builder API, interleaving barriers
+        // after each round. `CircuitData::from_standard_gates` cannot be used
+        // here because `Barrier` is a `StandardInstruction`, not a `StandardGate`.
+        let mut circuit =
+            CircuitData::with_capacity(num_qubits as u32, 0, no_of_gates, Param::Float(0.0))?;
+        let all_qubits: SmallVec<[Qubit; 32]> = (0..num_qubits).map(Qubit::new).collect();
+        let barrier_op = PackedOperation::from_standard_instruction(StandardInstruction::Barrier(
+            num_qubits as u32,
+        ));
+
+        let mut prev = 0;
+        for end in rounds_end {
+            for (gate, params, qargs) in &instructions[prev..end] {
+                circuit.push_standard_gate(*gate, params, qargs)?;
             }
+            circuit.push_packed_operation(barrier_op.clone(), None, &all_qubits, &[])?;
+            prev = end;
+        }
+        // Append any trailing swap gates (beyond the last round boundary).
+        for (gate, params, qargs) in &instructions[prev..] {
+            circuit.push_standard_gate(*gate, params, qargs)?;
         }
 
         Ok(circuit.into())
     } else {
-        // Fast path: no barriers — use the zero-overhead batch constructor.
-        let mut instructions: QftGatesVec = Vec::with_capacity(no_of_gates);
-
-        for j in (0..num_qubits).rev() {
-            instructions.push((StandardGate::H, smallvec![], smallvec![Qubit::new(j)]));
-
-            let tail = num_qubits - j - 1;
-            let approx_offset = approximation_degree.saturating_sub(tail);
-            let num_entanglements = j.saturating_sub(approx_offset);
-
-            for k in (j - num_entanglements..j).rev() {
-                let lam = PI * (2.0_f64).powi(k as i32 - j as i32);
-                instructions.push((
-                    StandardGate::CPhase,
-                    smallvec![Param::Float(lam)],
-                    smallvec![Qubit::new(j), Qubit::new(k)],
-                ));
-            }
-        }
-
-        if do_swaps {
-            for i in 0..num_qubits / 2 {
-                instructions.push((
-                    StandardGate::Swap,
-                    smallvec![],
-                    smallvec![Qubit::new(i), Qubit::new(num_qubits - i - 1)],
-                ));
-            }
-        }
-
+        // Fast path: no barriers — feed the instruction vec directly into the
+        // zero-overhead batch constructor.
         Ok(
             CircuitData::from_standard_gates(num_qubits as u32, instructions, Param::Float(0.0))?
                 .into(),

--- a/qiskit/synthesis/qft/qft_decompose_full.py
+++ b/qiskit/synthesis/qft/qft_decompose_full.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import warnings
 import numpy as np
 from qiskit.circuit import QuantumCircuit
+from qiskit._accelerate.synthesis.qft import synth_qft_full as _synth_qft_full
 
 
 def synth_qft_full(
@@ -56,23 +57,12 @@ def synth_qft_full(
 
     """
     _warn_if_precision_loss(num_qubits - approximation_degree - 1)
-    circuit = QuantumCircuit(num_qubits)
 
-    for j in reversed(range(num_qubits)):
-        circuit.h(j)
-        num_entanglements = max(0, j - max(0, approximation_degree - (num_qubits - j - 1)))
-        for k in reversed(range(j - num_entanglements, j)):
-            # Use negative exponents so that the angle safely underflows to zero, rather than
-            # using a temporary variable that overflows to infinity in the worst case.
-            lam = np.pi * (2.0 ** (k - j))
-            circuit.cp(lam, j, k)
-
-        if insert_barriers:
-            circuit.barrier()
-
-    if do_swaps:
-        for i in range(num_qubits // 2):
-            circuit.swap(i, num_qubits - i - 1)
+    circuit = QuantumCircuit._from_circuit_data(
+        # Circuit built in Rust (H + CP + barriers + optional SWAPs)
+        _synth_qft_full(num_qubits, do_swaps, approximation_degree, insert_barriers),
+        legacy_qubits=True,
+    )
 
     if inverse:
         circuit = circuit.inverse()

--- a/releasenotes/notes/improve_qft_full_performance_via_rust-6877d92b7470e344.yaml
+++ b/releasenotes/notes/improve_qft_full_performance_via_rust-6877d92b7470e344.yaml
@@ -1,0 +1,6 @@
+--- 
+performance:
+- Improved the runtime performance of :py:func:`~qiskit.synthesis.synth_qft_full` function
+  by migrating the implementation to Rust. Benchmarks demonstrate speedups ranging from 9x to 30x, 
+  including 9x for 5 qubits, 30x for 200 qubits, and 18x for 1000 qubits. There are no API changes.
+ 

--- a/releasenotes/notes/improve_qft_full_performance_via_rust-6877d92b7470e344.yaml
+++ b/releasenotes/notes/improve_qft_full_performance_via_rust-6877d92b7470e344.yaml
@@ -2,7 +2,5 @@
 performance:
 - Improved the runtime performance of :func:`~qiskit.synthesis.synth_qft_full` by
   migrating the implementation to Rust. Benchmarks show speedups ranging from 9x at
-  5 qubits to ~31x at 200 qubits, and 18x at 1000 qubits. The reduction at large
-  qubit counts reflects that circuit construction becomes dominated by memory
-  allocation rather than Python dispatch overhead.
+  5 qubits to ~31x at 200 qubits, and 12x at 1000 qubits. 
   See `#16789 <https://github.com/Qiskit/qiskit/pull/16789>`__.

--- a/releasenotes/notes/improve_qft_full_performance_via_rust-6877d92b7470e344.yaml
+++ b/releasenotes/notes/improve_qft_full_performance_via_rust-6877d92b7470e344.yaml
@@ -1,6 +1,6 @@
 ---
 performance:
 - Improved the runtime performance of :func:`~qiskit.synthesis.synth_qft_full` by
-  migrating the implementation to Rust. Benchmarks show speedups ranging from 9x at
-  5 qubits to ~31x at 200 qubits, and 12x at 1000 qubits. 
+  migrating the implementation to Rust. Benchmarks show speedups ranging from ~9x at
+  5 qubits to ~30x at 200 qubits, and ~11x at 1000 qubits. 
   See `#16789 <https://github.com/Qiskit/qiskit/pull/16789>`__.

--- a/releasenotes/notes/improve_qft_full_performance_via_rust-6877d92b7470e344.yaml
+++ b/releasenotes/notes/improve_qft_full_performance_via_rust-6877d92b7470e344.yaml
@@ -1,6 +1,8 @@
---- 
+---
 performance:
-- Improved the runtime performance of :py:func:`~qiskit.synthesis.synth_qft_full` function
-  by migrating the implementation to Rust. Benchmarks demonstrate speedups ranging from 9x to 30x, 
-  including 9x for 5 qubits, 30x for 200 qubits, and 18x for 1000 qubits. There are no API changes.
- 
+- Improved the runtime performance of :func:`~qiskit.synthesis.synth_qft_full` by
+  migrating the implementation to Rust. Benchmarks show speedups ranging from 9x at
+  5 qubits to ~31x at 200 qubits, and 18x at 1000 qubits. The reduction at large
+  qubit counts reflects that circuit construction becomes dominated by memory
+  allocation rather than Python dispatch overhead.
+  See `#16789 <https://github.com/Qiskit/qiskit/pull/16789>`__.


### PR DESCRIPTION
### Summary
Migrates synth_qft_full from a pure-Python implementation to Rust. The implementation includes:
- crates/synthesis/src/qft/qft_decompose_full.rs -  construct the textbook Quantum Fourier Transform (QFT) circuit.
- qiskit/synthesis/qft/qft_decompose_full.py - thin Python wrapper that delegates circuit construction to Rust. The inverse, when needed, is performed in Python because the Rust API currently does not provide an equivalent CircuitData function.
- All existing tests passed. Additinally, tested correctness by comparing the current implementation against the original version as follows:
    - Unitary equivalence - exact Operator comparison for all parameter combinations up to 12 qubits.
    - Gate-sequence match - instruction-level comparison (gate name, qubit indices, angles rounded to 12 decimal places) up to 100 qubits.
    - Gate-count formula - verifies H, CP, and Swap counts against the closed-form formula for circuits up to 1000 qubits.

### Performance

Benchmarking compares the Rust implementation (current branch) against the original Python version (main branch):
| Number of qubits | Python (ms) | Rust (ms) | Speedup |
|-----------------:|------------:|----------:|---------:|
| 5    | 0.0548    | 0.0060    | 9.2x  |
| 10   | 0.1675    | 0.0098    | 17.2x |
| 20   | 0.5802    | 0.0208    | 28.0x |
| 50   | 3.3801    | 0.1020    | 33.1x |
| 100  | 13.6543   | 0.4142    | 33.0x |
| 200  | 53.9664   | 1.7819    | 30.3x |
| 500  | 361.6054  | 20.0564   | 18.0x |
| 1000 | 1405.1210 | 128.3175  | 11.0x |

Speedup ranges from ~9x at 5 qubits up to ~30x at 200 qubits. The decrease at large sizes reflects that circuit construction overhead becomes dominated by memory allocation for the instruction list rather than Python dispatch cost.

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [X] I used the following tool to help write this PR description: IBM Bob 2.0.3; I reviewed and checked the tool's suggestions. I also used it to create the local correctness tests.
- [ ] I used the following tool to generate or modify code: 
