### PR TITLE
Fix HoareOptimizer custom instruction cancellation

### DIFF
--- a/qiskit/transpiler/passes/optimization/hoare_opt.py
+++ b/qiskit/transpiler/passes/optimization/hoare_opt.py
@@ -12,7 +12,7 @@
 
 """Pass for Hoare logic circuit optimization."""
 from qiskit.transpiler.basepasses import TransformationPass
-from qiskit.circuit import QuantumRegister, ControlledGate, Gate
+from qiskit.circuit import QuantumRegister, ControlledGate, Gate, Instruction
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.circuit.library import UnitaryGate
 from qiskit.quantum_info.operators.predicates import matrix_equal
@@ -301,10 +301,10 @@ class HoareOptimizer(TransformationPass):
             gate2 = gate2.base_gate
         gate2 = gate2.base_class
 
-        # equality of gates can be determined via type and parameters, unless
-        # the gates have no specific type, in which case definition is used
+        # equality of operations can be determined via type and parameters, unless
+        # the operations have no specific type, in which case definition is used
         # or they are unitary gates, in which case matrix equality is used
-        if gate1 is Gate and gate2 is Gate:
+        if gate1 in (Gate, Instruction) and gate2 in (Gate, Instruction):
             return def1 == def2 and def1 and def2
         elif gate1 is UnitaryGate and gate2 is UnitaryGate:
             return matrix_equal(par1[0], par2[0], ignore_phase=True)

--- a/releasenotes/notes/fix-hoare-custom-instruction-cancel-8db07f6baf1f3a54.yaml
+++ b/releasenotes/notes/fix-hoare-custom-instruction-cancel-8db07f6baf1f3a54.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed :class:`.HoareOptimizer` removing two adjacent custom instructions
+    that do not combine to the identity. Instructions without a specific type
+    were compared by type and parameters only, so any two of them without
+    parameters looked equal. They are now compared by definition, as was
+    already the case for custom gates.
+    Fixed `#14356 <https://github.com/Qiskit/qiskit/issues/14356>`__.

--- a/test/python/transpiler/test_hoare_opt.py
+++ b/test/python/transpiler/test_hoare_opt.py
@@ -626,6 +626,41 @@ class TestHoareOptimizer(QiskitTestCase):
         seq = [DAGOpNode(op=CSwapGate()), DAGOpNode(op=SwapGate())]
         self.assertTrue(HoareOptimizer()._is_identity(seq))
 
+    def test_custom_instruction_removal(self):
+        """Should not remove two distinct custom instructions, since they
+        don't form the identity even though both are plain instructions
+        without parameters.
+        """
+
+        #           ┌─────────────┐┌────────┐
+        # q_0: ─────┤0            ├┤0       ├
+        #           │             ││        │
+        # q_1: ─────┤1            ├┤1       ├
+        #           │  entangling ││        │
+        # q_2: ─────┤2            ├┤2 empty ├
+        #      ┌───┐│             ││        │
+        # q_3: ┤ H ├┤3            ├┤3       ├
+        #      └───┘└─────────────┘│        │
+        #   c: ════════════════════╡0       ╞
+        #                          └────────┘
+        circuit = QuantumCircuit(4, 1)
+        circuit.h(3)
+
+        entangling = QuantumCircuit(4, name="entangling")
+        entangling.cx(0, 1)
+        entangling.cx(0, 2)
+        entangling.cx(0, 3)
+        entangling.h(3)
+        circuit.append(entangling, range(4), [])
+
+        empty = QuantumCircuit(4, 1, name="empty")
+        circuit.append(empty, range(4), range(1))
+
+        pass_ = HoareOptimizer(size=2)
+        result = pass_.run(circuit_to_dag(circuit))
+
+        self.assertEqual(result, circuit_to_dag(circuit))
+
     def test_multiple_pass(self):
         """Verify that multiple pass can be run
         with the same Hoare instance.


### PR DESCRIPTION
Fix #14356.

`HoareOptimizer._is_identity` compared two adjacent plain `Instruction`s by base class and parameters only. Any two custom instructions have base class `Instruction` and no parameters, so unrelated ones looked like an identity pair and both got dropped, silently changing the circuit.

Custom *gates* were already handled by comparing their definitions instead. This extends that branch to cover custom instructions too. Instructions that really are each other's inverse are still cancelled.

AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tools to understand this PR: ChatGPT and Claude
