### PR TITLE
Mark opaque C FFI types as `!Sized` in `pyo3-ffi`

### DIFF
--- a/crates/bindgen/src/render/rust.rs
+++ b/crates/bindgen/src/render/rust.rs
@@ -373,13 +373,18 @@ pub enum {name} {{
         let name = &val.name;
         let Some(fields) = val.fields.as_deref() else {
             // In the absence of Rust-stable `extern type`, this is the Nomicon-approved way of
-            // defining an opaque type:
+            // defining an opaque type, with the addition of `[()]` to ensure the type is `!Sized`:
             //      https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
+            //
+            // It helps to make things forcibly unsized so that you can't produce things like
+            // `&[Ty]`, which is important for `CInstructionView::params` where we _do_ expose a
+            // contiguous buffer of `QkParam` without specifying a compile-time width of it.
             return format!(
                 "
 #[repr(C)]
 pub struct {name} {{
-    _private: ::core::marker::PhantomData<(*mut u8, ::core::marker::PhantomPinned)>,
+    _variance: ::core::marker::PhantomData<(*mut u8, ::core::marker::PhantomPinned)>,
+    _unsized: [u8],
 }}"
             );
         };


### PR DESCRIPTION
This is motivated by the work that exposes an `InstructionView` object, which provides a direct view onto a `&[Param]` from the `qiskit-circuit` Rust code.  This is fine from within Rust, but the corresponding C-API type `ffi::QkParam` has a width that's not knowable to downstream C-API consumers until runtime.

It's tempting from Rust code using the C FFI to attempt to cast to `QkCircuitInstructionView.params` into a slice, but this should not be possible because the type widths Rust expects would not match.  Direct C use does not have this problem; C compilers will reject pointer arithmetic on pointers to opaque structs, since the type width is clearly not known.  The equivalent in Rust is to forcibly make the modelled opaque types `!Sized`.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
