### PR TITLE
Remove pylib from circuit crate

### DIFF
--- a/crates/bindgen/pyo3-ffi/Cargo.lock
+++ b/crates/bindgen/pyo3-ffi/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.29.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
  "libc",
  "once_cell",
@@ -75,18 +75,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.29.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.29.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.29.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -106,12 +106,13 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.29.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",
+ "pyo3-build-config",
  "quote",
  "syn",
 ]

--- a/crates/cext/Cargo.toml
+++ b/crates/cext/Cargo.toml
@@ -36,5 +36,5 @@ num-traits.workspace = true
 bytemuck.workspace = true
 
 [features]
-python_binding = ["dep:pyo3"]
+python_binding = ["dep:pyo3", "qiskit-circuit/py"]
 cache_pygates = ["qiskit-circuit/cache_pygates", "qiskit-transpiler/cache_pygates"]

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -2481,7 +2481,7 @@ pub unsafe extern "C" fn qk_circuit_draw(
         (true, true, None)
     };
 
-    let circuit_str = draw_circuit(circuit, bundle_cregs, merge_wires, fold).unwrap();
+    let circuit_str = draw_circuit(circuit, bundle_cregs, merge_wires, fold);
 
     CString::new(circuit_str).unwrap().into_raw()
 }

--- a/crates/circuit/Cargo.toml
+++ b/crates/circuit/Cargo.toml
@@ -40,6 +40,7 @@ lexical-write-float = "1.0.6"
 [dependencies.pyo3]
 workspace = true
 features = ["hashbrown", "indexmap", "num-complex", "num-bigint", "smallvec", "py-clone"]
+optional = true
 
 [dependencies.approx]
 workspace = true
@@ -62,4 +63,5 @@ workspace = true
 features = ["nalgebra"]
 
 [features]
-cache_pygates = []
+py = ["dep:pyo3"]
+cache_pygates = ["py"]

--- a/crates/circuit/src/annotation.rs
+++ b/crates/circuit/src/annotation.rs
@@ -10,8 +10,11 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+#[cfg(feature = "py")]
 use pyo3::intern;
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
+#[cfg(feature = "py")]
 use pyo3::types::PyString;
 
 /// An arbitrary annotation for instructions.
@@ -47,8 +50,10 @@ use pyo3::types::PyString;
 /// :func:`.transpile` or :func:`.generate_preset_pass_manager` to ensure that the compiler passes
 /// selected will not invalidate the annotation.  We expect to have more first-class support for
 /// annotations to declare their validity requirements in the future.
