### PR TITLE
Allow null pointer in `qk_circuit_barrier`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,6 +2320,7 @@ name = "qiskit-cext"
 version = "2.6.0-dev"
 dependencies = [
  "anyhow",
+ "bytemuck",
  "hashbrown 0.15.5",
  "mimalloc",
  "nalgebra 0.35.0",

--- a/crates/cext/Cargo.toml
+++ b/crates/cext/Cargo.toml
@@ -33,6 +33,7 @@ mimalloc = { workspace = true, optional = true}
 uuid.workspace = true
 num-bigint.workspace = true
 num-traits.workspace = true
+bytemuck.workspace = true
 
 [features]
 python_binding = ["dep:pyo3"]

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -1149,15 +1149,14 @@ pub unsafe extern "C" fn qk_circuit_reset(circuit: *mut CircuitData, qubit: u32)
 pub unsafe extern "C" fn qk_circuit_barrier(
     circuit: *mut CircuitData,
     qubits: *const u32,
-    num_qubits: u32,
+    mut num_qubits: u32,
 ) -> ExitCode {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { mut_ptr_as_ref(circuit) };
     let qubits_base;
     let qubits: &[Qubit] = if qubits.is_null() {
-        qubits_base = (0..circuit.num_qubits() as u32)
-            .map(Qubit)
-            .collect::<Vec<_>>();
+        num_qubits = circuit.num_qubits() as u32;
+        qubits_base = (0..num_qubits).map(Qubit).collect::<Vec<_>>();
         bytemuck::cast_slice(qubits_base.as_slice())
     } else {
         // SAFETY: since it is not null, then per documentation `qubits` is aligned and valid for

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -1123,9 +1123,13 @@ pub unsafe extern "C" fn qk_circuit_reset(circuit: *mut CircuitData, qubit: u32)
 /// @ingroup QkCircuit
 /// Append a barrier to the circuit.
 ///
+/// If `qubits` is `NULL`, then `num_qubits` is ignored and the barrier is applied to all qubits in
+/// the circuit.  This is a convenience; it is more efficient to allocate your own all-qubits buffer
+/// and re-use it, if you need multiple full-width barriers.
+///
 /// @param circuit A pointer to the circuit to add the barrier to.
-/// @param num_qubits The number of qubits wide the barrier is.
 /// @param qubits The pointer to the array of ``uint32_t`` qubit indices to add the barrier on.
+/// @param num_qubits The number of qubits wide the barrier is.  Ignored if `qubits` is null.
 ///
 /// @return An exit code.
 ///
@@ -1138,10 +1142,9 @@ pub unsafe extern "C" fn qk_circuit_reset(circuit: *mut CircuitData, qubit: u32)
 ///
 /// # Safety
 ///
-/// The length of the array ``qubits`` points to must be ``num_qubits``. If there is
-/// a mismatch the behavior is undefined.
-///
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
+/// If `qubits` is not `NULL`, it must be aligned and point to `num_qubits` valid initialized
+/// values that have no duplicates and are all in-bounds for the circuit.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_circuit_barrier(
     circuit: *mut CircuitData,
@@ -1150,17 +1153,23 @@ pub unsafe extern "C" fn qk_circuit_barrier(
 ) -> ExitCode {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { mut_ptr_as_ref(circuit) };
-    // SAFETY: Per the documentation the qubits pointer is an array of num_qubits elements
-    let qubits: Vec<Qubit> = unsafe {
-        (0..num_qubits)
-            .map(|idx| Qubit(*qubits.wrapping_add(idx as usize)))
-            .collect()
+    let qubits_base;
+    let qubits: &[Qubit] = if qubits.is_null() {
+        qubits_base = (0..circuit.num_qubits() as u32)
+            .map(Qubit)
+            .collect::<Vec<_>>();
+        bytemuck::cast_slice(qubits_base.as_slice())
+    } else {
+        // SAFETY: since it is not null, then per documentation `qubits` is aligned and valid for
+        // `num_qubits` reads of initialized data.
+        let as_u32 = unsafe { std::slice::from_raw_parts(qubits, num_qubits as usize) };
+        bytemuck::cast_slice(as_u32)
     };
     circuit
         .push_packed_operation(
             PackedOperation::from_standard_instruction(StandardInstruction::Barrier(num_qubits)),
             None,
-            &qubits,
+            qubits,
             &[],
         )
         .unwrap();

--- a/releasenotes/notes/c-barrier-null-069a46b7b2ce196a.yaml
+++ b/releasenotes/notes/c-barrier-null-069a46b7b2ce196a.yaml
@@ -1,0 +1,8 @@
+---
+features_c:
+  - |
+    :c:func:`qk_circuit_barrier` can now accept a null pointer as the ``qubits`` argument, in which
+    case ``num_qubits`` is ignored, and the barrier is applied to all qubits.
+performance:
+  - |
+    :c:func:`qk_circuit_barrier` no longer re-allocates a temporary buffer to view the `qubits` array.

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -200,6 +200,35 @@ static int test_circuit_copy_empty_like(void) {
     return Ok;
 }
 
+static int test_barrier_null_ptr(void) {
+    int ret = Ok;
+    const uint32_t num_qubits = 16;
+    QkCircuitInstruction a_inst, b_inst;
+    QkCircuit *a = qk_circuit_new(num_qubits, 0);
+    QkCircuit *b = qk_circuit_copy_empty_like(a, QkVarsMode_Alike, QkBlocksMode_Keep);
+
+    uint32_t *all_qubits = malloc(num_qubits * sizeof(*all_qubits));
+    for (uint32_t i = 0; i < num_qubits; i++)
+        all_qubits[i] = i;
+
+    qk_circuit_barrier(a, all_qubits, num_qubits);
+    qk_circuit_barrier(b, NULL, 0);
+    qk_circuit_get_instruction(a, 0, &a_inst);
+    qk_circuit_get_instruction(b, 0, &b_inst);
+    if (num_qubits != a_inst.num_qubits || a_inst.num_qubits != b_inst.num_qubits ||
+        memcmp(a_inst.qubits, all_qubits, num_qubits * sizeof(*all_qubits)) ||
+        memcmp(b_inst.qubits, all_qubits, num_qubits * sizeof(*all_qubits))) {
+        ret = EqualityError;
+    }
+
+    qk_circuit_instruction_clear(&a_inst);
+    qk_circuit_instruction_clear(&b_inst);
+    qk_circuit_free(a);
+    qk_circuit_free(b);
+    free(all_qubits);
+    return ret;
+}
+
 static int test_no_gate_1000_bits(void) {
     QkCircuit *qc = qk_circuit_new(1000, 1000);
     uint32_t num_qubits = qk_circuit_num_qubits(qc);
@@ -1656,6 +1685,7 @@ int test_circuit(void) {
     num_failed += RUN_TEST(test_circuit_copy);
     num_failed += RUN_TEST(test_circuit_copy_with_instructions);
     num_failed += RUN_TEST(test_circuit_copy_empty_like);
+    num_failed += RUN_TEST(test_barrier_null_ptr);
     num_failed += RUN_TEST(test_no_gate_1000_bits);
     num_failed += RUN_TEST(test_get_gate_counts);
     num_failed += RUN_TEST(test_get_gate_counts_bv_no_measure);


### PR DESCRIPTION
With the other modification in this commit to avoid the unnecessary iteration through the `qubits` array, it's actually more efficient to do full-width barriers yourself with a manual buffer, but this is a common convenience operation, and it's plausible we could add a fast path for it through Rust in the future too.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
