### PR TITLE
Upgrade `bytemuck` traits on `Qubit`/`Clbit` to `Pod`

### DIFF
--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -40,16 +40,16 @@ pub mod var_stretch_container;
 mod variable_mapper;
 pub mod vf2;
 
-use bytemuck::AnyBitPattern;
+use bytemuck::{Pod, Zeroable};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PySequence, PyString, PyTuple};
 
-#[derive(Copy, Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq, FromPyObject, AnyBitPattern)]
+#[derive(Copy, Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq, FromPyObject, Zeroable, Pod)]
 #[repr(transparent)]
 pub struct Qubit(pub u32);
 
-#[derive(Copy, Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq, FromPyObject, AnyBitPattern)]
+#[derive(Copy, Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq, FromPyObject, Zeroable, Pod)]
 #[repr(transparent)]
 pub struct Clbit(pub u32);
 


### PR DESCRIPTION
We previously used a weaker form of this marker (`AnyBitPattern`), which was suitable for casting from `u32` into `Qubit`/`Clbit`, but the reverse needed an additional assertion of `NoUninit`.

In fact, `Qubit` and `Clbit` are both `repr(transparent)` around a _public_ `u32`, so safe Rust code can already make these any `u32`, and `u32` implements top of the trait tree in `Pod`.  Marking `Qubit` and `Clbit` as `Pod` in `bytemuck` allows all casts between these types, without exposing surface that wasn't already possible in safe Rust.

---

My immediate motivation is because I need to cast `&[Qubit]` to `&[u32]`, and we don't currently have the trait impls to permit that direction (only the reverse).

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