+#[cfg(feature = "py")]
 #[pyclass(module = "qiskit.circuit", name = "Annotation", subclass, frozen)]
 pub struct PyAnnotation;
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyAnnotation {
     #[allow(unused_variables)]

--- a/crates/circuit/src/bit.rs
+++ b/crates/circuit/src/bit.rs
@@ -19,16 +19,22 @@ use std::{
     sync::atomic::{AtomicU32, AtomicU64, Ordering},
 };
 
+#[cfg(feature = "py")]
 use hashbrown::HashSet;
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
+#[cfg(feature = "py")]
 use pyo3::{
     IntoPyObjectExt, PyTypeInfo,
     exceptions::{PyIndexError, PyTypeError, PyValueError},
     types::{PyList, PyType},
 };
 
+#[cfg(feature = "py")]
 use crate::circuit_data::CircuitError;
+#[cfg(feature = "py")]
 use crate::dag_circuit::PyBitLocations;
+#[cfg(feature = "py")]
 use qiskit_util::py::{PySequenceIndex, SequenceIndex};
 
 /// Describes a relationship between a bit and all the registers it belongs to
@@ -73,6 +79,7 @@ impl<R: Register + PartialEq> BitLocations<R> {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'py, R> IntoPyObject<'py> for BitLocations<R>
 where
     R: Debug + Clone + Register + for<'a> IntoPyObject<'a>,
@@ -93,6 +100,7 @@ where
     }
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py, R> FromPyObject<'a, 'py> for BitLocations<R>
 where
     R: Debug
@@ -159,6 +167,7 @@ trait ManifestableBit: ShareableBit {
 /// .. note::
 ///     This class cannot be instantiated directly. Its only purpose is to allow generic type
 ///     checking for :class:`.Clbit` and :class:`.Qubit`.
+#[cfg(feature = "py")]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[pyclass(
     subclass,
@@ -173,6 +182,7 @@ pub struct PyBit;
 /// .. note::
 ///     This class cannot be instantiated directly.  Its only purpose is to allow generic type
 ///     checking for :class:`~.ClassicalRegister` and :class:`~.QuantumRegister`.
+#[cfg(feature = "py")]
 #[pyclass(
     name = "Register",
     module = "qiskit.circuit",
@@ -431,10 +441,12 @@ macro_rules! create_bit_object {
             }
         }
 
+        #[cfg(feature = "py")]
         #[doc = concat!("A ", $bit_desc, ", which can be compared between different circuits.")]
         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
         #[pyclass(subclass, name=$pybit_name, module="qiskit.circuit", extends=PyBit, frozen, eq, hash, skip_from_py_object)]
         pub struct $pybit_struct($bit_struct);
+        #[cfg(feature = "py")]
         #[pymethods]
         impl $pybit_struct {
             /// Create a new bit.
@@ -495,7 +507,7 @@ macro_rules! create_bit_object {
                         ty.getattr("_from_owned")?,
                         (register.name.to_owned(), register.size, index),
                     )
-                        .into_bound_py_any(slf.py()),
+                    .into_bound_py_any(slf.py()),
                     // Don't need to examine the subclass, because it's handled by the overrides of
                     // the `_from_anonymous` and `_from_owned` methods.
                     BitInfo::Anonymous { uid, .. } => {
@@ -563,6 +575,7 @@ macro_rules! create_bit_object {
             }
         }
 
+        #[cfg(feature = "py")]
         impl<'a, 'py> FromPyObject<'a, 'py> for $bit_struct {
             type Error = ::pyo3::CastError<'a, 'py>;
 
@@ -570,6 +583,7 @@ macro_rules! create_bit_object {
                 ob.cast::<$pybit_struct>().map(|ob| ob.borrow().0.clone())
             }
         }
+        #[cfg(feature = "py")]
         // The owning impl of `IntoPyObject` needs to be done manually, to better handle
         // subclassing.
         impl<'a, 'py> IntoPyObject<'py> for &'a $bit_struct {
@@ -693,6 +707,7 @@ macro_rules! create_bit_object {
             }
         }
 
+        #[cfg(feature = "py")]
         impl<'a, 'py> FromPyObject<'a, 'py> for $reg_struct {
             type Error = ::pyo3::CastError<'a, 'py>;
 
@@ -700,6 +715,7 @@ macro_rules! create_bit_object {
                 ob.cast::<$pyreg_struct>().map(|ob| ob.borrow().0.clone())
             }
         }
+        #[cfg(feature = "py")]
         // The owning impl of `IntoPyObject` needs to be done manually, to better handle
         // subclassing.
         impl<'a, 'py> IntoPyObject<'py> for &'a $reg_struct {
@@ -712,11 +728,13 @@ macro_rules! create_bit_object {
             }
         }
 
+        #[cfg(feature = "py")]
         /// Implement a register.
         #[pyclass(subclass, name=$pyreg_name, module="qiskit.circuit", extends=PyRegister, frozen, eq, hash, sequence, skip_from_py_object)]
         #[derive(Clone, Debug, PartialEq, Eq, Hash)]
         pub struct $pyreg_struct($reg_struct);
 
+        #[cfg(feature = "py")]
         #[pymethods]
         impl $pyreg_struct {
             /// Create a new register.
@@ -819,8 +837,8 @@ macro_rules! create_bit_object {
             fn __getitem__<'py>(&self, ob: Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
                 let get_inner = |idx| {
                     self.0
-                        .get(idx)
-                        .expect("PySequenceIndex always returns valid indices")
+                    .get(idx)
+                    .expect("PySequenceIndex always returns valid indices")
                 };
                 if let Ok(sequence) = ob.extract::<PySequenceIndex>() {
                     match sequence.with_len(self.0.len())? {
@@ -845,13 +863,13 @@ macro_rules! create_bit_object {
             fn index(&self, bit: Bound<$pybit_struct>) -> PyResult<usize> {
                 let bit_inner = bit.borrow();
                 self.0
-                    .index_of(&bit_inner.0)
-                    .ok_or_else(|| match bit.repr() {
-                        Ok(repr) => {
-                            PyValueError::new_err(format!("Bit {repr} not found in register."))
-                        }
-                        Err(err) => err,
-                    })
+                .index_of(&bit_inner.0)
+                .ok_or_else(|| match bit.repr() {
+                    Ok(repr) => {
+                        PyValueError::new_err(format!("Bit {repr} not found in register."))
+                    }
+                    Err(err) => err,
+                })
             }
 
             /// Allows for the creation of a new register with a temporary prefix and the
@@ -886,6 +904,7 @@ macro_rules! create_bit_object {
             }
         }
 
+        #[cfg(feature = "py")]
         impl ::std::ops::Deref for $pyreg_struct {
             type Target = $reg_struct;
             fn deref(&self) -> &Self::Target {
@@ -936,9 +955,11 @@ impl ShareableQubit {
 }
 
 /// A qubit used as an ancilla.
+#[cfg(feature = "py")]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[pyclass(name="AncillaQubit", module="qiskit.circuit", extends=PyQubit, frozen, skip_from_py_object)]
 pub struct PyAncillaQubit;
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyAncillaQubit {
     /// Create a new anonymous ancilla qubit.
@@ -996,6 +1017,7 @@ impl PyAncillaQubit {
         .into_any())
     }
 }
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for ShareableQubit {
     type Target = PyAny;
     type Output = Bound<'py, PyAny>;
@@ -1050,6 +1072,7 @@ impl QuantumRegister {
 }
 // This isn't intended for use from Rust space.
 /// Implement an ancilla register.
+#[cfg(feature = "py")]
 #[pyclass(
     name = "AncillaRegister",
     module = "qiskit.circuit",
@@ -1059,6 +1082,7 @@ impl QuantumRegister {
 )]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PyAncillaRegister;
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyAncillaRegister {
     // Most of the methods are inherited from `QuantumRegister` in Python space.
@@ -1127,6 +1151,7 @@ impl PyAncillaRegister {
         PyAncillaQubit::type_object(py)
     }
 }
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for QuantumRegister {
     type Target = PyAny;
     type Output = Bound<'py, PyAny>;
@@ -1169,7 +1194,9 @@ create_bit_object!(
     CLBIT_INSTANCES,
     CLASSICAL_REGISTER_INSTANCES
 );
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for ShareableClbit {
+    #[cfg(feature = "py")]
     type Target = PyClbit;
     type Output = Bound<'py, PyClbit>;
     type Error = PyErr;
@@ -1179,6 +1206,7 @@ impl<'py> IntoPyObject<'py> for ShareableClbit {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for ClassicalRegister {
     type Target = PyClassicalRegister;
     type Output = Bound<'py, PyClassicalRegister>;

--- a/crates/circuit/src/bit_locator.rs
+++ b/crates/circuit/src/bit_locator.rs
@@ -10,10 +10,14 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use std::{fmt::Debug, hash::Hash, sync::OnceLock};
+#[cfg(feature = "py")]
+use std::sync::OnceLock;
+use std::{fmt::Debug, hash::Hash};
 
 use crate::bit::{BitLocations, Register};
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
+#[cfg(feature = "py")]
 use pyo3::types::{IntoPyDict, PyDict};
 use qiskit_util::IndexMap;
 
@@ -22,6 +26,7 @@ use qiskit_util::IndexMap;
 #[derive(Debug)]
 pub struct BitLocator<B, R: Register> {
     bit_locations: IndexMap<B, BitLocations<R>>,
+    #[cfg(feature = "py")]
     cached: OnceLock<Py<PyDict>>,
 }
 
@@ -34,6 +39,7 @@ where
     fn clone(&self) -> Self {
         Self {
             bit_locations: self.bit_locations.clone(),
+            #[cfg(feature = "py")]
             cached: OnceLock::new(),
         }
     }
@@ -63,6 +69,7 @@ where
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             bit_locations: IndexMap::with_capacity_and_hasher(capacity, Default::default()),
+            #[cfg(feature = "py")]
             cached: OnceLock::new(),
         }
     }
@@ -72,6 +79,7 @@ where
     /// If the bit was already tracked, its locations are updated with the new ones, and the old
     /// ones are returned.
     pub fn insert(&mut self, bit: B, location: BitLocations<R>) -> Option<BitLocations<R>> {
+        #[cfg(feature = "py")]
         self.cached.take();
         self.bit_locations.insert(bit, location)
     }
@@ -83,6 +91,7 @@ where
 
     /// Get the locations of a bit for mutation, if it is tracked.
     pub fn get_mut(&mut self, bit: &B) -> Option<&mut BitLocations<R>> {
+        #[cfg(feature = "py")]
         self.cached.take();
         self.bit_locations.get_mut(bit)
     }
@@ -96,10 +105,12 @@ where
     /// Note: INVALIDATES THIS INSTANCE.
     pub fn dispose(&mut self) {
         self.bit_locations.clear();
+        #[cfg(feature = "py")]
         self.cached.take();
     }
 }
 
+#[cfg(feature = "py")]
 impl<B, R> BitLocator<B, R>
 where
     B: Debug

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -10,27 +10,36 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use std::convert::Infallible;
 use std::fmt::Debug;
+
+#[cfg(feature = "py")]
 use std::hash::Hash;
+#[cfg(feature = "py")]
 use std::ops::Deref;
 #[cfg(feature = "cache_pygates")]
 use std::sync::OnceLock;
 
+#[cfg(feature = "py")]
+use crate::bit::PyBit;
 use crate::bit::{
-    BitLocations, ClassicalRegister, PyBit, QuantumRegister, Register, ShareableClbit,
-    ShareableQubit,
+    BitLocations, ClassicalRegister, QuantumRegister, Register, ShareableClbit, ShareableQubit,
 };
 use crate::bit_locator::BitLocator;
+#[cfg(feature = "py")]
 use crate::circuit_instruction::{CircuitInstruction, OperationFromPython};
 use crate::classical::expr;
 use crate::dag_circuit::{DAGCircuit, add_global_phase};
+#[cfg(feature = "py")]
 use crate::imports::{ANNOTATED_OPERATION, QUANTUM_CIRCUIT};
 use crate::instruction::Parameters;
 use crate::interner::{Interned, InternedMap, Interner};
 use crate::object_registry::{self, ObjectRegistry};
+#[cfg(feature = "py")]
+use crate::operations::{BoxedCustomOperation, PyOpKind, PythonOperation};
 use crate::operations::{
-    BoxedCustomOperation, ControlFlow, ControlFlowView, LoopParam, Operation, OperationRef, Param,
-    PauliBased, PauliProductRotation, PyOpKind, PythonOperation, StandardGate,
+    ControlFlow, ControlFlowView, LoopParam, Operation, OperationRef, Param, PauliBased,
+    PauliProductRotation, StandardGate,
 };
 use crate::packed_instruction::{PackedInstruction, PackedOperation};
 use crate::parameter::parameter_expression::{ParameterError, ParameterExpression};
@@ -40,19 +49,30 @@ use crate::register_data::{RegisterAlreadyExists, RegisterData};
 use crate::var_stretch_container::{
     StretchType, VarStretchContainer, VarStretchContainerError, VarType,
 };
+
+#[cfg(feature = "py")]
+use crate::instruction;
 use crate::{
     Block, BlocksMode, CapacityError, Clbit, ControlFlowBlocks, Qubit, Stretch, Var, VarsMode,
-    instruction,
 };
-use qiskit_util::py::{PySequenceIndex, SequenceIndex};
+#[cfg(feature = "py")]
+use qiskit_util::py::PySequenceIndex;
+use qiskit_util::py::SequenceIndex;
 
 use ndarray::ArrayView1;
+#[cfg(feature = "py")]
 use num_complex::Complex64;
+#[cfg(feature = "py")]
 use numpy::PyReadonlyArray1;
+#[cfg(feature = "py")]
 use pyo3::IntoPyObjectExt;
+#[cfg(feature = "py")]
 use pyo3::exceptions::{PyRuntimeError, PyTypeError, PyValueError};
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
+#[cfg(feature = "py")]
 use pyo3::types::{IntoPyDict, PyDict, PyList, PySet, PyTuple, PyType};
+#[cfg(feature = "py")]
 use pyo3::{PyTraverseError, PyVisit, import_exception, intern};
 
 use hashbrown::{HashMap, HashSet};
@@ -60,6 +80,7 @@ use qiskit_util::IndexMap;
 use smallvec::SmallVec;
 use thiserror::Error;
 
+#[cfg(feature = "py")]
 import_exception!(qiskit.circuit.exceptions, CircuitError);
 
 /// This struct models the error conditions that can be raised from the
@@ -86,6 +107,7 @@ pub enum CircuitDataError {
     #[error("{0} at index {1} exceeds circuit capacity.")]
     BitExceedsCapacity(String, usize),
     // Explicitly an error returned from calling Python
+    #[cfg(feature = "py")]
     #[error(transparent)]
     ErrorFromPython(#[from] PyErr),
     #[error(transparent)]
@@ -114,6 +136,13 @@ impl<T: Debug, B: Debug> From<object_registry::AddError<T, B>> for CircuitDataEr
     }
 }
 
+impl From<Infallible> for CircuitDataError {
+    fn from(value: Infallible) -> Self {
+        match value {}
+    }
+}
+
+#[cfg(feature = "py")]
 impl From<CircuitDataError> for PyErr {
     fn from(error: CircuitDataError) -> Self {
         match error {
@@ -146,6 +175,7 @@ impl From<CircuitDataError> for PyErr {
     }
 }
 
+#[cfg(feature = "py")]
 /// A tuple of a `CircuitData`'s internal state used for pickle's `__setstate__()` method.
 type CircuitDataState<'py> = (
     Vec<QuantumRegister>,
@@ -266,6 +296,7 @@ pub struct CircuitData {
 /// Raises:
 ///     KeyError: if ``data`` contains a reference to a bit that is not present
 ///         in ``qubits`` or ``clbits``.
+#[cfg(feature = "py")]
 #[pyclass(
     name = "CircuitData",
     sequence,
@@ -277,18 +308,21 @@ pub struct PyCircuitData {
     pub inner: CircuitData,
 }
 
+#[cfg(feature = "py")]
 impl From<CircuitData> for PyCircuitData {
     fn from(data: CircuitData) -> Self {
         PyCircuitData { inner: data }
     }
 }
 
+#[cfg(feature = "py")]
 impl From<PyCircuitData> for CircuitData {
     fn from(data: PyCircuitData) -> Self {
         data.inner
     }
 }
 
+#[cfg(feature = "py")]
 impl Deref for PyCircuitData {
     type Target = CircuitData;
 
@@ -491,6 +525,7 @@ impl CircuitData {
         self.data.reserve(additional);
     }
 
+    #[cfg(feature = "py")]
     /// Move this [CircuitData] into a complete Python `QuantumCircuit` object.
     pub fn into_py_quantum_circuit(self, py: Python) -> PyResult<Bound<PyAny>> {
         let py_circuit_data: PyCircuitData = self.into();
@@ -667,6 +702,7 @@ impl CircuitData {
         Ok(out)
     }
 
+    #[cfg(feature = "py")]
     /// Clone a new [CircuitData] from a [DAGCircuit], but applying a Python deepcopy
     ///
     /// This is the logical equivalent of Python's `dag_to_circuit`.
@@ -1247,6 +1283,7 @@ impl CircuitData {
                         HashMap::from([(symbol.clone(), e.as_ref().clone())]);
                     expr.subs(&map, false)?
                 }
+                #[cfg(feature = "py")]
                 Param::Obj(ob) => {
                     Python::attach(|py| -> Result<_, CircuitDataError> {
                         // The integer handling is only needed to support the case where an int is
@@ -1277,9 +1314,13 @@ impl CircuitData {
                 }
             };
             // Param::from_expr() only errors in the python path when calling Python
-            Ok(Param::from_expr(new_expr, coerce)?)
+            #[cfg(feature = "py")]
+            return Ok(Param::from_expr(new_expr, coerce)?);
+            #[cfg(not(feature = "py"))]
+            return Param::from_expr(new_expr, coerce).ok_or(CircuitDataError::InvalidParameter);
         };
 
+        #[cfg(feature = "py")]
         let mut user_operations = HashMap::new();
         let mut uuids = Vec::new();
         // Mark blocks that we've already edited.
@@ -1288,8 +1329,9 @@ impl CircuitData {
             debug_assert!(!uses.is_empty());
             seen_blocks.clear();
             uuids.clear();
+
             for inner_symbol in value.as_ref().iter_parameters()? {
-                uuids.push(self.param_table.track(&inner_symbol, None)?)
+                uuids.push(self.param_table.track(&inner_symbol, None)?);
             }
             for usage in uses {
                 let (instruction, parameter) = match usage {
@@ -1331,6 +1373,7 @@ impl CircuitData {
                         let new_param = bind_expr(expr, &symbol, value.as_ref(), true)?;
 
                         // standard gates don't allow for complex parameters
+                        #[cfg(feature = "py")]
                         if let Param::Obj(expr) = &new_param {
                             return Err(CircuitDataError::StandardGateParameterIsComplex(
                                 previous.op.name().to_string(),
@@ -1395,6 +1438,7 @@ impl CircuitData {
                             previous.py_op.take();
                         }
                     }
+                    #[cfg(feature = "py")]
                     OperationRef::PyCustom(inst) => {
                         // Track user operations we've seen so we can rebind their definitions.
                         // Strictly this can add the same binding pair more than once, if an
@@ -1499,6 +1543,7 @@ impl CircuitData {
         }
 
         // handle custom gates, this can only happen in Py-space
+        #[cfg(feature = "py")]
         if !user_operations.is_empty() {
             Python::attach(|py| -> PyResult<()> {
                 let _definition_attr = intern!(py, "_definition");
@@ -1644,6 +1689,7 @@ impl CircuitData {
     /// Add a param to the current global phase of the circuit
     pub fn add_global_phase(&mut self, value: &Param) -> Result<(), CircuitDataError> {
         match value {
+            #[cfg(feature = "py")]
             Param::Obj(_) => Err(CircuitDataError::InvalidGlobalPhaseType),
             _ => self.set_global_phase_param(add_global_phase(&self.global_phase, value)),
         }
@@ -1879,6 +1925,7 @@ impl CircuitData {
 /// PyO3-provided `FromPyObject` implementations on containers.
 #[repr(transparent)]
 struct AssignParam(Param);
+#[cfg(feature = "py")]
 impl<'a, 'py> FromPyObject<'a, 'py> for AssignParam {
     type Error = PyErr;
 
@@ -1903,6 +1950,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for AssignParam {
 ///     A list of the specified bits from `bits`. The `PyResult` error will contain a Python
 ///     `CircuitError` if an incorrect type or index is encountered, if the same bit is specified
 ///     more than once, or if the specifier is to a bit not in the `bit_set`.
+#[cfg(feature = "py")]
 fn bit_argument_conversion<B, R>(
     specifier: &Bound<PyAny>,
     bit_sequence: &[B],
@@ -1970,6 +2018,7 @@ where
     }
 }
 
+#[cfg(feature = "py")]
 fn bit_argument_conversion_scalar<B, R>(
     specifier: &Bound<PyAny>,
     bit_sequence: &[B],
@@ -2072,6 +2121,7 @@ fn for_each_symbol_use_in_control_flow(
     Ok(())
 }
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyCircuitData {
     #[new]
@@ -3306,6 +3356,7 @@ impl PyCircuitData {
     }
 }
 
+#[cfg(feature = "py")]
 impl PyCircuitData {
     pub fn pack(&mut self, py: Python, inst: &CircuitInstruction) -> PyResult<PackedInstruction> {
         let qubits = self.inner.qargs_interner.insert_owned(
@@ -3425,13 +3476,12 @@ impl PyCircuitData {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::converters::py_dag_to_circuit;
     use crate::dag_circuit::DAGCircuit;
     use crate::operations::{ArrayType, PauliProductMeasurement, UnitaryGate};
     use nalgebra::{Matrix2, Matrix4};
 
     #[test]
-    fn packed_pointer_types_behave() -> PyResult<()> {
+    fn packed_pointer_types_behave() -> Result<(), CircuitDataError> {
         // This is largely to exercise the packed-pointer logic under debug builds (since the
         // Python-space tests run with Rust in release mode) and Miri.
 
@@ -3497,9 +3547,8 @@ mod test {
         };
         let other = qc.clone();
         check(&qc, &other);
-        let roundtrip = py_dag_to_circuit(
-            &DAGCircuit::from_circuit_data(&qc, false, None, None)?.into(),
-            false,
+        let roundtrip = CircuitData::from_dag_ref(
+            &DAGCircuit::from_circuit_data(&qc, false, None, None).unwrap(),
         )?;
         check(&qc, &roundtrip);
         Ok(())

--- a/crates/circuit/src/circuit_drawer.rs
+++ b/crates/circuit/src/circuit_drawer.rs
@@ -21,7 +21,6 @@ use hashbrown::HashSet;
 use itertools::{Itertools, MinMaxResult};
 use lexical_core::ToLexicalWithOptions;
 use lexical_write_float::{self, format::STANDARD};
-use pyo3::prelude::*;
 use std::f64::consts::PI;
 use std::fmt::Debug;
 use std::ops::Index;
@@ -45,8 +44,8 @@ pub fn draw_circuit(
     cregbundle: bool,
     mergewires: bool,
     fold: Option<usize>,
-) -> PyResult<String> {
-    let vis_mat = VisualizationMatrix::from_circuit(circuit, cregbundle)?;
+) -> String {
+    let vis_mat = VisualizationMatrix::from_circuit(circuit, cregbundle);
 
     let text_drawer = TextDrawer::from_visualization_matrix(&vis_mat, cregbundle);
 
@@ -91,7 +90,7 @@ pub fn draw_circuit(
     {
         output.pop();
     }
-    Ok(output)
+    output
 }
 
 /// Return a list of layers such that each layer contains a list of op node indices, representing instructions
@@ -539,7 +538,7 @@ struct VisualizationMatrix<'a> {
 }
 
 impl<'a> VisualizationMatrix<'a> {
-    fn from_circuit(circuit: &'a CircuitData, bundle_cregs: bool) -> PyResult<Self> {
+    fn from_circuit(circuit: &'a CircuitData, bundle_cregs: bool) -> Self {
         let inst_layers = build_layers(circuit);
 
         let num_wires = circuit.num_qubits()
@@ -606,11 +605,11 @@ impl<'a> VisualizationMatrix<'a> {
             }
         }
 
-        Ok(VisualizationMatrix {
+        VisualizationMatrix {
             layers,
             circuit,
             clbit_map,
-        })
+        }
     }
 
     fn num_wires(&self) -> usize {
@@ -851,6 +850,7 @@ impl TextDrawer {
                             Param::ParameterExpression(expr) => {
                                 format!("Delay({}[{}])", expr, delay_unit)
                             }
+                            #[cfg(feature = "py")]
                             Param::Obj(obj) => format!("Delay({:?}[{}])", obj, delay_unit), // TODO: extract the int
                         }
                     }
@@ -897,6 +897,7 @@ impl TextDrawer {
             OperationRef::PauliProductRotation(ppr) => match &ppr.angle {
                 Param::Float(f) => format!("PPR({})", F64UiFormatter::new(5).format_with_pi(*f)),
                 Param::ParameterExpression(e) => format!("PPR({})", e),
+                #[cfg(feature = "py")]
                 Param::Obj(o) => format!("PPR({:?})", o),
                 Param::Int(i) => format!("PPR({:?})", i),
             },
@@ -1577,7 +1578,7 @@ mod tests {
     fn test_creg_bundle() {
         let circuit = basic_circuit();
 
-        let result = draw_circuit(&circuit, true, false, None).unwrap();
+        let result = draw_circuit(&circuit, true, false, None);
 
         let expected = "
       ┌───┐
@@ -1600,7 +1601,7 @@ c2: 2/══════════
     fn test_merge_wires() {
         let circuit = basic_circuit();
 
-        let result = draw_circuit(&circuit, false, true, None).unwrap();
+        let result = draw_circuit(&circuit, false, true, None);
         let expected = "
       ┌───┐
  q_0: ┤ H ├──■──
@@ -1650,7 +1651,7 @@ c2_1: ══════════
         };
         circuit.push(inst).unwrap();
 
-        let result = draw_circuit(&circuit, false, false, Some(100)).unwrap();
+        let result = draw_circuit(&circuit, false, false, Some(100));
         let expected = "
    ┌───┐┌─┐
 q: ┤ H ├┤M├
@@ -1693,7 +1694,7 @@ c: ══════╩═
             .push_standard_gate(StandardGate::H, &[], &[Qubit::new(1)])
             .unwrap();
 
-        let result = draw_circuit(&circuit, false, false, Some(100)).unwrap();
+        let result = draw_circuit(&circuit, false, false, Some(100));
         let expected = "
       ┌───┐
    q: ┤ H ├
@@ -1728,7 +1729,7 @@ cr_1: ═════
             .push_standard_gate(StandardGate::CZ, &[], &[Qubit::new(0), Qubit::new(1)])
             .unwrap();
 
-        let result = draw_circuit(&circuit, false, false, Some(10)).unwrap();
+        let result = draw_circuit(&circuit, false, false, Some(10));
         let expected = "
       ┌───┐     »
  q_0: ┤ H ├──■──»
@@ -1793,7 +1794,7 @@ c2_1: ══════════»
         let mut inst_clone = circuit.data()[0].clone();
         inst_clone.label = Some(Box::new("my_ch".to_string()));
         circuit.push(inst_clone).unwrap();
-        let result = draw_circuit(&circuit, false, false, Some(80)).unwrap();
+        let result = draw_circuit(&circuit, false, false, Some(80));
         let expected = "
           ┌────────────┐┌───────────────┐
 q_0: ──■──┤0 Rxx(1.23) ├┤0 my_rxx(1.23) ├────■────
@@ -1922,7 +1923,7 @@ q_1: ┤ H ├┤1           ├┤1              ├┤ my_ch ├
             py_op: OnceLock::new(),
         };
         circuit.push(inst).unwrap();
-        let result = draw_circuit(&circuit, false, false, Some(80)).unwrap();
+        let result = draw_circuit(&circuit, false, false, Some(80));
         let expected = "
           ┌─────────┐                  ┌────────────────────┐┌──────────┐»
 q_0: ─────┤ Unitary ├──────────────────┤0                   ├┤2         ├»
@@ -1976,7 +1977,7 @@ q_3: ──────────────────────┤1     
                 .collect::<Vec<Param>>();
             circuit.push_standard_gate(op, &params, &qubits).unwrap();
         }
-        let result = draw_circuit(&circuit, false, false, Some(80)).unwrap();
+        let result = draw_circuit(&circuit, false, false, Some(80));
         let expected = "
      ┌───┐  ┌───────────┐      ┌─────┐   ┌─────┐ ┌───────────────────────┐          »
 q_0: ┤ Y ├──┤ Rx(3.141) ├──────┤ Sdg ├───┤ Tdg ├─┤ U3(3.141,3.141,3.141) ├──■───────»
@@ -2063,7 +2064,7 @@ q_4: ─────────────────────────
     fn test_global_phase() {
         let mut circuit = basic_circuit();
         circuit.set_global_phase_param(3.14.into()).unwrap();
-        let result = draw_circuit(&circuit, true, false, None).unwrap();
+        let result = draw_circuit(&circuit, true, false, None);
 
         let expected = "
 global phase: 3.14
@@ -2090,7 +2091,7 @@ c2: 2/══════════
                 ParameterExpression::from_symbol(Symbol::standalone("ϕ".to_owned(), None)),
             )))
             .unwrap();
-        let result = draw_circuit(&circuit, true, false, Some(80)).unwrap();
+        let result = draw_circuit(&circuit, true, false, Some(80));
 
         let expected = "
 global phase: ϕ
@@ -2132,7 +2133,7 @@ c2: 2/══════════
                 &[Qubit(0), Qubit(1)],
             )
             .unwrap();
-        let result = draw_circuit(&circuit, false, false, Some(100)).unwrap();
+        let result = draw_circuit(&circuit, false, false, Some(100));
         let expected = "
      ┌─────────┐┌────────────┐┌─────────┐
 q_0: ┤0 Rxx(a) ├┤0 my_rxx(a) ├┤0 Rzx(2) ├
@@ -2219,7 +2220,7 @@ q_1: ┤1        ├┤1           ├┤1        ├
             circuit.push(inst).unwrap();
         }
 
-        let result = draw_circuit(&circuit, false, false, Some(100)).unwrap();
+        let result = draw_circuit(&circuit, false, false, Some(100));
         let expected = "
           ┌────────────────┐┌────────────────┐┌────────────────┐┌────────────────┐┌───────────────┐ ░  ░ »
 q_0: ─|0>─┤ Delay(2.1[ns]) ├┤ Delay(2.1[ps]) ├┤ Delay(2.1[us]) ├┤ Delay(2.1[ms]) ├┤ Delay(2.1[s]) ├─░──░─»
@@ -2296,7 +2297,7 @@ c_3: ═════════════════════════
                 &[Qubit(0), Qubit(1)],
             )
             .unwrap();
-        let result = draw_circuit(&circuit, false, false, Some(100)).unwrap();
+        let result = draw_circuit(&circuit, false, false, Some(100));
         let expected = "
      ┌─────────┐┌─────────────┐┌─────────┐
 q_0: ┤0 Rxx(ϕ) ├┤0 μου_rxx(ϕ) ├┤0 Rzx(2) ├
@@ -2337,7 +2338,7 @@ q_1: ┤1        ├┤1            ├┤1        ├
                 &[Qubit(0), Qubit(1)],
             )
             .unwrap();
-        let result = draw_circuit(&circuit, false, false, Some(100)).unwrap();
+        let result = draw_circuit(&circuit, false, false, Some(100));
         let expected = "
                ┌───────────┐            ┌──────────────┐┌─────────┐
 q_0: ──────────┤0 Rxx(🎩)  ├────────────┤0  💶🔉(🎩)   ├┤0 Rzx(2) ├
@@ -2390,7 +2391,7 @@ q_1: ┤ Ry(🎩) ├┤1         ├─┤ 💶🔉(🎩) ├─┤1          �
             )
             .unwrap();
 
-        let result = draw_circuit(&circuit, true, true, None).unwrap();
+        let result = draw_circuit(&circuit, true, true, None);
         let expected = "
 global phase: 4π/5
       ┌────────────┐ ┌────────────┐ ┌───────────────┐
@@ -2554,7 +2555,7 @@ q_1: ┤ Rz(1.2346e8) ├┤ Rx(0.12346) ├┤ Rx(1.2346e-5) ├┤ Rx(2π/3) �
             )
             .unwrap();
 
-        let result = draw_circuit(&circuit, true, true, Some(80)).unwrap();
+        let result = draw_circuit(&circuit, true, true, Some(80));
         let expected = "
                       ┌────────────┐┌──────────────┐
  q_0: ────────────────┤0 Z         ├┤0  Z          ├
@@ -2637,7 +2638,7 @@ q_10: ────────────────────────�
             )
             .unwrap();
 
-        let result = draw_circuit(&circuit, true, true, Some(80)).unwrap();
+        let result = draw_circuit(&circuit, true, true, Some(80));
         let expected = "
       ┌───────────┐
 qr_0: ┤0 I        ├───────────────────
@@ -2672,7 +2673,7 @@ cr: 3/══════╩══════════╩══════�
 
         build(&mut circuit);
 
-        let result = draw_circuit(&circuit, false, mergewires, Some(100)).unwrap();
+        let result = draw_circuit(&circuit, false, mergewires, Some(100));
         assert_eq!(result, expected);
     }
 

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -13,29 +13,49 @@
 #[cfg(feature = "cache_pygates")]
 use std::sync::OnceLock;
 
+#[cfg(feature = "py")]
 use numpy::{IntoPyArray, PyArray2, PyReadonlyArray1, PyReadonlyArray2};
+#[cfg(feature = "py")]
 use pyo3::basic::CompareOp;
+#[cfg(feature = "py")]
 use pyo3::exceptions::{PyDeprecationWarning, PyTypeError, PyValueError};
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
 
+#[cfg(feature = "py")]
 use pyo3::IntoPyObjectExt;
+#[cfg(feature = "py")]
 use pyo3::types::{PyBool, PyList, PyTuple, PyType};
+#[cfg(feature = "py")]
 use pyo3::{PyResult, intern};
 
+#[cfg(feature = "py")]
 use crate::circuit_data::{CircuitData, PyCircuitData};
+#[cfg(feature = "py")]
 use crate::dag_circuit::DAGCircuit;
+#[cfg(feature = "py")]
 use crate::duration::Duration;
+#[cfg(feature = "py")]
 use crate::imports::{CONTROLLED_GATE, WARNINGS_WARN};
-use crate::instruction::{Instruction, Parameters, create_py_op};
+#[cfg(feature = "py")]
+use crate::instruction::create_py_op;
+#[cfg(feature = "py")]
+use crate::instruction::{Instruction, Parameters};
+#[cfg(feature = "py")]
 use crate::operations::{
     ArrayType, BoxDuration, ControlFlow, ControlFlowInstruction, ControlFlowType, Operation,
     OperationRef, Param, PauliBased, PauliProductMeasurement, PauliProductRotation, PyInstruction,
     PyOpKind, StandardGate, StandardInstruction, StandardInstructionType, UnitaryGate,
 };
+#[cfg(feature = "py")]
 use crate::packed_instruction::PackedOperation;
+#[cfg(feature = "py")]
 use crate::parameter::parameter_expression::ParameterExpression;
+#[cfg(feature = "py")]
 use nalgebra::{Dyn, MatrixView2, MatrixView4};
+#[cfg(feature = "py")]
 use num_complex::Complex64;
+#[cfg(feature = "py")]
 use smallvec::{SmallVec, smallvec};
 
 /// A single instruction in a :class:`.QuantumCircuit`, comprised of the :attr:`operation` and
@@ -70,6 +90,7 @@ use smallvec::{SmallVec, smallvec};
 ///     mutations of the object do not invalidate the types, nor the restrictions placed on it by
 ///     its context.  Typically this will mean, for example, that :attr:`qubits` must be a sequence
 ///     of distinct items, with no duplicates.
+#[cfg(feature = "py")]
 #[pyclass(
     freelist = 20,
     sequence,
@@ -91,6 +112,7 @@ pub struct CircuitInstruction {
     pub py_op: OnceLock<Py<PyAny>>,
 }
 
+#[cfg(feature = "py")]
 impl CircuitInstruction {
     /// Get the Python-space operation, ensuring that it is mutable from Python space (singleton
     /// gates might not necessarily satisfy this otherwise).
@@ -110,6 +132,7 @@ impl CircuitInstruction {
     }
 }
 
+#[cfg(feature = "py")]
 impl Instruction for CircuitInstruction {
     type Block = CircuitData;
 
@@ -126,6 +149,7 @@ impl Instruction for CircuitInstruction {
     }
 }
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl CircuitInstruction {
     #[new]
@@ -556,6 +580,7 @@ impl CircuitInstruction {
 /// to match the place you'll be putting the blocks.  If you want to fail the extraction if there's
 /// control-flow blocks, use `qiskit_circuit::NoBlocks`.  If you want to leave the blocks
 /// unextracted, use `Py<PyAny>`.
+#[cfg(feature = "py")]
 #[derive(Debug)]
 pub struct OperationFromPython<T> {
     pub operation: PackedOperation,
@@ -563,6 +588,7 @@ pub struct OperationFromPython<T> {
     pub label: Option<Box<String>>,
 }
 
+#[cfg(feature = "py")]
 impl<T: CircuitBlock> OperationFromPython<T> {
     /// Takes the params out of [OperationFromPython::params].
     ///
@@ -588,9 +614,11 @@ pub struct NoBlocks;
 ///
 /// This shouldn't need to be imported anywhere nor implemented by anything else; it's only intended
 /// to let the `OperationFromPython` extraction be generic.
+#[cfg(feature = "py")]
 pub trait CircuitBlock: Sized {
     fn extract_py_block(ob: Bound<PyCircuitData>) -> PyResult<Self>;
 }
+#[cfg(feature = "py")]
 impl CircuitBlock for PyCircuitData {
     fn extract_py_block(ob: Bound<PyCircuitData>) -> PyResult<Self> {
         Ok(ob.borrow().clone())
@@ -598,27 +626,32 @@ impl CircuitBlock for PyCircuitData {
 }
 // TODO: in the long run we don't need to extract from python directly to CircuitData
 // But for now it's needed in assing_parameters_inner
+#[cfg(feature = "py")]
 impl CircuitBlock for CircuitData {
     fn extract_py_block(ob: Bound<PyCircuitData>) -> PyResult<Self> {
         Ok(ob.borrow().clone().inner)
     }
 }
+#[cfg(feature = "py")]
 impl CircuitBlock for DAGCircuit {
     fn extract_py_block(ob: Bound<PyCircuitData>) -> PyResult<Self> {
         Self::from_circuit_data(&ob.borrow().inner, false, None, None).map_err(Into::into)
     }
 }
+#[cfg(feature = "py")]
 impl CircuitBlock for NoBlocks {
     fn extract_py_block(_ob: Bound<PyCircuitData>) -> PyResult<Self> {
         Err(PyTypeError::new_err("control-flow ops are not valid here"))
     }
 }
+#[cfg(feature = "py")]
 impl CircuitBlock for Py<PyAny> {
     fn extract_py_block(ob: Bound<PyCircuitData>) -> PyResult<Self> {
         Ok(ob.into_any().unbind())
     }
 }
 
+#[cfg(feature = "py")]
 impl<T> Instruction for OperationFromPython<T> {
     type Block = T;
 
@@ -635,6 +668,7 @@ impl<T> Instruction for OperationFromPython<T> {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py, T: CircuitBlock> FromPyObject<'a, 'py> for OperationFromPython<T> {
     type Error = PyErr;
 
@@ -954,6 +988,7 @@ impl<'a, 'py, T: CircuitBlock> FromPyObject<'a, 'py> for OperationFromPython<T> 
 
 /// Extracts a Python-space params list into an optional [Parameters] list, given
 /// the corresponding operation reference.
+#[cfg(feature = "py")]
 pub fn extract_params<T: CircuitBlock>(
     op: OperationRef,
     params: &Bound<PyAny>,
@@ -1026,6 +1061,7 @@ pub fn extract_params<T: CircuitBlock>(
 }
 
 /// Convert a sequence-like Python object to a tuple.
+#[cfg(feature = "py")]
 fn as_tuple<'py>(py: Python<'py>, seq: Option<Bound<'py, PyAny>>) -> PyResult<Bound<'py, PyTuple>> {
     let Some(seq) = seq else {
         return Ok(PyTuple::empty(py));
@@ -1051,6 +1087,7 @@ fn as_tuple<'py>(py: Python<'py>, seq: Option<Bound<'py, PyAny>>) -> PyResult<Bo
 /// Beware the `stacklevel` here doesn't work quite the same way as it does in Python as Rust-space
 /// calls are completely transparent to Python.
 #[inline]
+#[cfg(feature = "py")]
 fn warn_on_legacy_circuit_instruction_iteration(py: Python) -> PyResult<()> {
     WARNINGS_WARN
         .get_bound(py)

--- a/crates/circuit/src/classical/expr/binary.rs
+++ b/crates/circuit/src/classical/expr/binary.rs
@@ -10,12 +10,16 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::classical::expr::{Expr, ExprKind, PyExpr};
+use std::convert::Infallible;
+
+use crate::classical::expr::Expr;
+#[cfg(feature = "py")]
+use crate::classical::expr::{ExprKind, PyExpr};
 use crate::classical::types::Type;
+#[cfg(feature = "py")]
 use crate::imports;
-use pyo3::prelude::*;
-use pyo3::types::PyTuple;
-use pyo3::{IntoPyObjectExt, intern};
+#[cfg(feature = "py")]
+use pyo3::{IntoPyObjectExt, intern, prelude::*, types::PyTuple};
 
 /// A binary expression.
 #[derive(Clone, Debug, PartialEq)]
@@ -67,11 +71,12 @@ unsafe impl ::bytemuck::CheckedBitPattern for BinaryOp {
 }
 
 impl BinaryOp {
-    pub fn from_u8(value: u8) -> PyResult<BinaryOp> {
+    pub fn from_u8(value: u8) -> Result<BinaryOp, Infallible> {
         Ok(bytemuck::checked::cast::<u8, BinaryOp>(value))
     }
 }
 
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for Binary {
     type Target = PyAny;
     type Output = Bound<'py, PyAny>;
@@ -82,6 +87,7 @@ impl<'py> IntoPyObject<'py> for Binary {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py> FromPyObject<'a, 'py> for Binary {
     type Error = <PyBinary as FromPyObject<'a, 'py>>::Error;
 
@@ -91,6 +97,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Binary {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for BinaryOp {
     type Target = PyAny;
     type Output = Bound<'py, Self::Target>;
@@ -101,6 +108,7 @@ impl<'py> IntoPyObject<'py> for BinaryOp {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py> FromPyObject<'a, 'py> for BinaryOp {
     type Error = PyErr;
 
@@ -110,11 +118,13 @@ impl<'a, 'py> FromPyObject<'a, 'py> for BinaryOp {
     }
 }
 
+#[cfg(feature = "py")]
 /// A Python descriptor to prevent PyO3 from attempting to import the Python-side
 /// enum before we're initialized.
 #[pyclass(module = "qiskit._accelerate.circuit.classical.expr")]
 struct PyBinaryOp;
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyBinaryOp {
     fn __get__(&self, obj: &Bound<PyAny>, _obj_type: &Bound<PyAny>) -> Py<PyAny> {
@@ -122,6 +132,7 @@ impl PyBinaryOp {
     }
 }
 
+#[cfg(feature = "py")]
 /// A binary expression.
 ///
 /// Args:
@@ -139,6 +150,7 @@ impl PyBinaryOp {
 #[derive(PartialEq, Clone, Debug)]
 pub struct PyBinary(Binary);
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyBinary {
     // The docstring for 'Op' is defined in Python (expr.py).

--- a/crates/circuit/src/classical/expr/cast.rs
+++ b/crates/circuit/src/classical/expr/cast.rs
@@ -10,10 +10,14 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::classical::expr::{Expr, ExprKind, PyExpr};
-use crate::classical::types::Type;
+#[cfg(feature = "py")]
+use crate::classical::expr::{ExprKind, PyExpr};
+use crate::classical::{expr::Expr, types::Type};
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
+#[cfg(feature = "py")]
 use pyo3::types::PyTuple;
+#[cfg(feature = "py")]
 use pyo3::{IntoPyObjectExt, intern};
 
 /// A cast from one type to another, implied by the use of an expression in a different
@@ -26,6 +30,7 @@ pub struct Cast {
     pub implicit: bool,
 }
 
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for Cast {
     type Target = PyAny;
     type Output = Bound<'py, PyAny>;
@@ -36,6 +41,7 @@ impl<'py> IntoPyObject<'py> for Cast {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py> FromPyObject<'a, 'py> for Cast {
     type Error = <PyCast as FromPyObject<'a, 'py>>::Error;
 
@@ -45,6 +51,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Cast {
     }
 }
 
+#[cfg(feature = "py")]
 /// A cast from one type to another, implied by the use of an expression in a different
 /// context.
 #[pyclass(
@@ -57,6 +64,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Cast {
 #[derive(PartialEq, Clone, Debug)]
 pub struct PyCast(Cast);
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyCast {
     #[new]

--- a/crates/circuit/src/classical/expr/expr.rs
+++ b/crates/circuit/src/classical/expr/expr.rs
@@ -14,7 +14,9 @@ use std::error::Error;
 
 use crate::classical::expr::{Binary, Cast, Index, Stretch, Unary, Value, Var};
 use crate::classical::types::Type;
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
+#[cfg(feature = "py")]
 use pyo3::{IntoPyObjectExt, intern};
 
 /// A classical expression.
@@ -385,6 +387,7 @@ impl From<Box<Index>> for Expr {
     }
 }
 
+#[cfg(feature = "py")]
 /// Root base class of all nodes in the expression tree.  The base case should never be
 /// instantiated directly.
 ///
@@ -405,6 +408,7 @@ impl From<Box<Index>> for Expr {
 #[derive(PartialEq, Clone, Copy, Debug, Hash)]
 pub struct PyExpr(pub ExprKind); // ExprKind is used for fast extraction from Python
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyExpr {
     /// Call the relevant ``visit_*`` method on the given :class:`ExprVisitor`.  The usual entry
@@ -440,6 +444,7 @@ pub enum ExprKind {
     Index,
 }
 
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for Expr {
     type Target = PyAny;
     type Output = Bound<'py, PyAny>;
@@ -458,6 +463,7 @@ impl<'py> IntoPyObject<'py> for Expr {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py> FromPyObject<'a, 'py> for Expr {
     type Error = PyErr;
 
@@ -477,6 +483,8 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Expr {
 
 #[cfg(test)]
 mod tests {
+    use std::convert::Infallible;
+
     use crate::bit::{ClassicalRegister, ShareableClbit};
     use crate::classical::expr::{
         Binary, BinaryOp, Cast, Expr, ExprRef, ExprRefMut, IdentifierRef, Index, Stretch, Unary,
@@ -485,7 +493,6 @@ mod tests {
     use crate::classical::types::Type;
     use crate::duration::Duration;
     use num_bigint::BigUint;
-    use pyo3::{PyErr, PyResult};
     use uuid::Uuid;
 
     #[test]
@@ -632,7 +639,7 @@ mod tests {
     }
 
     #[test]
-    fn test_visit_mut_ordering() -> PyResult<()> {
+    fn test_visit_mut_ordering() -> Result<(), Infallible> {
         let mut expr: Expr = Binary {
             op: BinaryOp::Mul,
             left: Binary {
@@ -708,7 +715,7 @@ mod tests {
 
         expr.visit_mut(|x| {
             assert!(order.next().unwrap()(&x));
-            Ok::<_, PyErr>(())
+            Ok::<_, Infallible>(())
         })?;
 
         assert!(order.next().is_none());
@@ -716,7 +723,7 @@ mod tests {
     }
 
     #[test]
-    fn test_visit_mut() -> PyResult<()> {
+    fn test_visit_mut() -> Result<(), Infallible> {
         let mut expr: Expr = Binary {
             op: BinaryOp::BitAnd,
             left: Unary {
@@ -744,7 +751,7 @@ mod tests {
         expr.visit_mut(|x| match x {
             ExprRefMut::Var(Var::Standalone { name, .. }) => {
                 *name = "updated".to_string();
-                Ok::<_, PyErr>(())
+                Ok::<_, Infallible>(())
             }
             _ => Ok(()),
         })?;
@@ -757,7 +764,7 @@ mod tests {
     }
 
     #[test]
-    fn test_structurally_eq_to_self() -> PyResult<()> {
+    fn test_structurally_eq_to_self() -> Result<(), Infallible> {
         let exprs = [
             Expr::Var(Var::Bit {
                 bit: ShareableClbit::new_anonymous(),
@@ -986,7 +993,7 @@ mod tests {
     }
 
     #[test]
-    fn test_structurally_eq_key_function_both() -> PyResult<()> {
+    fn test_structurally_eq_key_function_both() -> Result<(), Infallible> {
         let left_clbit = ShareableClbit::new_anonymous();
         let left_cr = ClassicalRegister::new_owning("a", 3);
         let right_clbit = ShareableClbit::new_anonymous();

--- a/crates/circuit/src/classical/expr/index.rs
+++ b/crates/circuit/src/classical/expr/index.rs
@@ -10,10 +10,15 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::classical::expr::{Expr, ExprKind, PyExpr};
+use crate::classical::expr::Expr;
+#[cfg(feature = "py")]
+use crate::classical::expr::{ExprKind, PyExpr};
 use crate::classical::types::Type;
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
+#[cfg(feature = "py")]
 use pyo3::types::PyTuple;
+#[cfg(feature = "py")]
 use pyo3::{IntoPyObjectExt, intern};
 
 /// An indexing expression.
@@ -25,6 +30,7 @@ pub struct Index {
     pub constant: bool,
 }
 
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for Index {
     type Target = PyAny;
     type Output = Bound<'py, PyAny>;
@@ -35,6 +41,7 @@ impl<'py> IntoPyObject<'py> for Index {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py> FromPyObject<'a, 'py> for Index {
     type Error = <PyIndex as FromPyObject<'a, 'py>>::Error;
 
@@ -44,6 +51,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Index {
     }
 }
 
+#[cfg(feature = "py")]
 /// An indexing expression.
 ///
 /// Args:
@@ -60,6 +68,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Index {
 #[derive(PartialEq, Clone, Debug)]
 pub struct PyIndex(Index);
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyIndex {
     #[new]

--- a/crates/circuit/src/classical/expr/mod.rs
+++ b/crates/circuit/src/classical/expr/mod.rs
@@ -10,6 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
 
 mod binary;
@@ -34,15 +35,26 @@ pub use var::Var;
 // These aren't "pub use" since we probably shouldn't have a
 // reason to use the Python class types from Rust if we're
 // doing things the right way.
+#[cfg(feature = "py")]
 use crate::classical::expr::binary::PyBinary;
+#[cfg(feature = "py")]
 use crate::classical::expr::cast::PyCast;
-use crate::classical::expr::expr::{ExprKind, PyExpr};
+#[cfg(feature = "py")]
+use crate::classical::expr::expr::ExprKind;
+#[cfg(feature = "py")]
+use crate::classical::expr::expr::PyExpr;
+#[cfg(feature = "py")]
 use crate::classical::expr::index::PyIndex;
+#[cfg(feature = "py")]
 use crate::classical::expr::stretch::PyStretch;
+#[cfg(feature = "py")]
 use crate::classical::expr::unary::PyUnary;
+#[cfg(feature = "py")]
 use crate::classical::expr::value::PyValue;
+#[cfg(feature = "py")]
 use crate::classical::expr::var::PyVar;
 
+#[cfg(feature = "py")]
 pub(crate) fn register_python(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<PyExpr>()?;
     m.add_class::<PyUnary>()?;

--- a/crates/circuit/src/classical/expr/stretch.rs
+++ b/crates/circuit/src/classical/expr/stretch.rs
@@ -10,12 +10,19 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+#[cfg(feature = "py")]
 use crate::classical::expr::{ExprKind, PyExpr};
+#[cfg(feature = "py")]
 use crate::classical::types::Type;
+#[cfg(feature = "py")]
 use crate::imports::UUID;
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
+#[cfg(feature = "py")]
 use pyo3::types::{IntoPyDict, PyTuple};
+#[cfg(feature = "py")]
 use pyo3::{IntoPyObjectExt, intern};
+#[cfg(feature = "py")]
 use uuid::Uuid;
 
 /// A stretch variable.
@@ -25,6 +32,7 @@ pub struct Stretch {
     pub name: String,
 }
 
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for Stretch {
     type Target = PyAny;
     type Output = Bound<'py, PyAny>;
@@ -35,6 +43,7 @@ impl<'py> IntoPyObject<'py> for Stretch {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py> FromPyObject<'a, 'py> for Stretch {
     type Error = <PyStretch as FromPyObject<'a, 'py>>::Error;
 
@@ -44,6 +53,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Stretch {
     }
 }
 
+#[cfg(feature = "py")]
 /// A stretch variable.
 ///
 /// In general, construction of stretch variables for use in programs should use :meth:`Stretch.new`
@@ -60,6 +70,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Stretch {
 #[derive(PartialEq, Clone, Debug, Hash)]
 pub struct PyStretch(Stretch);
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyStretch {
     #[new]

--- a/crates/circuit/src/classical/expr/unary.rs
+++ b/crates/circuit/src/classical/expr/unary.rs
@@ -10,11 +10,19 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::classical::expr::{Expr, ExprKind, PyExpr};
+use std::convert::Infallible;
+
+use crate::classical::expr::Expr;
+#[cfg(feature = "py")]
+use crate::classical::expr::{ExprKind, PyExpr};
 use crate::classical::types::Type;
+#[cfg(feature = "py")]
 use crate::imports;
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
+#[cfg(feature = "py")]
 use pyo3::types::PyTuple;
+#[cfg(feature = "py")]
 use pyo3::{IntoPyObjectExt, intern};
 
 /// A unary expression.
@@ -52,11 +60,12 @@ unsafe impl ::bytemuck::CheckedBitPattern for UnaryOp {
 }
 
 impl UnaryOp {
-    pub fn from_u8(value: u8) -> PyResult<UnaryOp> {
+    pub fn from_u8(value: u8) -> Result<UnaryOp, Infallible> {
         Ok(bytemuck::checked::cast::<u8, UnaryOp>(value))
     }
 }
 
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for Unary {
     type Target = PyAny;
     type Output = Bound<'py, PyAny>;
@@ -67,6 +76,7 @@ impl<'py> IntoPyObject<'py> for Unary {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py> FromPyObject<'a, 'py> for Unary {
     type Error = <PyUnary as FromPyObject<'a, 'py>>::Error;
 
@@ -76,6 +86,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Unary {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for UnaryOp {
     type Target = PyAny;
     type Output = Bound<'py, Self::Target>;
@@ -86,6 +97,7 @@ impl<'py> IntoPyObject<'py> for UnaryOp {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py> FromPyObject<'a, 'py> for UnaryOp {
     type Error = PyErr;
 
@@ -95,11 +107,13 @@ impl<'a, 'py> FromPyObject<'a, 'py> for UnaryOp {
     }
 }
 
+#[cfg(feature = "py")]
 /// A Python descriptor to prevent PyO3 from attempting to import the Python-side
 /// enum before we're initialized.
 #[pyclass(module = "qiskit._accelerate.circuit.classical.expr")]
 struct PyUnaryOp;
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyUnaryOp {
     fn __get__(&self, obj: &Bound<PyAny>, _obj_type: &Bound<PyAny>) -> Py<PyAny> {
@@ -107,6 +121,7 @@ impl PyUnaryOp {
     }
 }
 
+#[cfg(feature = "py")]
 /// A unary expression.
 ///
 /// Args:
@@ -123,6 +138,7 @@ impl PyUnaryOp {
 #[derive(PartialEq, Clone, Debug)]
 pub struct PyUnary(Unary);
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyUnary {
     // The docstring for 'Op' is defined in Python (expr.py).

--- a/crates/circuit/src/classical/expr/value.rs
+++ b/crates/circuit/src/classical/expr/value.rs
@@ -10,12 +10,16 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+#[cfg(feature = "py")]
 use crate::classical::expr::{ExprKind, PyExpr};
 use crate::classical::types::Type;
 use crate::duration::Duration;
 use num_bigint::BigUint;
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
+#[cfg(feature = "py")]
 use pyo3::types::PyTuple;
+#[cfg(feature = "py")]
 use pyo3::{IntoPyObjectExt, intern};
 
 /// A single scalar value expression.
@@ -26,6 +30,7 @@ pub enum Value {
     Uint { raw: BigUint, ty: Type },
 }
 
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for Value {
     type Target = PyAny;
     type Output = Bound<'py, PyAny>;
@@ -36,6 +41,7 @@ impl<'py> IntoPyObject<'py> for Value {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py> FromPyObject<'a, 'py> for Value {
     type Error = <PyValue as FromPyObject<'a, 'py>>::Error;
 
@@ -45,6 +51,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Value {
     }
 }
 
+#[cfg(feature = "py")]
 /// A single scalar value.
 #[pyclass(
     eq,
@@ -56,6 +63,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Value {
 #[derive(PartialEq, Clone, Debug)]
 pub struct PyValue(Value);
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyValue {
     #[new]

--- a/crates/circuit/src/classical/expr/var.rs
+++ b/crates/circuit/src/classical/expr/var.rs
@@ -11,12 +11,18 @@
 // that they have been altered from the originals.
 
 use crate::bit::{ClassicalRegister, ShareableClbit};
+#[cfg(feature = "py")]
 use crate::classical::expr::{ExprKind, PyExpr};
 use crate::classical::types::Type;
+#[cfg(feature = "py")]
 use crate::imports::UUID;
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
+#[cfg(feature = "py")]
 use pyo3::types::{IntoPyDict, PyTuple};
+#[cfg(feature = "py")]
 use pyo3::{IntoPyObjectExt, intern};
+#[cfg(feature = "py")]
 use uuid::Uuid;
 
 /// A classical variable expression.
@@ -49,6 +55,7 @@ impl Var {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for Var {
     type Target = PyAny;
     type Output = Bound<'py, PyAny>;
@@ -59,6 +66,7 @@ impl<'py> IntoPyObject<'py> for Var {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py> FromPyObject<'a, 'py> for Var {
     type Error = <PyVar as FromPyObject<'a, 'py>>::Error;
 
@@ -68,6 +76,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Var {
     }
 }
 
+#[cfg(feature = "py")]
 /// A classical variable.
 ///
 /// These variables take two forms: a new-style variable that owns its storage location and has an
@@ -89,6 +98,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Var {
 #[derive(PartialEq, Clone, Debug, Hash)]
 pub struct PyVar(Var);
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyVar {
     #[new]

--- a/crates/circuit/src/classical/mod.rs
+++ b/crates/circuit/src/classical/mod.rs
@@ -13,8 +13,10 @@
 pub mod expr;
 pub mod types;
 
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
 
+#[cfg(feature = "py")]
 pub(crate) fn register_python(m: &Bound<PyModule>) -> PyResult<()> {
     let expr_mod = PyModule::new(m.py(), "expr")?;
     expr::register_python(&expr_mod)?;

--- a/crates/circuit/src/classical/types.rs
+++ b/crates/circuit/src/classical/types.rs
@@ -10,14 +10,22 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+#[cfg(feature = "py")]
 use pyo3::PyTypeInfo;
+#[cfg(feature = "py")]
 use pyo3::exceptions::PyAttributeError;
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
+#[cfg(feature = "py")]
 use pyo3::sync::PyOnceLock;
+#[cfg(feature = "py")]
 use pyo3::types::PyTuple;
 
+#[cfg(feature = "py")]
 static BOOL_TYPE: PyOnceLock<Py<PyBool>> = PyOnceLock::new();
+#[cfg(feature = "py")]
 static DURATION_TYPE: PyOnceLock<Py<PyDuration>> = PyOnceLock::new();
+#[cfg(feature = "py")]
 static FLOAT_TYPE: PyOnceLock<Py<PyFloat>> = PyOnceLock::new();
 
 /// A classical expression's "type".
@@ -33,6 +41,7 @@ pub enum Type {
     Uint(u32),
 }
 
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for Type {
     type Target = PyAny;
     type Output = Bound<'py, Self::Target>;
@@ -48,6 +57,7 @@ impl<'py> IntoPyObject<'py> for Type {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py> FromPyObject<'a, 'py> for Type {
     type Error = PyErr;
 
@@ -65,6 +75,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Type {
     }
 }
 
+#[cfg(feature = "py")]
 /// Root base class of all nodes in the type tree.  The base case should never be instantiated
 /// directly.
 ///
@@ -82,6 +93,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Type {
 #[derive(PartialEq, Clone, Copy, Debug, Hash)]
 struct PyType(TypeKind);
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyType {
     /// Get the kind of this type.
@@ -124,6 +136,7 @@ enum TypeKind {
     Uint,
 }
 
+#[cfg(feature = "py")]
 /// The Boolean type.  This has exactly two values: ``True`` and ``False``.
 #[pyclass(
     eq,
@@ -137,6 +150,7 @@ enum TypeKind {
 #[derive(PartialEq, Clone, Copy, Debug, Hash)]
 struct PyBool;
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyBool {
     #[new]
@@ -157,6 +171,7 @@ impl PyBool {
     }
 }
 
+#[cfg(feature = "py")]
 /// A length of time, possibly negative.
 #[pyclass(
     eq,
@@ -170,6 +185,7 @@ impl PyBool {
 #[derive(PartialEq, Clone, Copy, Debug, Hash)]
 struct PyDuration;
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyDuration {
     #[new]
@@ -190,6 +206,7 @@ impl PyDuration {
     }
 }
 
+#[cfg(feature = "py")]
 /// An IEEE-754 double-precision floating point number.
 ///
 /// In the future, this may also be used to represent other fixed-width floats.
@@ -205,6 +222,7 @@ impl PyDuration {
 #[derive(PartialEq, Clone, Copy, Debug, Hash)]
 struct PyFloat;
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyFloat {
     #[new]
@@ -225,6 +243,7 @@ impl PyFloat {
     }
 }
 
+#[cfg(feature = "py")]
 /// An unsigned integer of fixed bit width.
 #[pyclass(
     eq,
@@ -238,6 +257,7 @@ impl PyFloat {
 #[derive(PartialEq, Clone, Copy, Debug, Hash)]
 struct PyUint(u32);
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyUint {
     #[new]
@@ -259,6 +279,7 @@ impl PyUint {
     }
 }
 
+#[cfg(feature = "py")]
 pub(crate) fn register_python(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<PyType>()?;
     m.add_class::<PyBool>()?;

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -10,6 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+#[cfg(feature = "py")]
 use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::hash::Hash;
@@ -18,25 +19,36 @@ use std::sync::Arc;
 use foldhash::fast::RandomState;
 use smallvec::SmallVec;
 
+#[cfg(feature = "py")]
+use crate::TupleLikeArg;
 use crate::bit::{
-    BitLocations, ClassicalRegister, PyClbit, PyQubit, QuantumRegister, Register, ShareableClbit,
-    ShareableQubit,
+    BitLocations, ClassicalRegister, QuantumRegister, Register, ShareableClbit, ShareableQubit,
 };
+#[cfg(feature = "py")]
+use crate::bit::{PyClbit, PyQubit};
 use crate::bit_locator::BitLocator;
 use crate::circuit_data::CircuitData;
+#[cfg(feature = "py")]
 use crate::circuit_instruction::{CircuitInstruction, OperationFromPython};
 use crate::classical::expr;
+#[cfg(feature = "py")]
 use crate::converters::QuantumCircuitData;
+#[cfg(feature = "py")]
 use crate::dag_node::{DAGInNode, DAGNode, DAGOpNode, DAGOutNode};
+#[cfg(feature = "py")]
 use crate::dot_utils::build_dot;
+#[cfg(feature = "py")]
 use crate::error::DAGCircuitError;
 use crate::interner::{Interned, InternedMap, Interner};
 use crate::object_registry::ObjectRegistry;
+#[cfg(feature = "py")]
+use crate::operations::{ArrayType, BoxDuration, LoopParam, StandardInstruction};
 use crate::operations::{
-    ArrayType, BoxDuration, Condition, ControlFlow, ControlFlowInstruction, ControlFlowView,
-    LoopParam, Operation, OperationRef, Param, PyInstruction, PyOpKind, StandardGate,
-    StandardInstruction, SwitchTarget,
+    Condition, ControlFlow, ControlFlowInstruction, ControlFlowView, Operation, OperationRef,
+    Param, StandardGate, SwitchTarget,
 };
+#[cfg(feature = "py")]
+use crate::operations::{PyInstruction, PyOpKind};
 use crate::packed_instruction::{PackedInstruction, PackedOperation};
 use crate::parameter::parameter_expression::ParameterExpression;
 use crate::register_data::{RegisterAlreadyExists, RegisterData};
@@ -44,23 +56,30 @@ use crate::var_stretch_container::{
     StretchType, VarStretchContainer, VarStretchContainerError, VarType,
 };
 use crate::variable_mapper::VariableMapper;
-use crate::{
-    Block, BlockMapper, BlocksMode, Clbit, ControlFlowBlocks, Qubit, Stretch, TupleLikeArg, Var,
-    VarsMode, imports, instruction, vf2,
-};
+use crate::{Block, BlocksMode, Clbit, ControlFlowBlocks, Qubit, Stretch, Var, VarsMode};
+#[cfg(feature = "py")]
+use crate::{BlockMapper, imports, instruction, vf2};
+#[cfg(feature = "py")]
 use qiskit_util::py::{PySequenceIndex, SequenceIndex};
 
 use hashbrown::{HashMap, HashSet};
-use itertools::{EitherOrBoth, Itertools};
+#[cfg(feature = "py")]
+use itertools::EitherOrBoth;
+use itertools::Itertools;
 use qiskit_util::{IndexMap, IndexSet};
 
+#[cfg(feature = "py")]
 use pyo3::IntoPyObjectExt;
+#[cfg(feature = "py")]
 use pyo3::exceptions::{
     PyDeprecationWarning, PyIndexError, PyRuntimeError, PyTypeError, PyValueError,
 };
+#[cfg(feature = "py")]
 use pyo3::intern;
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
 
+#[cfg(feature = "py")]
 use pyo3::types::{IntoPyDict, PyDict, PyInt, PyIterator, PyList, PySet, PyTuple, PyType};
 
 use rustworkx_core::dag_algo::layers;
@@ -72,9 +91,9 @@ use rustworkx_core::petgraph::prelude::StableDiGraph;
 use rustworkx_core::petgraph::prelude::*;
 use rustworkx_core::petgraph::stable_graph::{EdgeReference, IndexType};
 use rustworkx_core::petgraph::unionfind::UnionFind;
-use rustworkx_core::petgraph::visit::{
-    EdgeIndexable, IntoEdgeReferences, IntoNodeReferences, NodeFiltered, NodeIndexable,
-};
+#[cfg(feature = "py")]
+use rustworkx_core::petgraph::visit::{EdgeIndexable, NodeFiltered};
+use rustworkx_core::petgraph::visit::{IntoEdgeReferences, IntoNodeReferences, NodeIndexable};
 use rustworkx_core::traversal::{
     ancestors as core_ancestors, bfs_predecessors as core_bfs_predecessors,
     bfs_successors as core_bfs_successors, descendants as core_descendants,
@@ -85,15 +104,21 @@ fn dag_compose_width_error(bit_kind: &str, other: usize, dest: usize) -> String 
     format!("Cannot compose onto a DAGCircuit with fewer {bit_kind} ({other} > {dest}).")
 }
 
+#[cfg(feature = "py")]
 use crate::imports::PARAMETER;
 use crate::instruction::Parameters;
+#[cfg(feature = "py")]
 use crate::parameter_table::ParameterUuid;
+#[cfg(feature = "py")]
 use approx::relative_eq;
+#[cfg(feature = "py")]
 use std::collections::{BTreeMap, VecDeque};
 use std::convert::Infallible;
+#[cfg(feature = "py")]
 use std::f64::consts::PI;
 #[cfg(feature = "cache_pygates")]
 use std::sync::OnceLock;
+#[cfg(feature = "py")]
 use uuid::Uuid;
 
 static CONTROL_FLOW_OP_NAMES: [&str; 5] =
@@ -108,6 +133,7 @@ pub use rustworkx_core::petgraph::stable_graph::NodeIndex;
 #[error("Wire {0:?} already exists in circuit")]
 pub struct DuplicateWireError(Wire);
 
+#[cfg(feature = "py")]
 impl From<DuplicateWireError> for PyErr {
     fn from(value: DuplicateWireError) -> Self {
         DAGCircuitError::new_err(value.to_string())
@@ -173,6 +199,7 @@ pub enum DAGError {
     #[error(transparent)]
     Circuit(#[from] crate::circuit_data::CircuitDataError),
     // For special Python cases.
+    #[cfg(feature = "py")]
     #[error(transparent)]
     Python(PyErr),
 }
@@ -195,6 +222,7 @@ impl<T: Debug> From<crate::object_registry::AbsentObject<T>> for DAGError {
     }
 }
 
+#[cfg(feature = "py")]
 impl From<DAGError> for PyErr {
     fn from(value: DAGError) -> Self {
         match value {
@@ -297,6 +325,7 @@ impl From<Var> for Wire {
     }
 }
 
+#[cfg(feature = "py")]
 impl Wire {
     fn to_pickle(self, py: Python) -> PyResult<Py<PyAny>> {
         match self {
@@ -371,12 +400,14 @@ pub struct DAGCircuit {
     op_names: IndexMap<String, usize>,
 }
 
+#[cfg(feature = "py")]
 #[derive(Clone, Debug)]
 struct PyLegacyResources {
     clbits: Py<PyTuple>,
     cregs: Py<PyTuple>,
 }
 
+#[cfg(feature = "py")]
 fn condition_resources(condition: &Bound<PyAny>) -> PyResult<PyLegacyResources> {
     let res = imports::CONTROL_FLOW_CONDITION_RESOURCES
         .get_bound(condition.py())
@@ -391,6 +422,7 @@ fn reject_new_register(reg: &ClassicalRegister) -> Result<(), DAGError> {
     Err(DAGError::RejectNewRegister(reg.bits().collect_vec()))
 }
 
+#[cfg(feature = "py")]
 #[pyclass(
     name = "BitLocations",
     module = "qiskit._accelerate.circuit",
@@ -405,6 +437,7 @@ pub struct PyBitLocations {
     pub registers: Py<PyList>,
 }
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyBitLocations {
     #[new]
@@ -476,6 +509,7 @@ impl PyBitLocations {
 /// There are 3 types of nodes in the graph: inputs, outputs, and operations.
 /// The nodes are connected by directed edges that correspond to qubits and
 /// bits.
+#[cfg(feature = "py")]
 #[pyclass(
     name = "DAGCircuit",
     module = "qiskit._accelerate.circuit",
@@ -498,6 +532,7 @@ pub struct PyDAGCircuit {
     inner: DAGCircuit,
 }
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyDAGCircuit {
     #[new]
@@ -5036,6 +5071,7 @@ impl DAGCircuit {
     /// and condition will not be propagated back.
     ///
     /// Panics if `node` does not refer to an operation.
+    #[cfg(feature = "py")]
     pub fn unpack_py_op<'py>(
         &self,
         py: Python<'py>,
@@ -5856,6 +5892,7 @@ impl DAGCircuit {
                     OperationRef::StandardGate(gate) => {
                         Ok(Some(gate.num_qubits() <= 2 && !inst.is_parameterized()))
                     }
+                    #[cfg(feature = "py")]
                     OperationRef::PyCustom(PyInstruction {
                         kind: PyOpKind::Gate,
                         qubits: ..=2,
@@ -5986,9 +6023,7 @@ impl DAGCircuit {
         dir: Direction,
     ) -> Result<NodeIndex, DAGError> {
         self.track_instruction(&instr);
-        let (all_cbits, vars) = self
-            .get_classical_resources(&instr)
-            .map_err(DAGError::Python)?;
+        let (all_cbits, vars) = self.get_classical_resources(&instr)?;
         let qubits_id = instr.qubits;
         let new_node = self.dag.add_node(NodeType::Operation(instr));
         let terminus_index = match dir {
@@ -6050,13 +6085,16 @@ impl DAGCircuit {
     fn get_classical_resources(
         &self,
         instr: &PackedInstruction,
-    ) -> PyResult<(Vec<Clbit>, Option<Vec<Var>>)> {
+    ) -> Result<(Vec<Clbit>, Option<Vec<Var>>), DAGError> {
         let (all_clbits, vars): (Vec<Clbit>, Option<Vec<Var>>) = {
             if self.may_have_additional_wires(instr) {
                 let mut clbits: IndexSet<Clbit> =
                     IndexSet::from_iter(self.cargs_interner.get(instr.clbits).iter().copied());
+                #[cfg(feature = "py")]
                 let (additional_clbits, additional_vars) =
                     Python::attach(|py| self.additional_wires(py, instr))?;
+                #[cfg(not(feature = "py"))]
+                let (additional_clbits, additional_vars) = self.additional_wires(instr)?;
                 for clbit in additional_clbits {
                     clbits.insert(clbit);
                 }
@@ -6202,6 +6240,7 @@ impl DAGCircuit {
             .filter(|node: &NodeIndex| matches!(&self.dag[*node], NodeType::Operation(_)))
     }
 
+    #[cfg(feature = "py")]
     // TODO: Move Python auxiliary method
     fn topological_key_sort(
         &self,
@@ -6235,6 +6274,7 @@ impl DAGCircuit {
             .any(|x| self.op_names.contains_key(&x.to_string()))
     }
 
+    #[cfg(feature = "py")]
     pub fn get_node(&self, py: Python, node: NodeIndex) -> PyResult<Py<PyAny>> {
         self.unpack_into(py, node, self.dag.node_weight(node).unwrap())
     }
@@ -6260,6 +6300,7 @@ impl DAGCircuit {
     fn may_have_additional_wires(&self, instr: &PackedInstruction) -> bool {
         match instr.op.view() {
             OperationRef::ControlFlow(_) => true,
+            #[cfg(feature = "py")]
             OperationRef::PyCustom(PyInstruction {
                 kind: PyOpKind::Instruction,
                 op_name,
@@ -6271,10 +6312,10 @@ impl DAGCircuit {
 
     fn additional_wires(
         &self,
-        py: Python,
+        #[cfg(feature = "py")] py: Python,
         instr: &PackedInstruction,
-    ) -> PyResult<(Vec<Clbit>, Vec<Var>)> {
-        let wires_from_expr = |node: &expr::Expr| -> PyResult<(Vec<Clbit>, Vec<Var>)> {
+    ) -> Result<(Vec<Clbit>, Vec<Var>), DAGError> {
+        let wires_from_expr = |node: &expr::Expr| -> Result<(Vec<Clbit>, Vec<Var>), DAGError> {
             let mut clbits = Vec::new();
             let mut vars: Vec<Var> = Vec::new();
             for var in node.vars() {
@@ -6298,75 +6339,91 @@ impl DAGCircuit {
         let mut clbits = Vec::new();
         let mut vars = Vec::new();
 
-        if let Some(instr) = self.try_view_control_flow(instr) {
-            match instr {
-                ControlFlowView::IfElse { condition, .. }
-                | ControlFlowView::While { condition, .. } => match condition {
-                    Condition::Bit(bit, _) => {
-                        clbits.push(self.clbits.find(bit).unwrap());
-                    }
-                    Condition::Register(reg, _) => {
-                        for bit in reg.bits() {
-                            clbits.push(self.clbits.find(&bit).unwrap());
+        match self.try_view_control_flow(instr) {
+            Some(instr) => {
+                match instr {
+                    ControlFlowView::IfElse { condition, .. }
+                    | ControlFlowView::While { condition, .. } => match condition {
+                        Condition::Bit(bit, _) => {
+                            clbits.push(self.clbits.find(bit).unwrap());
                         }
-                    }
-                    Condition::Expr(condition) => {
-                        let (expr_clbits, expr_vars) = wires_from_expr(condition)?;
-                        for bit in expr_clbits {
-                            clbits.push(bit);
+                        Condition::Register(reg, _) => {
+                            for bit in reg.bits() {
+                                clbits.push(self.clbits.find(&bit).unwrap());
+                            }
                         }
-                        for var in expr_vars {
-                            vars.push(var);
+                        Condition::Expr(condition) => {
+                            let (expr_clbits, expr_vars) = wires_from_expr(condition)?;
+                            for bit in expr_clbits {
+                                clbits.push(bit);
+                            }
+                            for var in expr_vars {
+                                vars.push(var);
+                            }
                         }
-                    }
-                },
-                ControlFlowView::Switch { target, .. } => match target {
-                    SwitchTarget::Bit(bit) => {
-                        clbits.push(self.clbits.find(bit).unwrap());
-                    }
-                    SwitchTarget::Register(reg) => {
-                        for bit in reg.bits() {
-                            clbits.push(self.clbits.find(&bit).unwrap());
+                    },
+                    ControlFlowView::Switch { target, .. } => match target {
+                        SwitchTarget::Bit(bit) => {
+                            clbits.push(self.clbits.find(bit).unwrap());
                         }
-                    }
-                    SwitchTarget::Expr(expr) => {
-                        let (expr_clbits, expr_vars) = wires_from_expr(expr)?;
-                        for bit in expr_clbits {
-                            clbits.push(bit);
+                        SwitchTarget::Register(reg) => {
+                            for bit in reg.bits() {
+                                clbits.push(self.clbits.find(&bit).unwrap());
+                            }
                         }
-                        for var in expr_vars {
-                            vars.push(var);
+                        SwitchTarget::Expr(expr) => {
+                            let (expr_clbits, expr_vars) = wires_from_expr(expr)?;
+                            for bit in expr_clbits {
+                                clbits.push(bit);
+                            }
+                            for var in expr_vars {
+                                vars.push(var);
+                            }
                         }
-                    }
-                },
+                    },
 
-                // These don't have any classical wires
-                ControlFlowView::Box { .. }
-                | ControlFlowView::BreakLoop
-                | ControlFlowView::ContinueLoop
-                | ControlFlowView::ForLoop { .. } => {}
-            }
-            for block in instr.blocks() {
-                for var in block.captured_vars() {
-                    vars.push(self.vars_stretches.vars().find(var).unwrap());
+                    // These don't have any classical wires
+                    ControlFlowView::Box { .. }
+                    | ControlFlowView::BreakLoop
+                    | ControlFlowView::ContinueLoop
+                    | ControlFlowView::ForLoop { .. } => {}
+                }
+                for block in instr.blocks() {
+                    for var in block.captured_vars() {
+                        vars.push(self.vars_stretches.vars().find(var).unwrap());
+                    }
                 }
             }
-        } else if let OperationRef::PyCustom(instr) = instr.op.view() {
-            let op = instr.ob.bind(py);
-            if op.is_instance(imports::STORE_OP.get_bound(py))? {
-                let (expr_clbits, expr_vars) = wires_from_expr(&op.getattr("lvalue")?.extract()?)?;
-                for bit in expr_clbits {
-                    clbits.push(bit);
-                }
-                for var in expr_vars {
-                    vars.push(var);
-                }
-                let (expr_clbits, expr_vars) = wires_from_expr(&op.getattr("rvalue")?.extract()?)?;
-                for bit in expr_clbits {
-                    clbits.push(bit);
-                }
-                for var in expr_vars {
-                    vars.push(var);
+            None =>
+            {
+                #[cfg(feature = "py")]
+                if let OperationRef::PyCustom(instr) = instr.op.view() {
+                    let op = instr.ob.bind(py);
+                    let mut get_store = || -> PyResult<()> {
+                        let (expr_clbits, expr_vars) =
+                            wires_from_expr(&op.getattr("lvalue")?.extract()?)?;
+                        for bit in expr_clbits {
+                            clbits.push(bit);
+                        }
+                        for var in expr_vars {
+                            vars.push(var);
+                        }
+                        let (expr_clbits, expr_vars) =
+                            wires_from_expr(&op.getattr("rvalue")?.extract()?)?;
+                        for bit in expr_clbits {
+                            clbits.push(bit);
+                        }
+                        for var in expr_vars {
+                            vars.push(var);
+                        }
+                        Ok(())
+                    };
+                    if op
+                        .is_instance(imports::STORE_OP.get_bound(py))
+                        .map_err(DAGError::Python)?
+                    {
+                        get_store().map_err(DAGError::Python)?
+                    }
                 }
             }
         }
@@ -6441,7 +6498,9 @@ impl DAGCircuit {
                 &mut self.global_phase,
                 Param::ParameterExpression(angle),
             )),
-            Param::Obj(_) | Param::Int(_) => Err(DAGError::ObjGlobalPhase),
+            Param::Int(_) => Err(DAGError::ObjGlobalPhase),
+            #[cfg(feature = "py")]
+            Param::Obj(_) => Err(DAGError::ObjGlobalPhase),
         }
     }
 
@@ -6557,6 +6616,7 @@ impl DAGCircuit {
     }
 
     // TODO: Move Python auxiliary method
+    #[cfg(feature = "py")]
     fn pack_into(&mut self, py: Python, b: &Bound<PyAny>) -> Result<NodeType, PyErr> {
         Ok(if let Ok(in_node) = b.cast::<DAGInNode>() {
             let in_node = in_node.borrow();
@@ -6620,6 +6680,7 @@ impl DAGCircuit {
     }
 
     // TODO: Move Python auxiliary method
+    #[cfg(feature = "py")]
     fn unpack_into(&self, py: Python, id: NodeIndex, weight: &NodeType) -> PyResult<Py<PyAny>> {
         let dag_node = match weight {
             NodeType::QubitIn(qubit) => Py::new(
@@ -7283,8 +7344,10 @@ impl DAGCircuit {
         }
 
         if self.may_have_additional_wires(inst) {
-            let (clbits, vars) =
-                Python::attach(|py| self.additional_wires(py, inst).map_err(DAGError::Python))?;
+            #[cfg(feature = "py")]
+            let (clbits, vars) = Python::attach(|py| self.additional_wires(py, inst))?;
+            #[cfg(not(feature = "py"))]
+            let (clbits, vars) = self.additional_wires(inst)?;
             for b in clbits {
                 if !self.clbit_io_map.len() - 1 < b.index() {
                     return Err(DAGError::WireNotInOutput(ShareableWire::Clbit(
@@ -7483,6 +7546,7 @@ impl DAGCircuit {
 
     pub fn add_global_phase(&mut self, value: &Param) -> Result<(), DAGError> {
         match value {
+            #[cfg(feature = "py")]
             Param::Obj(_) => Err(DAGError::ObjGlobalPhase),
             _ => self
                 .set_global_phase_param(add_global_phase(&self.global_phase, value))
@@ -7686,12 +7750,17 @@ impl DAGCircuit {
         })?;
         new_dag.try_extend(qc_data.iter().map(|instr| -> Result<_, DAGError> {
             Ok(PackedInstruction {
-                op: if copy_op {
-                    instr
-                        .op
-                        .clone_with_py_deepcopy()
-                        .map_err(DAGError::Python)?
-                } else {
+                op: {
+                    #[cfg(feature = "py")]
+                    if copy_op {
+                        instr
+                            .op
+                            .clone_with_py_deepcopy()
+                            .map_err(DAGError::Python)?
+                    } else {
+                        instr.op.clone()
+                    }
+                    #[cfg(not(feature = "py"))]
                     instr.op.clone()
                 },
                 qubits: qarg_map[instr.qubits],
@@ -7731,9 +7800,10 @@ impl DAGCircuit {
             block_qargs.extend(self.qargs_interner.get(instr.qubits));
             block_cargs.extend(self.cargs_interner.get(instr.clbits));
             if self.may_have_additional_wires(instr) {
-                let (additional_clbits, _) = Python::attach(|py| {
-                    self.additional_wires(py, instr).map_err(DAGError::Python)
-                })?;
+                #[cfg(feature = "py")]
+                let (additional_clbits, _) = Python::attach(|py| self.additional_wires(py, instr))?;
+                #[cfg(not(feature = "py"))]
+                let (additional_clbits, _) = self.additional_wires(instr)?;
                 for clbit in additional_clbits {
                     block_cargs.insert(clbit);
                 }
@@ -8139,6 +8209,7 @@ impl DAGCircuit {
     }
 
     /// Substitute a give node in the dag with a new operation from python
+    #[cfg(feature = "py")]
     pub fn substitute_node_with_py_op(
         &mut self,
         node_index: NodeIndex,
@@ -8187,10 +8258,8 @@ impl DAGCircuit {
             py_op: OnceLock::from(op.clone().unbind()),
         };
 
-        let (additional_clbits, additional_vars) = Python::attach(|py| {
-            self.additional_wires(py, &new_instr)
-                .map_err(DAGError::Python)
-        })?;
+        let (additional_clbits, additional_vars) =
+            Python::attach(|py| self.additional_wires(py, &new_instr))?;
         new_wires.extend(additional_clbits.iter().map(|x| Wire::Clbit(*x)));
         new_wires.extend(additional_vars.iter().map(|x| Wire::Var(*x)));
 
@@ -8635,10 +8704,7 @@ impl DAGCircuitBuilder {
     /// Pushes a valid [PackedInstruction] to the back of the circuit.
     pub fn push_back(&mut self, instr: PackedInstruction) -> Result<NodeIndex, DAGError> {
         self.dag.track_instruction(&instr);
-        let (all_cbits, vars) = self
-            .dag
-            .get_classical_resources(&instr)
-            .map_err(DAGError::Python)?;
+        let (all_cbits, vars) = self.dag.get_classical_resources(&instr)?;
         let qubits_id = instr.qubits;
         let new_node = self.dag.dag.add_node(NodeType::Operation(instr));
 
@@ -8825,6 +8891,7 @@ impl ::std::ops::Index<NodeIndex> for DAGCircuit {
     }
 }
 
+#[cfg(feature = "py")]
 impl PyDAGCircuit {
     /// Alternative constructor to build an instance of [DAGCircuit] from a `QuantumCircuit`.
     pub fn from_circuit(
@@ -8833,12 +8900,22 @@ impl PyDAGCircuit {
         qubit_order: Option<Vec<Qubit>>,
         clbit_order: Option<Vec<Clbit>>,
     ) -> Result<Self, DAGError> {
-        // Extract necessary attributes
         let qc_data = qc.data;
+        let metadata = qc
+            .metadata
+            .map(|ob| {
+                if copy_op {
+                    ob.call_method0(intern!(ob.py(), "copy")).map(Bound::unbind)
+                } else {
+                    Ok(ob.unbind())
+                }
+            })
+            .transpose()
+            .map_err(DAGError::Python)?;
         let dag = DAGCircuit::from_circuit_data(&qc_data, copy_op, qubit_order, clbit_order)?;
         Ok(PyDAGCircuit {
             name: qc.name,
-            metadata: qc.metadata.map(|data| data.unbind()),
+            metadata,
             inner: dag,
             duration: None,
             unit: "dt".to_string(),
@@ -8895,6 +8972,7 @@ impl PyDAGCircuit {
     }
 }
 
+#[cfg(feature = "py")]
 impl From<DAGCircuit> for PyDAGCircuit {
     fn from(value: DAGCircuit) -> Self {
         PyDAGCircuit {
@@ -8907,6 +8985,7 @@ impl From<DAGCircuit> for PyDAGCircuit {
     }
 }
 
+#[cfg(feature = "py")]
 fn idle_wires(
     dag: &DAGCircuit,
     py: Python,
@@ -9046,7 +9125,6 @@ mod test {
     use crate::packed_instruction::{PackedInstruction, PackedOperation};
     use crate::{Clbit, Qubit};
     use hashbrown::HashSet;
-    use pyo3::prelude::*;
     use rustworkx_core::petgraph::prelude::*;
     use rustworkx_core::petgraph::stable_graph::DefaultIx;
     use rustworkx_core::petgraph::visit::IntoEdgeReferences;
@@ -9088,7 +9166,7 @@ mod test {
     }
 
     #[test]
-    fn test_push_back() -> PyResult<()> {
+    fn test_push_back() -> Result<(), DAGError> {
         let mut dag = new_dag(2, 2);
 
         // IO nodes.
@@ -9157,7 +9235,7 @@ mod test {
     }
 
     #[test]
-    fn test_push_front() -> PyResult<()> {
+    fn test_push_front() -> Result<(), DAGError> {
         let mut dag = new_dag(2, 2);
 
         // IO nodes.

--- a/crates/circuit/src/duration.rs
+++ b/crates/circuit/src/duration.rs
@@ -10,8 +10,11 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+#[cfg(feature = "py")]
 use pyo3::exceptions::PyValueError;
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
+#[cfg(feature = "py")]
 use pyo3::types::PyTuple;
 
 /// A length of time used to express circuit timing.
@@ -30,7 +33,10 @@ use pyo3::types::PyTuple;
 ///          raise ValueError("expected dt or seconds")
 ///
 /// You can also use :meth:`value` and :meth:`unit` to get the information separately.
-#[pyclass(eq, module = "qiskit._accelerate.circuit", from_py_object)]
+#[cfg_attr(
+    feature = "py",
+    pyclass(eq, module = "qiskit._accelerate.circuit", from_py_object)
+)]
 #[derive(PartialEq, Clone, Copy, Debug)]
 #[allow(non_camel_case_types)]
 pub enum Duration {
@@ -42,8 +48,9 @@ pub enum Duration {
     s(f64),
 }
 
-#[pymethods]
+#[cfg_attr(feature = "py", pymethods)]
 impl Duration {
+    #[cfg(feature = "py")]
     #[new]
     fn py_new(unit: &str, value: Bound<PyAny>) -> PyResult<Self> {
         match unit {
@@ -73,6 +80,7 @@ impl Duration {
     ///
     /// This will be a Python ``int`` if the :meth:`~Duration.unit` is ``"dt"``,
     /// else a ``float``.
+    #[cfg(feature = "py")]
     #[pyo3(name = "value")]
     pub fn py_value<'py>(&self, py: Python<'py>) -> Bound<'py, PyAny> {
         match *self {
@@ -91,6 +99,7 @@ impl Duration {
         }
     }
 
+    #[cfg(feature = "py")]
     fn __repr__(&self) -> String {
         match self {
             Duration::ps(t) => format!("Duration.ps({t})"),
@@ -102,6 +111,7 @@ impl Duration {
         }
     }
 
+    #[cfg(feature = "py")]
     fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyTuple>> {
         (py.get_type::<Duration>(), (self.unit(), self.py_value(py))).into_pyobject(py)
     }

--- a/crates/circuit/src/instruction.rs
+++ b/crates/circuit/src/instruction.rs
@@ -10,11 +10,14 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+#[cfg(feature = "py")]
 use crate::circuit_data::CircuitData;
 use crate::operations::{OperationRef, Param};
 use ndarray::Array2;
 use num_complex::Complex64;
+#[cfg(feature = "py")]
 use pyo3::exceptions::PyNotImplementedError;
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
 use smallvec::SmallVec;
 
@@ -163,6 +166,7 @@ pub trait Instruction {
     fn try_matrix(&self) -> Option<Array2<Complex64>> {
         match self.op() {
             OperationRef::StandardGate(g) => g.matrix(self.params_view()),
+            #[cfg(feature = "py")]
             OperationRef::PyCustom(i) => i.matrix(),
             OperationRef::Unitary(u) => u.matrix(),
             OperationRef::PauliProductRotation(ppr) => ppr.matrix(),
@@ -171,6 +175,7 @@ pub trait Instruction {
     }
 }
 
+#[cfg(feature = "py")]
 pub fn create_py_op(
     py: Python,
     op: OperationRef,

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -18,13 +18,18 @@ pub mod circuit_data;
 pub mod circuit_drawer;
 pub mod circuit_instruction;
 pub mod classical;
+#[cfg(feature = "py")]
 pub mod converters;
 pub mod dag_circuit;
+#[cfg(feature = "py")]
 pub mod dag_node;
+#[cfg(feature = "py")]
 mod dot_utils;
 pub mod duration;
+#[cfg(feature = "py")]
 pub mod error;
 pub mod gate_matrix;
+#[cfg(feature = "py")]
 pub mod imports;
 pub mod instruction;
 pub mod interner;
@@ -41,15 +46,20 @@ mod variable_mapper;
 pub mod vf2;
 
 use bytemuck::{Pod, Zeroable};
+#[cfg(feature = "py")]
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
+#[cfg(feature = "py")]
 use pyo3::types::{PySequence, PyString, PyTuple};
 
-#[derive(Copy, Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq, FromPyObject, Zeroable, Pod)]
+#[cfg_attr(feature = "py", derive(FromPyObject))]
+#[derive(Copy, Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq, Zeroable, Pod)]
 #[repr(transparent)]
 pub struct Qubit(pub u32);
 
-#[derive(Copy, Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq, FromPyObject, Zeroable, Pod)]
+#[cfg_attr(feature = "py", derive(FromPyObject))]
+#[derive(Copy, Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq, Zeroable, Pod)]
 #[repr(transparent)]
 pub struct Clbit(pub u32);
 
@@ -113,10 +123,12 @@ impl_circuit_identifier!(Var);
 impl_circuit_identifier!(Stretch);
 impl_circuit_identifier!(Block);
 
+#[cfg(feature = "py")]
 pub struct TupleLikeArg<'py> {
     value: Bound<'py, PyTuple>,
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py> FromPyObject<'a, 'py> for TupleLikeArg<'py> {
     type Error = PyErr;
 
@@ -153,6 +165,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for TupleLikeArg<'py> {
 ///
 /// Usually this doesn't matter much to code authors, but it can help a lot when dealing with
 /// references nested in ad-hoc structures, like `(&T1, &T2)`.
+#[cfg(feature = "py")]
 #[macro_export]
 macro_rules! impl_intopyobject_for_copy_pyclass {
     ($ty:ty) => {
@@ -181,6 +194,7 @@ pub enum VarsMode {
     Drop,
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py> FromPyObject<'a, 'py> for VarsMode {
     type Error = PyErr;
 
@@ -208,12 +222,14 @@ pub enum BlocksMode {
 #[derive(Clone, Copy, Debug, thiserror::Error)]
 #[error("exceeded allowed runtime capacity")]
 pub struct CapacityError;
+#[cfg(feature = "py")]
 impl From<CapacityError> for PyErr {
     fn from(val: CapacityError) -> PyErr {
         PyRuntimeError::new_err(val.to_string())
     }
 }
 
+#[cfg(feature = "py")]
 pub fn circuit(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<annotation::PyAnnotation>()?;
     m.add_class::<bit::PyBit>()?;

--- a/crates/circuit/src/nlayout.rs
+++ b/crates/circuit/src/nlayout.rs
@@ -10,8 +10,13 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use std::num::TryFromIntError;
+
+#[cfg(feature = "py")]
 use pyo3::IntoPyObjectExt;
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
+#[cfg(feature = "py")]
 use pyo3::types::PyList;
 
 use hashbrown::HashMap;
@@ -25,19 +30,8 @@ use hashbrown::HashMap;
 macro_rules! qubit_newtype {
     ($id: ident) => {
         #[repr(transparent)]
-        #[derive(
-            Debug,
-            Clone,
-            Copy,
-            PartialEq,
-            Eq,
-            PartialOrd,
-            Ord,
-            Hash,
-            Default,
-            IntoPyObject,
-            IntoPyObjectRef,
-        )]
+        #[cfg_attr(feature = "py", derive(IntoPyObject, IntoPyObjectRef))]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
         pub struct $id(pub u32);
 
         impl $id {
@@ -72,6 +66,7 @@ macro_rules! qubit_newtype {
             }
         }
 
+        #[cfg(feature = "py")]
         impl<'a, 'py> ::pyo3::FromPyObject<'a, 'py> for $id {
             type Error = <u32 as FromPyObject<'a, 'py>>::Error;
 
@@ -80,6 +75,7 @@ macro_rules! qubit_newtype {
             }
         }
 
+        #[cfg(feature = "py")]
         unsafe impl numpy::Element for $id {
             const IS_COPY: bool = true;
 
@@ -134,30 +130,26 @@ impl VirtualQubit {
 ///         physical qubit index on the coupling graph.
 ///     logical_qubits (int): The number of logical qubits in the layout
 ///     physical_qubits (int): The number of physical qubits in the layout
-#[pyclass(module = "qiskit._accelerate.nlayout", skip_from_py_object)]
+#[cfg_attr(
+    feature = "py",
+    pyclass(module = "qiskit._accelerate.nlayout", skip_from_py_object)
+)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NLayout {
     virt_to_phys: Vec<PhysicalQubit>,
     phys_to_virt: Vec<VirtualQubit>,
 }
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl NLayout {
     #[new]
-    fn new(
+    fn py_new(
         qubit_indices: HashMap<VirtualQubit, PhysicalQubit>,
         virtual_qubits: usize,
         physical_qubits: usize,
     ) -> Self {
-        let mut res = NLayout {
-            virt_to_phys: vec![PhysicalQubit(u32::MAX); virtual_qubits],
-            phys_to_virt: vec![VirtualQubit(u32::MAX); physical_qubits],
-        };
-        for (virt, phys) in qubit_indices {
-            res.virt_to_phys[virt.index()] = phys;
-            res.phys_to_virt[phys.index()] = virt;
-        }
-        res
+        Self::new(qubit_indices, virtual_qubits, physical_qubits)
     }
 
     fn __reduce__(&self, py: Python) -> PyResult<Py<PyAny>> {
@@ -185,31 +177,27 @@ impl NLayout {
     }
 
     /// Get physical bit from virtual bit
-    #[pyo3(text_signature = "(self, virtual, /)")]
-    pub fn virtual_to_physical(&self, r#virtual: VirtualQubit) -> PhysicalQubit {
-        self.virt_to_phys[r#virtual.index()]
+    #[pyo3(text_signature = "(self, virtual, /)", name = "virtual_to_physical")]
+    pub fn py_virtual_to_physical(&self, r#virtual: VirtualQubit) -> PhysicalQubit {
+        self.virtual_to_physical(r#virtual)
     }
 
     /// Get virtual bit from physical bit
-    #[pyo3(text_signature = "(self, physical, /)")]
-    pub fn physical_to_virtual(&self, physical: PhysicalQubit) -> VirtualQubit {
-        self.phys_to_virt[physical.index()]
+    #[pyo3(text_signature = "(self, physical, /)", name = "physical_to_virtual")]
+    pub fn py_physical_to_virtual(&self, physical: PhysicalQubit) -> VirtualQubit {
+        self.physical_to_virtual(physical)
     }
 
     /// Swap the specified virtual qubits
-    #[pyo3(text_signature = "(self, bit_a, bit_b, /)")]
-    pub fn swap_virtual(&mut self, bit_a: VirtualQubit, bit_b: VirtualQubit) {
-        self.virt_to_phys.swap(bit_a.index(), bit_b.index());
-        self.phys_to_virt[self.virt_to_phys[bit_a.index()].index()] = bit_a;
-        self.phys_to_virt[self.virt_to_phys[bit_b.index()].index()] = bit_b;
+    #[pyo3(text_signature = "(self, bit_a, bit_b, /)", name = "swap_virtual")]
+    pub fn py_swap_virtual(&mut self, bit_a: VirtualQubit, bit_b: VirtualQubit) {
+        self.swap_virtual(bit_a, bit_b)
     }
 
     /// Swap the specified physical qubits
-    #[pyo3(text_signature = "(self, bit_a, bit_b, /)")]
-    pub fn swap_physical(&mut self, bit_a: PhysicalQubit, bit_b: PhysicalQubit) {
-        self.phys_to_virt.swap(bit_a.index(), bit_b.index());
-        self.virt_to_phys[self.phys_to_virt[bit_a.index()].index()] = bit_a;
-        self.virt_to_phys[self.phys_to_virt[bit_b.index()].index()] = bit_b;
+    #[pyo3(text_signature = "(self, bit_a, bit_b, /)", name = "swap_physical")]
+    pub fn py_swap_physical(&mut self, bit_a: PhysicalQubit, bit_b: PhysicalQubit) {
+        self.swap_physical(bit_a, bit_b)
     }
 
     pub fn copy(&self) -> NLayout {
@@ -217,6 +205,67 @@ impl NLayout {
     }
 
     #[staticmethod]
+    #[pyo3(name = "generate_trivial_layout")]
+    pub fn py_generate_trivial_layout(num_qubits: u32) -> Self {
+        Self::generate_trivial_layout(num_qubits)
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "from_virtual_to_physical")]
+    pub fn py_from_virtual_to_physical(
+        virt_to_phys: Vec<PhysicalQubit>,
+    ) -> Result<Self, TryFromIntError> {
+        Self::from_virtual_to_physical(virt_to_phys)
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "from_physical_to_virtual")]
+    pub fn py_from_physical_to_virtual(phys_to_virt: Vec<VirtualQubit>) -> PyResult<Self> {
+        Ok(Self::from_physical_to_virtual(phys_to_virt)?)
+    }
+}
+
+impl NLayout {
+    fn new(
+        qubit_indices: HashMap<VirtualQubit, PhysicalQubit>,
+        virtual_qubits: usize,
+        physical_qubits: usize,
+    ) -> Self {
+        let mut res = NLayout {
+            virt_to_phys: vec![PhysicalQubit(u32::MAX); virtual_qubits],
+            phys_to_virt: vec![VirtualQubit(u32::MAX); physical_qubits],
+        };
+        for (virt, phys) in qubit_indices {
+            res.virt_to_phys[virt.index()] = phys;
+            res.phys_to_virt[phys.index()] = virt;
+        }
+        res
+    }
+
+    /// Get physical bit from virtual bit
+    pub fn virtual_to_physical(&self, r#virtual: VirtualQubit) -> PhysicalQubit {
+        self.virt_to_phys[r#virtual.index()]
+    }
+
+    /// Get virtual bit from physical bit
+    pub fn physical_to_virtual(&self, physical: PhysicalQubit) -> VirtualQubit {
+        self.phys_to_virt[physical.index()]
+    }
+
+    /// Swap the specified virtual qubits
+    pub fn swap_virtual(&mut self, bit_a: VirtualQubit, bit_b: VirtualQubit) {
+        self.virt_to_phys.swap(bit_a.index(), bit_b.index());
+        self.phys_to_virt[self.virt_to_phys[bit_a.index()].index()] = bit_a;
+        self.phys_to_virt[self.virt_to_phys[bit_b.index()].index()] = bit_b;
+    }
+
+    /// Swap the specified physical qubits
+    pub fn swap_physical(&mut self, bit_a: PhysicalQubit, bit_b: PhysicalQubit) {
+        self.phys_to_virt.swap(bit_a.index(), bit_b.index());
+        self.virt_to_phys[self.phys_to_virt[bit_a.index()].index()] = bit_a;
+        self.virt_to_phys[self.phys_to_virt[bit_b.index()].index()] = bit_b;
+    }
+
     pub fn generate_trivial_layout(num_qubits: u32) -> Self {
         NLayout {
             virt_to_phys: (0..num_qubits).map(PhysicalQubit).collect(),
@@ -224,8 +273,9 @@ impl NLayout {
         }
     }
 
-    #[staticmethod]
-    pub fn from_virtual_to_physical(virt_to_phys: Vec<PhysicalQubit>) -> PyResult<Self> {
+    pub fn from_virtual_to_physical(
+        virt_to_phys: Vec<PhysicalQubit>,
+    ) -> Result<Self, TryFromIntError> {
         let mut phys_to_virt = vec![VirtualQubit(u32::MAX); virt_to_phys.len()];
         for (virt, phys) in virt_to_phys.iter().enumerate() {
             phys_to_virt[phys.index()] = VirtualQubit(virt.try_into()?);
@@ -236,8 +286,9 @@ impl NLayout {
         })
     }
 
-    #[staticmethod]
-    pub fn from_physical_to_virtual(phys_to_virt: Vec<VirtualQubit>) -> PyResult<Self> {
+    pub fn from_physical_to_virtual(
+        phys_to_virt: Vec<VirtualQubit>,
+    ) -> Result<Self, TryFromIntError> {
         let mut virt_to_phys = vec![PhysicalQubit(u32::MAX); phys_to_virt.len()];
         for (phys, virt) in phys_to_virt.iter().enumerate() {
             virt_to_phys[virt.index()] = PhysicalQubit(phys.try_into()?);
@@ -247,9 +298,7 @@ impl NLayout {
             phys_to_virt,
         })
     }
-}
 
-impl NLayout {
     /// Iterator of `(VirtualQubit, PhysicalQubit)` pairs, in order of the `VirtualQubit` indices.
     pub fn iter_virtual(
         &'_ self,
@@ -304,6 +353,7 @@ impl ::std::ops::Index<PhysicalQubit> for NLayout {
     }
 }
 
+#[cfg(feature = "py")]
 pub fn nlayout(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<NLayout>()?;
     Ok(())

--- a/crates/circuit/src/object_registry.rs
+++ b/crates/circuit/src/object_registry.rs
@@ -13,11 +13,17 @@
 use crate::CapacityError;
 use hashbrown::HashMap;
 use hashbrown::hash_map::OccupiedError;
+#[cfg(feature = "py")]
 use pyo3::exceptions::{PyKeyError, PyValueError};
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
+#[cfg(feature = "py")]
 use pyo3::types::PyList;
 use std::fmt::Debug;
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
+#[cfg(feature = "py")]
+use std::hash::Hasher;
+#[cfg(feature = "py")]
 use std::sync::OnceLock;
 
 /// Wrapper for Python-side objects that implements [Hash] and [Eq], allowing them to be
@@ -27,6 +33,7 @@ use std::sync::OnceLock;
 /// [Hash] trait impl.  The impl of [PartialEq] first compares the native Py pointers to determine
 /// equality. If these are not equal, only then does it call `repr()` on both sides, which has a
 /// significant performance advantage.
+#[cfg(feature = "py")]
 #[derive(Clone, Debug)]
 pub struct PyObjectAsKey {
     /// Python's `hash()` of the wrapped instance.
@@ -35,6 +42,7 @@ pub struct PyObjectAsKey {
     ob: Py<PyAny>,
 }
 
+#[cfg(feature = "py")]
 impl PyObjectAsKey {
     pub fn new(object: &Bound<PyAny>) -> Self {
         PyObjectAsKey {
@@ -59,24 +67,28 @@ impl PyObjectAsKey {
     }
 }
 
+#[cfg(feature = "py")]
 impl Hash for PyObjectAsKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
         state.write_isize(self.hash);
     }
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py> From<&'a Bound<'py, PyAny>> for PyObjectAsKey {
     fn from(value: &'a Bound<'py, PyAny>) -> Self {
         PyObjectAsKey::new(value)
     }
 }
 
+#[cfg(feature = "py")]
 impl<'py> From<Bound<'py, PyAny>> for PyObjectAsKey {
     fn from(value: Bound<'py, PyAny>) -> Self {
         PyObjectAsKey::new(&value)
     }
 }
 
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for PyObjectAsKey {
     type Target = PyAny;
     type Output = Bound<'py, PyAny>;
@@ -87,6 +99,7 @@ impl<'py> IntoPyObject<'py> for PyObjectAsKey {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py> IntoPyObject<'py> for &'a PyObjectAsKey {
     type Target = PyAny;
     type Output = Borrowed<'a, 'py, Self::Target>;
@@ -97,6 +110,7 @@ impl<'a, 'py> IntoPyObject<'py> for &'a PyObjectAsKey {
     }
 }
 
+#[cfg(feature = "py")]
 impl PartialEq for PyObjectAsKey {
     fn eq(&self, other: &Self) -> bool {
         self.ob.is(&other.ob)
@@ -111,6 +125,7 @@ impl PartialEq for PyObjectAsKey {
             })
     }
 }
+#[cfg(feature = "py")]
 impl Eq for PyObjectAsKey {}
 
 /// Error types for attempts to add unique objects.
@@ -132,6 +147,7 @@ impl<T: Debug, B: Debug> AddError<T, B> {
         }
     }
 }
+#[cfg(feature = "py")]
 impl<T: Debug, B: Debug> From<AddError<T, B>> for PyErr {
     fn from(val: AddError<T, B>) -> PyErr {
         match val {
@@ -151,6 +167,7 @@ impl<T: Debug> AbsentObject<T> {
         AbsentObject(format!("{:?}", self.0))
     }
 }
+#[cfg(feature = "py")]
 impl<T: Debug> From<AbsentObject<T>> for PyErr {
     fn from(val: AbsentObject<T>) -> Self {
         PyKeyError::new_err(val.to_string())
@@ -172,6 +189,7 @@ pub struct ObjectRegistry<T, B> {
     /// Maps objects to native index.
     indices: HashMap<B, T>,
     /// The objects registered, cached as a PyList.
+    #[cfg(feature = "py")]
     cached: OnceLock<Py<PyList>>,
 }
 
@@ -208,6 +226,7 @@ where
         ObjectRegistry {
             objects: Vec::with_capacity(capacity),
             indices: HashMap::with_capacity(capacity),
+            #[cfg(feature = "py")]
             cached: OnceLock::new(),
         }
     }
@@ -272,6 +291,7 @@ where
     pub fn add(&mut self, object: B) -> Result<T, AddError<T, B>> {
         let idx: u32 = self.objects.len().try_into().map_err(|_| CapacityError)?;
         // Dump the cache
+        #[cfg(feature = "py")]
         self.cached.take();
         match self.indices.try_insert(object.clone(), idx.into()) {
             Ok(_) => {
@@ -298,6 +318,7 @@ where
     }
 
     pub fn replace(&mut self, index: T, replacement: B) {
+        #[cfg(feature = "py")]
         self.cached.take();
         let to_replace = &mut self.objects[<u32 as From<T>>::from(index) as usize];
         self.indices.remove(to_replace);
@@ -311,6 +332,7 @@ where
             .map(|i| <u32 as From<T>>::from(i) as usize)
             .collect();
         indices_sorted.sort();
+        #[cfg(feature = "py")]
         self.cached.take();
         for index in indices_sorted.into_iter().rev() {
             let object = self.objects.remove(index);
@@ -330,6 +352,7 @@ where
     }
 }
 
+#[cfg(feature = "py")]
 impl<'a, T, B> ObjectRegistry<T, B>
 where
     B: Clone,

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -13,26 +13,35 @@
 use approx::relative_eq;
 use qiskit_quantum_info::sparse_pauli_op::MatrixCompressedPaulis;
 use std::any::Any;
+#[cfg(not(feature = "py"))]
+use std::convert::Infallible;
 use std::fmt::Debug;
 use std::num::NonZero;
+#[cfg(not(feature = "py"))]
+use std::num::TryFromIntError;
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::{fmt, vec};
 
+use crate::ControlFlowBlocks;
 use crate::bit::{ClassicalRegister, ShareableClbit};
-use crate::circuit_data::{CircuitData, PyCircuitData};
+use crate::circuit_data::CircuitData;
+#[cfg(feature = "py")]
+use crate::circuit_data::PyCircuitData;
 use crate::classical::expr;
 use crate::classical::expr::Var;
+#[cfg(feature = "py")]
 use crate::converters::QuantumCircuitData;
 use crate::duration::Duration;
+#[cfg(feature = "py")]
+use crate::imports;
 use crate::operations::custom_traits::{ClonableOp, ComparableOp};
 use crate::packed_instruction::{PackedInstruction, PackedOperation};
-use crate::parameter::parameter_expression::{
-    ParameterExpression, PyParameter, PyParameterExpression,
-};
+use crate::parameter::parameter_expression::ParameterExpression;
+#[cfg(feature = "py")]
+use crate::parameter::parameter_expression::{PyParameter, PyParameterExpression};
 use crate::parameter::symbol_expr::{Symbol, Value};
-use crate::{ControlFlowBlocks, imports};
 
 use nalgebra::{Matrix2, Matrix4};
 use ndarray::{Array1, Array2, ArrayView2, Dim, ShapeBuilder, array};
@@ -40,10 +49,15 @@ use num_bigint::BigUint;
 use num_complex::{Complex64, c64};
 use smallvec::SmallVec;
 
+#[cfg(feature = "py")]
 use numpy::{PyArray1, PyReadonlyArray2, ToPyArray};
+#[cfg(feature = "py")]
 use pyo3::exceptions::PyValueError;
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
+#[cfg(feature = "py")]
 use pyo3::types::{IntoPyDict, PyDict, PyFloat, PyInt, PyTuple, PyType};
+#[cfg(feature = "py")]
 use pyo3::{IntoPyObjectExt, Python, intern};
 
 // This is a convenience re-export, since basically everywhere in Qiskit expects all the
@@ -55,9 +69,11 @@ pub enum Param {
     ParameterExpression(Arc<ParameterExpression>),
     Int(u64),
     Float(f64),
+    #[cfg(feature = "py")]
     Obj(Py<PyAny>),
 }
 
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for &Param {
     type Target = PyAny; // target type is PyAny to cover f64, Py<PyAny> and PyParameterExpression
     type Output = Bound<'py, Self::Target>;
@@ -76,6 +92,7 @@ impl<'py> IntoPyObject<'py> for &Param {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for Param {
     type Target = PyAny;
     type Output = Bound<'py, Self::Target>;
@@ -86,6 +103,7 @@ impl<'py> IntoPyObject<'py> for Param {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py> FromPyObject<'a, 'py> for Param {
     type Error = ::std::convert::Infallible;
 
@@ -113,6 +131,7 @@ impl Param {
             _ => None,
         }
     }
+    #[cfg(feature = "py")]
     pub fn eq(&self, other: &Param) -> PyResult<bool> {
         match [self, other] {
             [Self::Float(a), Self::Float(b)] => Ok(a == b),
@@ -142,13 +161,44 @@ impl Param {
         }
     }
 
+    #[cfg(not(feature = "py"))]
+    pub fn eq(&self, other: &Param) -> Result<bool, TryFromIntError> {
+        match [self, other] {
+            [Self::Float(a), Self::Float(b)] => Ok(a == b),
+            [Self::Float(a), Self::ParameterExpression(b)] => {
+                Ok(&ParameterExpression::from_f64(*a) == b.as_ref())
+            }
+            [Self::ParameterExpression(a), Self::Float(b)] => {
+                Ok(a.as_ref() == &ParameterExpression::from_f64(*b))
+            }
+            [Self::ParameterExpression(a), Self::ParameterExpression(b)] => Ok(a == b),
+            [Self::Int(int), Self::Int(other_int)] => Ok(int == other_int),
+            [Self::Int(int), Self::Float(float)] | [Self::Float(float), Self::Int(int)] => {
+                Ok(float == &(*int as f64))
+            }
+            [Self::Int(int), Self::ParameterExpression(expr)]
+            | [Self::ParameterExpression(expr), Self::Int(int)] => {
+                Ok(ParameterExpression::try_from(*int).map(|i_expr| i_expr == **expr)?)
+            }
+        }
+    }
+
+    #[cfg(feature = "py")]
     pub fn is_close(&self, other: &Param, max_relative: f64) -> PyResult<bool> {
         match [self, other] {
             [Self::Float(a), Self::Float(b)] => Ok(relative_eq!(a, b, max_relative = max_relative)),
             _ => self.eq(other),
         }
     }
+    #[cfg(not(feature = "py"))]
+    pub fn is_close(&self, other: &Param, max_relative: f64) -> Result<bool, TryFromIntError> {
+        match [self, other] {
+            [Self::Float(a), Self::Float(b)] => Ok(relative_eq!(a, b, max_relative = max_relative)),
+            _ => self.eq(other),
+        }
+    }
 
+    #[cfg(feature = "py")]
     // TODO: Replace `Box<dyn Iterator>` with a custom iterator struct. The
     // Box<dyn Iterator> is an anti-pattern which shouldn't really be needed.
     /// Get an iterator over any `Symbol` instances tracked within this `Param`.
@@ -178,6 +228,50 @@ impl Param {
         }
     }
 
+    #[cfg(not(feature = "py"))]
+    // TODO: Replace `Box<dyn Iterator>` with a custom iterator struct. The
+    // Box<dyn Iterator> is an anti-pattern which shouldn't really be needed.
+    /// Get an iterator over any `Symbol` instances tracked within this `Param`.
+    pub fn iter_parameters(&self) -> Result<Box<dyn Iterator<Item = Symbol> + '_>, Infallible> {
+        match self {
+            Param::Float(_) | Param::Int(_) => Ok(Box::new(::std::iter::empty())),
+            Param::ParameterExpression(expr) => Ok(Box::new(expr.iter_symbols().cloned())),
+        }
+    }
+
+    // #[cfg(not(feature = "py"))]
+    /// Construct a [Param] from a [ParameterExpression]. Allows type coercion.
+    ///
+    /// # Arguments
+    ///
+    /// * expr - The expression to construct the [Param] from.
+    /// * coerce_to_float - If `true`, coerce integers and complex (with 0 imaginary part) types to
+    ///   [Param::Float]. If `false`, only float types are [Param::Float] and integers and
+    ///   complex numbers are represented as [Param::ParameterExpression].
+    ///
+    /// # Returns
+    ///
+    /// - `Param` - The [Param] object.
+    #[cfg(not(feature = "py"))]
+    pub fn from_expr(expr: ParameterExpression, coerce_to_float: bool) -> Option<Self> {
+        match expr.try_to_value(true) {
+            Ok(value) => match value {
+                Value::Int(i) => {
+                    coerce_to_float.then(|| Self::Float(i as f64)) // coerce integer to float
+                }
+                Value::Real(f) => Some(Self::Float(f)),
+                Value::Complex(c) => {
+                    // Complex numbers are only defined in Python custom
+                    // objects and aren't valid gate parameters for
+                    // anything else so return none
+                    (coerce_to_float && value.is_real()).then(|| Self::Float(c.re))
+                }
+            },
+            Err(_) => Some(Self::ParameterExpression(Arc::new(expr))),
+        }
+    }
+
+    #[cfg(feature = "py")]
     /// Construct a [Param] from a [ParameterExpression]. Allows type coercion.
     ///
     /// # Arguments
@@ -221,6 +315,7 @@ impl Param {
         }
     }
 
+    #[cfg(feature = "py")]
     /// Extract from a Python object without numeric coercion to float.  The default conversion will
     /// coerce integers into floats, but in things like `assign_parameters`, this is not always
     /// desirable.
@@ -256,6 +351,7 @@ impl Param {
         })
     }
 
+    #[cfg(feature = "py")]
     /// Clones the [Param] object safely by reference count or copying.
     pub fn clone_ref(&self, py: Python) -> Self {
         match self {
@@ -266,6 +362,7 @@ impl Param {
         }
     }
 
+    #[cfg(feature = "py")]
     pub fn py_deepcopy<'py>(
         &self,
         py: Python<'py>,
@@ -318,6 +415,7 @@ pub enum OperationRef<'a> {
     ControlFlow(&'a ControlFlowInstruction),
     StandardGate(StandardGate),
     StandardInstruction(StandardInstruction),
+    #[cfg(feature = "py")]
     PyCustom(&'a PyInstruction),
     Unitary(&'a UnitaryGate),
     PauliProductMeasurement(&'a PauliProductMeasurement),
@@ -332,6 +430,7 @@ impl Operation for OperationRef<'_> {
             Self::ControlFlow(op) => op.name(),
             Self::StandardGate(standard) => standard.name(),
             Self::StandardInstruction(instruction) => instruction.name(),
+            #[cfg(feature = "py")]
             Self::PyCustom(inst) => inst.name(),
             Self::Unitary(unitary) => unitary.name(),
             Self::PauliProductMeasurement(ppm) => ppm.name(),
@@ -345,6 +444,7 @@ impl Operation for OperationRef<'_> {
             Self::ControlFlow(op) => op.num_qubits(),
             Self::StandardGate(standard) => standard.num_qubits(),
             Self::StandardInstruction(instruction) => instruction.num_qubits(),
+            #[cfg(feature = "py")]
             Self::PyCustom(inst) => inst.num_qubits(),
             Self::Unitary(unitary) => unitary.num_qubits(),
             Self::PauliProductMeasurement(ppm) => ppm.num_qubits(),
@@ -358,6 +458,7 @@ impl Operation for OperationRef<'_> {
             Self::ControlFlow(op) => op.num_clbits(),
             Self::StandardGate(standard) => standard.num_clbits(),
             Self::StandardInstruction(instruction) => instruction.num_clbits(),
+            #[cfg(feature = "py")]
             Self::PyCustom(inst) => inst.num_clbits(),
             Self::Unitary(unitary) => unitary.num_clbits(),
             Self::PauliProductMeasurement(ppm) => ppm.num_clbits(),
@@ -371,6 +472,7 @@ impl Operation for OperationRef<'_> {
             Self::ControlFlow(op) => op.num_params(),
             Self::StandardGate(standard) => standard.num_params(),
             Self::StandardInstruction(instruction) => instruction.num_params(),
+            #[cfg(feature = "py")]
             Self::PyCustom(inst) => inst.num_params(),
             Self::Unitary(unitary) => unitary.num_params(),
             Self::PauliProductMeasurement(ppm) => ppm.num_params(),
@@ -384,6 +486,7 @@ impl Operation for OperationRef<'_> {
             Self::ControlFlow(op) => op.directive(),
             Self::StandardGate(standard) => standard.directive(),
             Self::StandardInstruction(instruction) => instruction.directive(),
+            #[cfg(feature = "py")]
             Self::PyCustom(inst) => inst.directive(),
             Self::Unitary(unitary) => unitary.directive(),
             Self::PauliProductMeasurement(ppm) => ppm.directive(),
@@ -396,7 +499,10 @@ impl Operation for OperationRef<'_> {
 /// Used to tag control flow instructions via the `_control_flow_type` class
 /// attribute in the corresponding Python class.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[pyclass(module = "qiskit._accelerate.circuit", eq, eq_int, from_py_object)]
+#[cfg_attr(
+    feature = "py",
+    pyclass(module = "qiskit._accelerate.circuit", eq, eq_int, from_py_object)
+)]
 #[repr(u8)]
 pub enum ControlFlowType {
     Box = 0,
@@ -439,7 +545,8 @@ impl FromStr for ControlFlowType {
     }
 }
 
-#[derive(Clone, Debug, IntoPyObject, PartialEq)]
+#[cfg_attr(feature = "py", derive(IntoPyObject))]
+#[derive(Clone, Debug, PartialEq)]
 pub enum BoxDuration {
     Duration(Duration),
     Expr(expr::Expr),
@@ -477,6 +584,7 @@ impl PyRange {
         }
     }
 }
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for PyRange {
     type Target = ::pyo3::types::PyRange;
     type Output = Bound<'py, Self::Target>;
@@ -485,6 +593,7 @@ impl<'py> IntoPyObject<'py> for PyRange {
         ::pyo3::types::PyRange::new_with_step(py, self.start, self.stop, self.step.get())
     }
 }
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for &'_ PyRange {
     type Target = <PyRange as IntoPyObject<'py>>::Target;
     type Output = <PyRange as IntoPyObject<'py>>::Output;
@@ -493,6 +602,7 @@ impl<'py> IntoPyObject<'py> for &'_ PyRange {
         (*self).into_pyobject(py)
     }
 }
+#[cfg(feature = "py")]
 impl<'a, 'py> FromPyObject<'a, 'py> for PyRange {
     type Error = PyErr;
     fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
@@ -508,7 +618,8 @@ impl<'a, 'py> FromPyObject<'a, 'py> for PyRange {
 }
 
 /// Possible specifications of the "collection" that a for loop iterates over.
-#[derive(Clone, Debug, IntoPyObject, IntoPyObjectRef, FromPyObject, PartialEq, Eq)]
+#[cfg_attr(feature = "py", derive(IntoPyObject, IntoPyObjectRef, FromPyObject))]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ForCollection {
     /// A literal Python `range` object extracted to Rust.
     PyRange(PyRange),
@@ -543,6 +654,7 @@ pub enum LoopParam {
     Variable(Var),
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py> FromPyObject<'a, 'py> for LoopParam {
     type Error = PyErr;
 
@@ -557,6 +669,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for LoopParam {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for LoopParam {
     type Target = PyAny;
     type Output = Bound<'py, Self::Target>;
@@ -596,6 +709,7 @@ pub enum ControlFlow {
     },
 }
 
+#[cfg(feature = "py")]
 impl ControlFlowInstruction {
     /// Check if another control flow operations is equivalent to this one.
     ///
@@ -946,13 +1060,15 @@ impl<'a, T> ControlFlowView<'a, T> {
 }
 
 /// A control flow operation's condition.
-#[derive(Clone, Debug, PartialEq, IntoPyObject)]
+#[cfg_attr(feature = "py", derive(IntoPyObject))]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Condition {
     Bit(ShareableClbit, bool),
     Register(ClassicalRegister, BigUint),
     Expr(expr::Expr),
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py> FromPyObject<'a, 'py> for Condition {
     type Error = <expr::Expr as FromPyObject<'a, 'py>>::Error;
 
@@ -968,13 +1084,15 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Condition {
 }
 
 /// A control flow operation's target.
-#[derive(Clone, Debug, PartialEq, IntoPyObject)]
+#[cfg_attr(feature = "py", derive(IntoPyObject))]
+#[derive(Clone, Debug, PartialEq)]
 pub enum SwitchTarget {
     Bit(ShareableClbit),
     Register(ClassicalRegister),
     Expr(expr::Expr),
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py> FromPyObject<'a, 'py> for SwitchTarget {
     type Error = <expr::Expr as FromPyObject<'a, 'py>>::Error;
 
@@ -995,6 +1113,7 @@ pub enum CaseSpecifier {
     Default,
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py> FromPyObject<'a, 'py> for CaseSpecifier {
     type Error = PyErr;
 
@@ -1009,6 +1128,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for CaseSpecifier {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for CaseSpecifier {
     type Target = PyAny;
     type Output = Bound<'py, PyAny>;
@@ -1061,6 +1181,7 @@ impl fmt::Display for DelayUnit {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py> FromPyObject<'a, 'py> for DelayUnit {
     type Error = PyErr;
 
@@ -1089,7 +1210,10 @@ impl<'a, 'py> FromPyObject<'a, 'py> for DelayUnit {
 /// This is also used to tag standard instructions via the `_standard_instruction_type` class
 /// attribute in the corresponding Python class.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[pyclass(module = "qiskit._accelerate.circuit", eq, eq_int, from_py_object)]
+#[cfg_attr(
+    feature = "py",
+    pyclass(module = "qiskit._accelerate.circuit", eq, eq_int, from_py_object)
+)]
 #[repr(u8)]
 pub enum StandardInstructionType {
     Barrier = 0,
@@ -1192,6 +1316,7 @@ impl Operation for StandardInstruction {
     }
 }
 
+#[cfg(feature = "py")]
 impl StandardInstruction {
     pub fn create_py_op(
         &self,
@@ -1229,6 +1354,7 @@ pub fn clone_param(param: &Param) -> Param {
     match param {
         Param::Float(theta) => Param::Float(*theta),
         Param::ParameterExpression(theta) => Param::ParameterExpression(theta.clone()),
+        #[cfg(feature = "py")]
         Param::Obj(_) => unreachable!(),
         Param::Int(int) => Param::Int(*int),
     }
@@ -1245,6 +1371,7 @@ pub fn multiply_param(param: &Param, mult: f64) -> Param {
                 theta.mul(&ParameterExpression::from_f64(mult)).unwrap(),
             ))
         }
+        #[cfg(feature = "py")]
         Param::Obj(_) => unreachable!("Unsupported multiplication of a Param::Obj."),
     }
 }
@@ -1271,6 +1398,7 @@ pub fn add_param(param: &Param, summand: f64) -> Param {
             // safe to unwrap as addition with float does not have name conflicts
             Arc::new(theta.add(&ParameterExpression::from_f64(summand)).unwrap()),
         ),
+        #[cfg(feature = "py")]
         Param::Obj(_) => unreachable!("Unsupported addition of a Param::Obj."),
         Param::Int(int) => Param::Float(summand + (*int as f64)),
     }
@@ -1294,6 +1422,7 @@ pub fn radd_param(param1: Param, param2: Param) -> Param {
 
 /// This trait is defined on operation types in the circuit that are defined in Python.
 /// It contains the methods for managing the Python aspect
+#[cfg(feature = "py")]
 pub trait PythonOperation: Sized {
     /// Copy this operation, including a Python-space deep copy
     fn py_deepcopy(&self, py: Python, memo: Option<&Bound<'_, PyDict>>) -> PyResult<Self>;
@@ -1308,6 +1437,7 @@ pub trait PythonOperation: Sized {
 /// incorporates all of `Instruction`, which in turn incorporates all of `Operation`.  `Gate` means
 /// the operation represents a unitary action, `Instruction` is general and (usually) has a built-in
 /// hierarchical definition, while `Operation` is nearly entirely opaque.
+#[cfg(feature = "py")]
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
 pub enum PyOpKind {
     /// The instruction implements only `Operation`.
@@ -1317,6 +1447,7 @@ pub enum PyOpKind {
     /// The instruction is a subclass of `Gate`.
     Gate,
 }
+#[cfg(feature = "py")]
 impl PyOpKind {
     /// Get the operation kind from a Python type.
     ///
@@ -1344,6 +1475,7 @@ impl PyOpKind {
 /// If you find yourself deeply inspecting or traversing the internal Python object manually,
 /// something is probably not right; there is likely either something missing from Rust space, or
 /// the Rust-space code is too tightly coupled to a custom Python object.
+#[cfg(feature = "py")]
 #[derive(Clone, Debug)]
 #[repr(align(8))] // This is a `PackedOperation` packed pointer, so needs a fixed alignment.
 pub struct PyInstruction {
@@ -1357,6 +1489,7 @@ pub struct PyInstruction {
     pub ob: Py<PyAny>,
 }
 
+#[cfg(feature = "py")]
 impl PythonOperation for PyInstruction {
     fn py_deepcopy(&self, py: Python, memo: Option<&Bound<'_, PyDict>>) -> PyResult<Self> {
         let deepcopy = imports::DEEPCOPY.get_bound(py);
@@ -1375,6 +1508,7 @@ impl PythonOperation for PyInstruction {
     }
 }
 
+#[cfg(feature = "py")]
 impl Operation for PyInstruction {
     fn name(&self) -> &str {
         self.op_name.as_str()
@@ -1402,6 +1536,7 @@ impl Operation for PyInstruction {
     }
 }
 
+#[cfg(feature = "py")]
 impl PyInstruction {
     /// returns the number of control qubits in the instruction, if any.
     pub fn num_ctrl_qubits(&self) -> Option<u32> {
@@ -1687,6 +1822,7 @@ impl UnitaryGate {
 }
 
 impl UnitaryGate {
+    #[cfg(feature = "py")]
     pub fn create_py_op(&self, py: Python, label: Option<&str>) -> PyResult<Py<PyAny>> {
         let kwargs = PyDict::new(py);
         if let Some(label) = label {
@@ -1768,6 +1904,7 @@ impl Operation for PauliProductRotation {
 }
 
 impl PauliProductRotation {
+    #[cfg(feature = "py")]
     pub fn create_py_op(&self, py: Python, label: Option<&str>) -> PyResult<Py<PyAny>> {
         let z = self.z.to_pyarray(py);
         let x = self.x.to_pyarray(py);
@@ -1927,6 +2064,7 @@ impl Operation for PauliProductMeasurement {
 }
 
 impl PauliProductMeasurement {
+    #[cfg(feature = "py")]
     pub fn create_py_op(&self, py: Python, label: Option<&str>) -> PyResult<Py<PyAny>> {
         let z = self.z.to_pyarray(py);
         let x = self.x.to_pyarray(py);

--- a/crates/circuit/src/packed_instruction.rs
+++ b/crates/circuit/src/packed_instruction.rs
@@ -11,6 +11,7 @@
 // that they have been altered from the originals.
 
 use crate::circuit_data::CircuitData;
+#[cfg(feature = "py")]
 use crate::imports::{
     BARRIER, BOX_OP, BREAK_LOOP_OP, CONTINUE_LOOP_OP, DELAY, FOR_LOOP_OP, IF_ELSE_OP, MEASURE,
     PAULI_PRODUCT_MEASUREMENT, PAULI_PRODUCT_ROTATION_GATE, RESET, SWITCH_CASE_OP, UNITARY_GATE,
@@ -18,18 +19,24 @@ use crate::imports::{
 };
 use crate::instruction::Parameters;
 use crate::interner::Interned;
+#[cfg(feature = "py")]
+use crate::operations::ControlFlow;
 use crate::operations::{
-    BoxedCustomOperation, ControlFlow, ControlFlowInstruction, CustomOperation, Operation,
-    OperationRef, Param, PauliBased, PyInstruction, PyOpKind, PythonOperation, StandardGate,
-    StandardInstruction, UnitaryGate,
+    BoxedCustomOperation, ControlFlowInstruction, CustomOperation, Operation, OperationRef, Param,
+    PauliBased, StandardGate, StandardInstruction, UnitaryGate,
 };
+#[cfg(feature = "py")]
+use crate::operations::{PyInstruction, PyOpKind, PythonOperation};
 use crate::{Block, Clbit, Qubit};
 use hashbrown::HashMap;
 use nalgebra::{Matrix2, Matrix4};
 use ndarray::{Array2, CowArray, Ix2};
 use num_complex::Complex64;
+#[cfg(feature = "py")]
 use pyo3::exceptions::PyNotImplementedError;
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
+#[cfg(feature = "py")]
 use pyo3::types::{PyDict, PyType};
 use smallvec::SmallVec;
 #[cfg(feature = "cache_pygates")]
@@ -44,6 +51,7 @@ enum PackedOperationType {
     // dereferencing.
     StandardGate = 0,
     StandardInstruction = 1,
+    #[cfg(feature = "py")]
     PyInstruction = 2,
     UnitaryGate = 3,
     PauliBased = 4,
@@ -358,9 +366,9 @@ mod standard_instruction {
 
 /// A private module to encapsulate the encoding of pointer types.
 mod pointer {
-    use crate::operations::{
-        BoxedCustomOperation, ControlFlowInstruction, PyInstruction, UnitaryGate,
-    };
+    #[cfg(feature = "py")]
+    use crate::operations::PyInstruction;
+    use crate::operations::{BoxedCustomOperation, ControlFlowInstruction, UnitaryGate};
     use crate::packed_instruction::{PackedOperation, PackedOperationType, PauliBased};
     use std::ptr::NonNull;
 
@@ -440,6 +448,7 @@ mod pointer {
         };
     }
 
+    #[cfg(feature = "py")]
     impl_packable_pointer!(PyInstruction, PackedOperationType::PyInstruction);
     impl_packable_pointer!(UnitaryGate, PackedOperationType::UnitaryGate);
     impl_packable_pointer!(PauliBased, PackedOperationType::PauliBased);
@@ -502,6 +511,7 @@ impl PackedOperation {
     }
 
     /// View the internal `PyInstruction`, if any.
+    #[cfg(feature = "py")]
     #[inline]
     pub fn try_py_custom(&self) -> Option<&PyInstruction> {
         <&PyInstruction as TryFrom<&Self>>::try_from(self).ok()
@@ -516,6 +526,7 @@ impl PackedOperation {
             PackedOperationType::StandardInstruction => {
                 OperationRef::StandardInstruction(self.standard_instruction())
             }
+            #[cfg(feature = "py")]
             PackedOperationType::PyInstruction => OperationRef::PyCustom(self.try_into().unwrap()),
             PackedOperationType::UnitaryGate => OperationRef::Unitary(self.try_into().unwrap()),
             PackedOperationType::PauliBased => {
@@ -547,6 +558,7 @@ impl PackedOperation {
                 let opaque: &BoxedCustomOperation = self.try_into().unwrap();
                 opaque.is_unitary()
             }
+            #[cfg(feature = "py")]
             PackedOperationType::PyInstruction => {
                 let op: &PyInstruction = self.try_into().unwrap();
                 op.kind == PyOpKind::Gate
@@ -569,6 +581,7 @@ impl PackedOperation {
 
     /// Construct a new `PackedOperation` from an owned heap-allocated `PyInstruction`.
     #[inline]
+    #[cfg(feature = "py")]
     pub fn from_py_instruction(op: Box<PyInstruction>) -> Self {
         op.into()
     }
@@ -599,6 +612,7 @@ impl PackedOperation {
     /// Clone this `PackedOperation`, deepcopying if the internal object is a Python object.
     ///
     /// This is similar to [py_deepcopy], but only attaches to a Python interpreter if it has to.
+    #[cfg(feature = "py")]
     pub fn clone_with_py_deepcopy(&self) -> PyResult<Self> {
         match self.view() {
             OperationRef::PyCustom(inst) => {
@@ -614,6 +628,7 @@ impl PackedOperation {
         }
     }
 
+    #[cfg(feature = "py")]
     pub fn py_deepcopy<'py>(
         &self,
         py: Python<'py>,
@@ -632,6 +647,7 @@ impl PackedOperation {
     }
 
     /// Check equality of the operation, including Python-space checks, if appropriate.
+    #[cfg(feature = "py")]
     pub fn py_eq(&self, py: Python, other: &PackedOperation) -> PyResult<bool> {
         match (self.view(), other.view()) {
             (OperationRef::ControlFlow(left), OperationRef::ControlFlow(right)) => {
@@ -662,6 +678,7 @@ impl PackedOperation {
     /// Whether the Python class that we would use to represent the inner `Operation` object in
     /// Python space would be an instance of the given Python type.  This does not construct the
     /// Python-space `Operator` instance if it can be avoided (i.e. for standard gates).
+    #[cfg(feature = "py")]
     pub fn py_op_is_instance(&self, py_type: &Bound<PyType>) -> PyResult<bool> {
         let py = py_type.py();
         match self.view() {
@@ -739,6 +756,7 @@ impl Operation for PackedOperation {
             OperationRef::ControlFlow(control_flow) => control_flow.name(),
             OperationRef::StandardGate(ref standard) => standard.name(),
             OperationRef::StandardInstruction(ref instruction) => instruction.name(),
+            #[cfg(feature = "py")]
             OperationRef::PyCustom(inst) => inst.name(),
             OperationRef::Unitary(unitary) => unitary.name(),
             OperationRef::PauliProductMeasurement(ppm) => ppm.name(),
@@ -783,6 +801,7 @@ impl Clone for PackedOperation {
             OperationRef::StandardInstruction(instruction) => {
                 Self::from_standard_instruction(instruction)
             }
+            #[cfg(feature = "py")]
             OperationRef::PyCustom(inst) => Self::from_py_instruction(Box::new(inst.clone())),
             OperationRef::Unitary(unitary) => Self::from_unitary(Box::new(unitary.clone())),
             OperationRef::PauliProductMeasurement(ppm) => {
@@ -803,6 +822,7 @@ impl Drop for PackedOperation {
         use crate::packed_instruction::pointer::PackablePointer;
         match self.discriminant() {
             PackedOperationType::StandardGate | PackedOperationType::StandardInstruction => (),
+            #[cfg(feature = "py")]
             PackedOperationType::PyInstruction => PyInstruction::drop_packed(self),
             PackedOperationType::UnitaryGate => UnitaryGate::drop_packed(self),
             PackedOperationType::PauliBased => PauliBased::drop_packed(self),
@@ -972,6 +992,7 @@ impl PackedInstruction {
         })
     }
 
+    #[cfg(feature = "py")]
     pub fn py_deepcopy_inplace<'py>(
         &mut self,
         py: Python<'py>,
@@ -999,6 +1020,7 @@ impl PackedInstruction {
         match self.op.view() {
             OperationRef::StandardGate(g) => g.matrix(self.params_view()),
             OperationRef::CustomOperation(g) => g.matrix(self.params_view()),
+            #[cfg(feature = "py")]
             OperationRef::PyCustom(p) => p.matrix(),
             OperationRef::Unitary(u) => u.matrix(),
             OperationRef::PauliProductRotation(ppr) => ppr.matrix(),
@@ -1013,6 +1035,7 @@ impl PackedInstruction {
     pub fn try_cow_array(&self) -> Option<CowArray<'_, Complex64, Ix2>> {
         match self.op.view() {
             OperationRef::StandardGate(g) => g.matrix(self.params_view()).map(CowArray::from),
+            #[cfg(feature = "py")]
             OperationRef::PyCustom(p) => p.matrix().map(CowArray::from),
             OperationRef::PauliProductRotation(ppr) => ppr.matrix().map(CowArray::from),
             OperationRef::Unitary(u) => Some(CowArray::from(u.matrix_view())),
@@ -1028,6 +1051,7 @@ impl PackedInstruction {
             OperationRef::StandardGate(standard) => {
                 standard.matrix_as_static_1q(self.params_view())
             }
+            #[cfg(feature = "py")]
             OperationRef::PyCustom(inst) => inst.matrix_as_static_1q(),
             OperationRef::PauliProductRotation(ppr) => ppr.matrix_as_static_1q(),
             OperationRef::Unitary(unitary) => unitary.matrix_as_static_1q(),
@@ -1061,6 +1085,7 @@ impl PackedInstruction {
             OperationRef::StandardGate(standard) => {
                 standard.matrix_as_static_2q(self.params_view())
             }
+            #[cfg(feature = "py")]
             OperationRef::PyCustom(p) => p.matrix_as_static_2q(),
             OperationRef::PauliProductRotation(ppr) => ppr.matrix_as_static_2q(),
             OperationRef::Unitary(unitary) => unitary.matrix_as_static_2q(),
@@ -1086,6 +1111,7 @@ impl PackedInstruction {
     pub fn try_definition(&self) -> Option<CircuitData> {
         match self.op.view() {
             OperationRef::StandardGate(g) => g.definition(self.params_view()),
+            #[cfg(feature = "py")]
             OperationRef::PyCustom(i) => i.definition(),
             OperationRef::CustomOperation(g) => g.definition(self.params_view()),
             _ => None,

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -13,33 +13,51 @@
 use hashbrown::hash_map::Entry;
 use hashbrown::{HashMap, HashSet};
 use num_complex::Complex64;
+use std::convert::Infallible;
 use std::num::TryFromIntError;
-use std::sync::{Arc, atomic};
+use std::sync::Arc;
+
+#[cfg(feature = "py")]
+use std::sync::atomic;
 use thiserror::Error;
+#[cfg(feature = "py")]
 use uuid::Uuid;
 
+#[cfg(feature = "py")]
 use std::collections::hash_map::DefaultHasher;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
+#[cfg(feature = "py")]
 use pyo3::exceptions::{
     PyDeprecationWarning, PyRuntimeError, PyTypeError, PyValueError, PyZeroDivisionError,
 };
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
+#[cfg(feature = "py")]
 use pyo3::sync::PyOnceLock;
+#[cfg(feature = "py")]
 use pyo3::types::{
     IntoPyDict, PyComplex, PyFloat, PyInt, PyIterator, PyList, PyNotImplemented, PySet, PyString,
     PyTuple,
 };
+#[cfg(feature = "py")]
 use pyo3::{IntoPyObjectExt, intern};
 
+#[cfg(feature = "py")]
 use crate::circuit_data::CircuitError;
+#[cfg(feature = "py")]
 use crate::imports::{BUILTIN_HASH, SYMPIFY_PARAMETER_EXPRESSION, UUID, WARNINGS_WARN};
-use crate::parameter::symbol_expr::{self, SymbolExpr, SymbolVector};
+#[cfg(feature = "py")]
+use crate::parameter::symbol_expr::SymbolVector;
+use crate::parameter::symbol_expr::{self, SymbolExpr};
+#[cfg(feature = "py")]
 use crate::parameter::symbol_parser::parse_expression;
 use qiskit_util::IndexSet;
 
-use super::symbol_expr::{SYMEXPR_EPSILON, Symbol, Value};
+#[cfg(feature = "py")]
+use super::symbol_expr::SYMEXPR_EPSILON;
+use super::symbol_expr::{Symbol, Value};
 
 /// Errors for dealing with parameters and parameter expressions.
 #[derive(Error, Debug)]
@@ -66,6 +84,7 @@ pub enum ParameterError {
     DerivativeNotSupported(String),
 }
 
+#[cfg(feature = "py")]
 impl From<ParameterError> for PyErr {
     fn from(value: ParameterError) -> Self {
         match value {
@@ -138,6 +157,7 @@ impl fmt::Display for ParameterExpression {
     }
 }
 
+#[cfg(feature = "py")]
 impl ParameterExpression {
     pub fn qpy_replay(&self) -> Vec<OPReplay> {
         let mut replay = Vec::new();
@@ -205,6 +225,7 @@ impl ParameterExpression {
 // the Python classes Parameter and ParameterVector are subclasses of
 // ParameterExpression and the default trait impl would not handle the specialization
 // there.
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for ParameterExpression {
     type Target = PyParameterExpression;
     type Output = Bound<'py, Self::Target>;
@@ -331,6 +352,7 @@ impl ParameterExpression {
     }
 
     /// Load from a sequence of [OPReplay]s. Used in serialization.
+    // #[cfg(feature = "py")]
     pub fn from_qpy(replay: &[OPReplay]) -> Result<Self, ParameterError> {
         // the stack contains the latest lhs and rhs values
         let mut stack: Vec<ParameterExpression> = Vec::new();
@@ -786,6 +808,7 @@ impl TryFrom<u64> for ParameterExpression {
 ///
 /// This is backed by Qiskit's symbolic expression engine and a cache
 /// for the parameters inside the expression.
+#[cfg(feature = "py")]
 #[pyclass(
     subclass,
     module = "qiskit._accelerate.circuit",
@@ -797,6 +820,7 @@ pub struct PyParameterExpression {
     pub inner: ParameterExpression,
 }
 
+#[cfg(feature = "py")]
 impl Default for PyParameterExpression {
     /// The default constructor returns zero.
     fn default() -> Self {
@@ -806,18 +830,21 @@ impl Default for PyParameterExpression {
     }
 }
 
+#[cfg(feature = "py")]
 impl fmt::Display for PyParameterExpression {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.inner.fmt(f)
     }
 }
 
+#[cfg(feature = "py")]
 impl From<ParameterExpression> for PyParameterExpression {
     fn from(value: ParameterExpression) -> Self {
         Self { inner: value }
     }
 }
 
+#[cfg(feature = "py")]
 impl PyParameterExpression {
     /// Attempt to extract a `PyParameterExpression` from a bound `PyAny`.
     ///
@@ -873,6 +900,7 @@ impl PyParameterExpression {
     }
 }
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyParameterExpression {
     /// Simplify the expression. This, for example, attempts to cancel
@@ -1483,6 +1511,7 @@ impl PyParameterExpression {
 ///         bc = qc.assign_parameters({phi: 3.14})
 ///         bc.measure_all()
 ///         bc.draw("mpl")
+#[cfg(feature = "py")]
 #[pyclass(
     sequence,
     subclass,
@@ -1494,6 +1523,7 @@ impl PyParameterExpression {
 )]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Hash)]
 pub struct PyParameter(pub Arc<Symbol>);
+#[cfg(feature = "py")]
 impl From<Symbol> for PyParameter {
     fn from(val: Symbol) -> Self {
         Self(Arc::new(val))
@@ -1502,6 +1532,7 @@ impl From<Symbol> for PyParameter {
 
 // This needs to be implemented manually, since PyO3 does not provide this conversion
 // for subclasses.
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for PyParameter {
     type Target = PyAny;
     type Output = Bound<'py, Self::Target>;
@@ -1521,6 +1552,7 @@ impl<'py> IntoPyObject<'py> for PyParameter {
     }
 }
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyParameter {
     /// Args:
@@ -1695,6 +1727,7 @@ impl PyParameter {
 /// .. note::
 ///     There is very little reason to ever construct this class directly.  Objects of this type are
 ///     automatically constructed efficiently as part of creating a :class:`.ParameterVector`.
+#[cfg(feature = "py")]
 #[pyclass(
     sequence,
     subclass,
@@ -1708,6 +1741,7 @@ impl PyParameter {
 // Python type-level marker.  Nothing in Rust space should actually use this.
 pub(crate) struct PyParameterVectorElement;
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyParameterVectorElement {
     #[new]
@@ -1792,6 +1826,7 @@ impl PyParameterVectorElement {
 /// index.
 ///
 /// This class fulfills the :class:`collections.abc.Sequence` interface.
+#[cfg(feature = "py")]
 #[pyclass(
     sequence,
     module = "qiskit._accelerate.circuit",
@@ -1805,6 +1840,7 @@ pub struct PyParameterVector {
     /// Cache of the parameter list.
     params: PyOnceLock<Py<PyList>>,
 }
+#[cfg(feature = "py")]
 impl PyParameterVector {
     pub fn new(base: Arc<SymbolVector>) -> Self {
         Self {
@@ -1814,6 +1850,7 @@ impl PyParameterVector {
         }
     }
 }
+#[cfg(feature = "py")]
 #[pymethods]
 impl PyParameterVector {
     #[new]
@@ -1945,6 +1982,7 @@ impl PyParameterVector {
 }
 
 /// Try to extract a Uuid from a Python object, which could be a Python UUID or int.
+#[cfg(feature = "py")]
 fn uuid_from_py(uuid: Bound<PyAny>) -> PyResult<Uuid> {
     let int = if uuid.is_exact_instance(UUID.get_bound(uuid.py())) {
         uuid.getattr("int")?
@@ -1955,6 +1993,7 @@ fn uuid_from_py(uuid: Bound<PyAny>) -> PyResult<Uuid> {
 }
 
 /// Convert a Rust Uuid object to a Python UUID object.
+#[cfg(feature = "py")]
 fn uuid_to_py(py: Python<'_>, uuid: Uuid) -> PyResult<Bound<'_, PyAny>> {
     let uuid = uuid.as_u128();
     let kwargs = [("int", uuid)].into_py_dict(py)?;
@@ -1963,11 +2002,13 @@ fn uuid_to_py(py: Python<'_>, uuid: Uuid) -> PyResult<Bound<'_, PyAny>> {
 
 /// A singular parameter value used for QPY serialization. This covers anything
 /// but a [PyParameterExpression], which is represented by [None] in the serialization.
-#[derive(IntoPyObject, FromPyObject, Clone, Debug)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "py", derive(IntoPyObject, FromPyObject))]
 pub enum ParameterValueType {
     Int(i64),
     Float(f64),
     Complex(Complex64),
+    #[cfg(feature = "py")]
     Parameter(PyParameter),
 }
 
@@ -1979,8 +2020,11 @@ impl ParameterValueType {
                 Value::Real(r) => Some(ParameterValueType::Float(r)),
                 Value::Complex(c) => Some(ParameterValueType::Complex(c)),
             }
-        } else if let SymbolExpr::Symbol(symbol) = expr {
-            Some(Self::Parameter(PyParameter(symbol.clone())))
+        } else if let SymbolExpr::Symbol(_symbol) = expr {
+            #[cfg(feature = "py")]
+            return Some(Self::Parameter(PyParameter(_symbol.clone())));
+            #[cfg(not(feature = "py"))]
+            return None;
         } else {
             // ParameterExpressions have the value None, as they must be constructed
             None
@@ -1991,6 +2035,7 @@ impl ParameterValueType {
 impl From<ParameterValueType> for ParameterExpression {
     fn from(value: ParameterValueType) -> Self {
         match value {
+            #[cfg(feature = "py")]
             ParameterValueType::Parameter(PyParameter(symbol)) => {
                 let expr = SymbolExpr::Symbol(symbol);
                 Self::from_symbol_expr(expr)
@@ -2011,7 +2056,10 @@ impl From<ParameterValueType> for ParameterExpression {
     }
 }
 
-#[pyclass(module = "qiskit._accelerate.circuit", from_py_object)]
+#[cfg_attr(
+    feature = "py",
+    pyclass(module = "qiskit._accelerate.circuit", from_py_object)
+)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 #[repr(u8)]
 pub enum OpCode {
@@ -2056,11 +2104,12 @@ unsafe impl ::bytemuck::CheckedBitPattern for OpCode {
 unsafe impl ::bytemuck::NoUninit for OpCode {}
 
 impl OpCode {
-    pub fn from_u8(value: u8) -> PyResult<OpCode> {
+    pub fn from_u8(value: u8) -> Result<OpCode, Infallible> {
         Ok(bytemuck::checked::cast::<u8, OpCode>(value))
     }
 }
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl OpCode {
     #[new]
@@ -2088,7 +2137,10 @@ impl OpCode {
 }
 
 // enum for QPY replay
-#[pyclass(sequence, module = "qiskit._accelerate.circuit", from_py_object)]
+#[cfg_attr(
+    feature = "py",
+    pyclass(sequence, module = "qiskit._accelerate.circuit", from_py_object)
+)]
 #[derive(Clone, Debug)]
 pub struct OPReplay {
     pub op: OpCode,
@@ -2096,6 +2148,7 @@ pub struct OPReplay {
     pub rhs: Option<ParameterValueType>,
 }
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl OPReplay {
     #[new]
@@ -2221,6 +2274,7 @@ fn qpy_replay_inner(
 
             // add the expression to the replay
             match lhs_value {
+                #[cfg(feature = "py")]
                 Some(ParameterValueType::Parameter(_)) => {
                     // For non-commutative operations (SUB, DIV, POW): if LHS is a Parameter and RHS is
                     // an expression (None), we need to use reverse operations (RSUB, RDIV, RPOW)

--- a/crates/circuit/src/parameter/symbol_expr.rs
+++ b/crates/circuit/src/parameter/symbol_expr.rs
@@ -21,8 +21,10 @@ use std::sync::{Arc, atomic};
 use uuid::Uuid;
 
 use num_complex::Complex64;
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
 
+#[cfg(feature = "py")]
 use crate::parameter::parameter_expression::PyParameter;
 
 // epsilon for SymbolExpr is heuristically defined
@@ -66,6 +68,7 @@ impl Hash for Symbol {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py> FromPyObject<'a, 'py> for Symbol {
     type Error = PyErr;
 
@@ -74,6 +77,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Symbol {
     }
 }
 
+#[cfg(feature = "py")]
 impl<'py> IntoPyObject<'py> for Symbol {
     type Target = <PyParameter as IntoPyObject<'py>>::Target;
     type Output = <PyParameter as IntoPyObject<'py>>::Output;
@@ -211,13 +215,15 @@ pub enum SymbolExpr {
 }
 
 /// Value type, can be integer, real or complex number
-#[derive(Debug, Clone, Copy, IntoPyObject, IntoPyObjectRef)]
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "py", derive(IntoPyObject, IntoPyObjectRef))]
 pub enum Value {
     Real(f64),
     Int(i64),
     Complex(Complex64),
 }
 
+#[cfg(feature = "py")]
 impl<'a, 'py> FromPyObject<'a, 'py> for Value {
     type Error = PyErr;
 

--- a/crates/circuit/src/parameter_table.rs
+++ b/crates/circuit/src/parameter_table.rs
@@ -16,14 +16,20 @@ use hashbrown::hash_map::Entry;
 use hashbrown::{HashMap, HashSet};
 use thiserror::Error;
 
+#[cfg(feature = "py")]
 use pyo3::exceptions::PyTypeError;
+#[cfg(feature = "py")]
 use pyo3::import_exception;
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
+#[cfg(feature = "py")]
 use pyo3::types::PySet;
 
+#[cfg(feature = "py")]
 use crate::parameter::parameter_expression::{PyParameter, PyParameterExpression};
 use crate::parameter::symbol_expr::Symbol;
 
+#[cfg(feature = "py")]
 import_exception!(qiskit.circuit, CircuitError);
 
 /// This struct models the error conditions that can be raised from the
@@ -44,6 +50,7 @@ pub enum ParameterTableError {
     #[error("name conflict adding parameter '{0}'")]
     NameConflict(String),
 }
+#[cfg(feature = "py")]
 impl From<ParameterTableError> for PyErr {
     fn from(value: ParameterTableError) -> PyErr {
         CircuitError::new_err(value.to_string())
@@ -72,6 +79,7 @@ pub struct ParameterUuid(u128);
 impl ParameterUuid {
     /// Extract a UUID from a Python-space `Parameter` object. This assumes that the object is known
     /// to be a parameter.
+    #[cfg(feature = "py")]
     pub fn from_parameter(ob: &Bound<PyAny>) -> PyResult<Self> {
         let uuid = if let Ok(param) = ob.cast::<PyParameter>() {
             // this downcast should cover both PyParameterVectorElement and PyParameter
@@ -308,6 +316,7 @@ impl ParameterTable {
     /// Expose the tracked data for a given parameter as directly as possible to Python space.
     ///
     /// This is only really intended for use in testing.
+    #[cfg(feature = "py")]
     pub(crate) fn _py_raw_entry(&self, param: Bound<PyAny>) -> PyResult<Py<PySet>> {
         let py = param.py();
         let uuid = ParameterUuid::from_parameter(&param)?;

--- a/crates/circuit/src/register_data.rs
+++ b/crates/circuit/src/register_data.rs
@@ -10,14 +10,19 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+#[cfg(feature = "py")]
 use std::sync::OnceLock;
 use std::{fmt::Debug, marker::PhantomData};
 
 use hashbrown::HashMap;
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
+#[cfg(feature = "py")]
 use pyo3::types::{IntoPyDict, PyDict, PyList};
 
-use crate::{bit::Register, circuit_data::CircuitError};
+use crate::bit::Register;
+#[cfg(feature = "py")]
+use crate::circuit_data::CircuitError;
 
 /// Error thrown when adding a register using strict mode
 /// and it's already present.
@@ -25,6 +30,7 @@ use crate::{bit::Register, circuit_data::CircuitError};
 #[error("register name \"{0}\" already exists")]
 pub struct RegisterAlreadyExists(String);
 
+#[cfg(feature = "py")]
 impl From<RegisterAlreadyExists> for PyErr {
     fn from(value: RegisterAlreadyExists) -> Self {
         CircuitError::new_err(value.to_string())
@@ -70,6 +76,7 @@ impl<R: Register> RegisterIndex<R> {
 pub struct RegisterData<R: Register> {
     reg_index: HashMap<String, RegisterIndex<R>>,
     registers: Vec<R>,
+    #[cfg(feature = "py")]
     cached_registers: OnceLock<Py<PyDict>>,
 }
 
@@ -97,6 +104,7 @@ where
         Self {
             reg_index: HashMap::new(),
             registers: Vec::new(),
+            #[cfg(feature = "py")]
             cached_registers: OnceLock::new(),
         }
     }
@@ -107,6 +115,7 @@ where
         Self {
             reg_index: HashMap::with_capacity(capacity),
             registers: Vec::new(),
+            #[cfg(feature = "py")]
             cached_registers: OnceLock::new(),
         }
     }
@@ -126,6 +135,7 @@ where
             .is_ok()
         {
             self.registers.push(register);
+            #[cfg(feature = "py")]
             self.cached_registers.take();
             Ok(true)
         } else if strict {
@@ -172,6 +182,7 @@ where
     ///
     /// __**Note:** This operation is performed at `O(n)` times in the worst case.__
     pub fn remove(&mut self, register: &str) -> Option<R> {
+        #[cfg(feature = "py")]
         self.cached_registers.take();
         if let Some(index) = self.reg_index.remove(register) {
             let bit = self.registers.remove(index.index());
@@ -197,6 +208,7 @@ where
             .filter_map(|i| self.reg_index.get(&i).map(|idx| idx.index()))
             .collect();
         indices_sorted.sort();
+        #[cfg(feature = "py")]
         self.cached_registers.take();
         for index in indices_sorted.into_iter().rev() {
             let bit = self.registers.remove(index);
@@ -219,6 +231,7 @@ where
     pub fn dispose(&mut self) {
         self.reg_index.clear();
         self.registers.clear();
+        #[cfg(feature = "py")]
         self.cached_registers.take();
     }
 
@@ -237,11 +250,13 @@ where
         Self {
             registers,
             reg_index,
+            #[cfg(feature = "py")]
             cached_registers: OnceLock::new(),
         }
     }
 }
 
+#[cfg(feature = "py")]
 impl<R> RegisterData<R>
 where
     R: Debug + Clone + Register + for<'py> IntoPyObject<'py>,

--- a/crates/circuit/src/standard_gate/mod.rs
+++ b/crates/circuit/src/standard_gate/mod.rs
@@ -13,9 +13,13 @@
 mod convert;
 pub mod standard_generators;
 
-use crate::circuit_data::{CircuitData, PyCircuitData};
+use crate::circuit_data::CircuitData;
+#[cfg(feature = "py")]
+use crate::circuit_data::PyCircuitData;
 use crate::operations::{Operation, Param, add_param, clone_param, multiply_param, radd_param};
-use crate::{Qubit, gate_matrix, impl_intopyobject_for_copy_pyclass, imports};
+use crate::{Qubit, gate_matrix};
+#[cfg(feature = "py")]
+use crate::{impl_intopyobject_for_copy_pyclass, imports};
 use qiskit_quantum_info::versor_u2::{VersorU2, VersorU2Error};
 
 use ndarray::{Array2, aview2};
@@ -23,15 +27,21 @@ use num_complex::Complex64;
 use smallvec::{SmallVec, smallvec};
 use std::f64::consts::PI;
 
+#[cfg(feature = "py")]
 use numpy::{IntoPyArray, PyArray2};
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
+#[cfg(feature = "py")]
 use pyo3::types::{IntoPyDict, PyList, PyTuple};
 
 const FLOAT_ZERO: Param = Param::Float(0.0);
 
 #[derive(Clone, Debug, Copy, Eq, PartialEq, Hash)]
 #[repr(u8)]
-#[pyclass(module = "qiskit._accelerate.circuit", eq, eq_int, from_py_object)]
+#[cfg_attr(
+    feature = "py",
+    pyclass(module = "qiskit._accelerate.circuit", eq, eq_int, from_py_object)
+)]
 pub enum StandardGate {
     GlobalPhase = 0,
     H = 1,
@@ -88,6 +98,7 @@ pub enum StandardGate {
     // Remember to update StandardGate::is_valid_bit_pattern below
     // if you add or remove this enum's variants!
 }
+#[cfg(feature = "py")]
 impl_intopyobject_for_copy_pyclass!(StandardGate);
 
 unsafe impl ::bytemuck::CheckedBitPattern for StandardGate {
@@ -187,6 +198,7 @@ pub fn get_standard_gate_names() -> &'static [&'static str] {
 }
 
 impl StandardGate {
+    #[cfg(feature = "py")]
     pub fn create_py_op(
         &self,
         py: Python,
@@ -1854,8 +1866,13 @@ impl StandardGate {
     pub fn versor_u2(&self, params: &[Param]) -> Result<VersorU2, VersorU2Error> {
         convert::versor_u2(*self, params)
     }
+
+    pub fn is_controlled_gate(&self) -> bool {
+        self.num_ctrl_qubits() > 0
+    }
 }
 
+#[cfg(feature = "py")]
 #[pymethods]
 impl StandardGate {
     pub fn copy(&self) -> Self {
@@ -1908,9 +1925,9 @@ impl StandardGate {
         self.name()
     }
 
-    #[getter]
-    pub fn is_controlled_gate(&self) -> bool {
-        self.num_ctrl_qubits() > 0
+    #[getter(is_controlled_gate)]
+    pub fn py_is_controlled_gate(&self) -> bool {
+        self.is_controlled_gate()
     }
 
     #[getter]

--- a/crates/circuit/src/standard_gate/standard_generators.rs
+++ b/crates/circuit/src/standard_gate/standard_generators.rs
@@ -19,7 +19,9 @@
 use num_complex::Complex64;
 use std::f64::consts::{FRAC_PI_2, FRAC_PI_4, FRAC_PI_8, SQRT_2};
 
+#[cfg(feature = "py")]
 use pyo3::prelude::*;
+#[cfg(feature = "py")]
 use pyo3::wrap_pyfunction;
 
 use crate::operations::{Operation, Param, StandardGate};
@@ -60,6 +62,7 @@ pub fn standard_gate_exponent(gate: StandardGate, params: &[Param]) -> Option<Sp
         .map(|p| match p {
             Param::Float(f) => *f,
             Param::ParameterExpression(_) => 1.0,
+            #[cfg(feature = "py")]
             Param::Obj(_) => panic!("StandardGate does not have Param::Obj parameters"),
             Param::Int(_) => panic!("StandardGate does not have Param::Int parameters"),
         })
@@ -329,6 +332,7 @@ pub fn standard_gate_exponent(gate: StandardGate, params: &[Param]) -> Option<Sp
     })
 }
 
+#[cfg(feature = "py")]
 #[pyfunction(name = "_standard_gate_exponent")]
 #[pyo3(signature = (gate, params=None))]
 pub fn py_standard_gate_exponent(
@@ -339,6 +343,7 @@ pub fn py_standard_gate_exponent(
     standard_gate_exponent(gate, &params)
 }
 
+#[cfg(feature = "py")]
 pub fn standard_generators(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_standard_gate_exponent, m)?)?;
     Ok(())

--- a/crates/circuit/src/var_stretch_container.rs
+++ b/crates/circuit/src/var_stretch_container.rs
@@ -16,8 +16,11 @@ use crate::{Stretch, Var};
 use qiskit_util::IndexMap;
 use thiserror::Error;
 
+#[cfg(feature = "py")]
 use pyo3::exceptions::PyValueError;
+#[cfg(feature = "py")]
 use pyo3::types::PyTuple;
+#[cfg(feature = "py")]
 use pyo3::{IntoPyObjectExt, prelude::*};
 
 /// The scope type associated with a given variable in the container.
@@ -35,6 +38,7 @@ pub enum StretchType {
     Declare = 1,
 }
 
+#[cfg(feature = "py")]
 type VarStretchState = (Vec<(String, Py<PyAny>)>, Vec<expr::Var>, Vec<expr::Stretch>);
 
 /// Errors related to [VarStretchContainer] which may occur when adding
@@ -376,6 +380,7 @@ impl VarStretchContainer {
     }
 
     /// Returns cloned copies of identifier info, variable objects and stretch objects.
+    #[cfg(feature = "py")]
     pub fn to_pickle(&self, py: Python) -> VarStretchState {
         (
             self.identifier_info
@@ -388,6 +393,7 @@ impl VarStretchContainer {
     }
 
     /// Constructs Self given identifier info, variables and stretch objects previously serialized with [Self::to_pickle()]
+    #[cfg(feature = "py")]
     pub fn from_pickle(py: Python, state: VarStretchState) -> PyResult<Self> {
         let mut res = VarStretchContainer::with_capacity(Some(state.1.len()), Some(state.2.len()));
 
@@ -491,6 +497,7 @@ struct VarInfo {
     type_: VarType,
 }
 
+#[cfg(feature = "py")]
 impl VarInfo {
     fn to_pickle(&self, py: Python) -> PyResult<Py<PyAny>> {
         (self.var.0, self.type_ as u8).into_py_any(py)
@@ -516,6 +523,7 @@ struct StretchInfo {
     type_: StretchType,
 }
 
+#[cfg(feature = "py")]
 impl StretchInfo {
     fn to_pickle(&self, py: Python) -> PyResult<Py<PyAny>> {
         (self.stretch.0, self.type_ as u8).into_py_any(py)
@@ -540,6 +548,7 @@ enum IdentifierInfo {
     Var(VarInfo),
 }
 
+#[cfg(feature = "py")]
 impl IdentifierInfo {
     fn to_pickle(&self, py: Python) -> PyResult<Py<PyAny>> {
         match self {

--- a/crates/qasm3/Cargo.toml
+++ b/crates/qasm3/Cargo.toml
@@ -17,7 +17,7 @@ qiskit-util.workspace = true
 hashbrown.workspace = true
 oq3_semantics = "0.7.0"
 oq3_syntax = "0.7.0"
-qiskit-circuit.workspace = true
+qiskit-circuit = {workspace = true, features = ["py"]}
 foldhash.workspace = true
 regex = "1.12"
 lazy_static = "1.5"


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### Summary
Remove `pylib` from `circuit` crate.

The following commits attempt to remove the PyO3 dependency in the circuit crate to allow it to compile without Python in the cases where it needs to.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>