### PR TITLE
Update Register pack for QPY v18

### DIFF
--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -1114,7 +1114,7 @@ fn unpack_transpile_layout<'py>(
             ),
             formats::RegisterPack::V18(packed_register) => (
                 &packed_register.name,
-                packed_register.bit_indices.len(),
+                packed_register.size as usize,
                 &packed_register.register_type,
             ),
         };

--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -1106,12 +1106,21 @@ fn unpack_transpile_layout<'py>(
     let mut extra_register_map = HashMap::new();
     let mut existing_register_map = HashMap::new();
     for packed_register in &layout.extra_registers {
-        if packed_register.register_type == RegisterType::Qreg {
-            let register = QuantumRegister::new_owning(
-                packed_register.name.clone(),
-                packed_register.bit_indices.len() as u32,
-            );
-            extra_register_map.insert(packed_register.name.as_str(), register);
+        let (name, bit_indices_len, register_type) = match packed_register {
+            formats::RegisterPack::V4(packed_register) => (
+                &packed_register.name,
+                packed_register.bit_indices.len(),
+                &packed_register.register_type,
+            ),
+            formats::RegisterPack::V18(packed_register) => (
+                &packed_register.name,
+                packed_register.bit_indices.len(),
+                &packed_register.register_type,
+            ),
+        };
+        if *register_type == RegisterType::Qreg {
+            let register = QuantumRegister::new_owning(name.clone(), bit_indices_len as u32);
+            extra_register_map.insert(name.as_str(), register);
         }
     }
     // add the registers from the circuit, to streamline the search phase
@@ -1454,39 +1463,113 @@ fn add_registers_and_bits(
 
     // first, create all owning registers and collect their bits
     let mut non_standalone_registers = Vec::new();
-    for packed_register in &packed_circuit.header.registers {
-        if packed_register.standalone == 0 {
-            non_standalone_registers.push(packed_register);
-        } else {
-            match packed_register.register_type {
-                RegisterType::Qreg => {
-                    let qreg = QuantumRegister::new_owning(
-                        &packed_register.name,
-                        packed_register.bit_indices.len() as u32,
-                    );
-                    for (qubit, &index) in qreg.bits().zip(packed_register.bit_indices.iter()) {
-                        if index >= 0 {
-                            // index can be -1, indicating this bit is not in the circuit
-                            qubits[index as usize] = Some(qubit);
+    for raw_register in &packed_circuit.header.registers {
+        match raw_register {
+            formats::RegisterPack::V4(packed_register) => {
+                if packed_register.standalone == 0 {
+                    non_standalone_registers.push(raw_register);
+                } else {
+                    match packed_register.register_type {
+                        RegisterType::Qreg => {
+                            let qreg = QuantumRegister::new_owning(
+                                &packed_register.name,
+                                packed_register.bit_indices.len() as u32,
+                            );
+                            for (qubit, &index) in
+                                qreg.bits().zip(packed_register.bit_indices.iter())
+                            {
+                                if index >= 0 {
+                                    // index can be -1, indicating this bit is not in the circuit
+                                    qubits[index as usize] = Some(qubit);
+                                }
+                            }
+                            if packed_register.in_circuit != 0 {
+                                qregs.push(qreg);
+                            }
                         }
-                    }
-                    if packed_register.in_circuit != 0 {
-                        qregs.push(qreg);
+                        RegisterType::Creg => {
+                            let creg = ClassicalRegister::new_owning(
+                                &packed_register.name,
+                                packed_register.bit_indices.len() as u32,
+                            );
+                            for (clbit, &index) in
+                                creg.bits().zip(packed_register.bit_indices.iter())
+                            {
+                                if index >= 0 {
+                                    // index can be -1, indicating this bit is not in the circuit
+                                    clbits[index as usize] = Some(clbit);
+                                }
+                            }
+                            if packed_register.in_circuit != 0 {
+                                cregs.push(creg);
+                            }
+                        }
                     }
                 }
-                RegisterType::Creg => {
-                    let creg = ClassicalRegister::new_owning(
-                        &packed_register.name,
-                        packed_register.bit_indices.len() as u32,
-                    );
-                    for (clbit, &index) in creg.bits().zip(packed_register.bit_indices.iter()) {
-                        if index >= 0 {
-                            // index can be -1, indicating this bit is not in the circuit
-                            clbits[index as usize] = Some(clbit);
+            }
+            formats::RegisterPack::V18(packed_register) => {
+                if packed_register.standalone == 0 {
+                    non_standalone_registers.push(raw_register);
+                } else {
+                    match packed_register.register_type {
+                        RegisterType::Qreg => {
+                            let qreg = QuantumRegister::new_owning(
+                                &packed_register.name,
+                                packed_register.size,
+                            );
+                            if packed_register.register_attachment == 1 {
+                                let start = packed_register.start_index;
+                                for i in 0..packed_register.size {
+                                    let index = start + i;
+                                    qubits[index as usize] = qreg.get(i as usize);
+                                }
+                            } else if packed_register.register_attachment == 0 {
+                                for (qubit, &index) in
+                                    qreg.bits().zip(packed_register.bit_indices.iter())
+                                {
+                                    if index != u32::MAX {
+                                        // index can be -1, indicating this bit is not in the circuit
+                                        qubits[index as usize] = Some(qubit);
+                                    }
+                                }
+                            } else {
+                                return Err(QpyError::InvalidRegister(
+                                    "Invalid register attachment type: {packed_register.register_attachment}, must either be 0 or 1".to_owned(),
+                                ));
+                            }
+                            if packed_register.in_circuit != 0 {
+                                qregs.push(qreg);
+                            }
                         }
-                    }
-                    if packed_register.in_circuit != 0 {
-                        cregs.push(creg);
+                        RegisterType::Creg => {
+                            let creg = ClassicalRegister::new_owning(
+                                &packed_register.name,
+                                packed_register.size,
+                            );
+                            if packed_register.register_attachment == 1 {
+                                let start = packed_register.start_index;
+                                for i in 0..packed_register.size {
+                                    let index = start + i;
+                                    clbits[index as usize] = creg.get(i as usize);
+                                }
+                            } else if packed_register.register_attachment == 0 {
+                                for (clbit, &index) in
+                                    creg.bits().zip(packed_register.bit_indices.iter())
+                                {
+                                    if index != u32::MAX {
+                                        // index can be -1, indicating this bit is not in the circuit
+                                        clbits[index as usize] = Some(clbit);
+                                    }
+                                }
+                            } else {
+                                return Err(QpyError::InvalidRegister(
+                                    "Invalid register attachment type: {packed_register.register_attachment}, must either be 0 or 1".to_owned(),
+                                ));
+                            }
+                            if packed_register.in_circuit != 0 {
+                                cregs.push(creg);
+                            }
+                        }
                     }
                 }
             }
@@ -1509,37 +1592,81 @@ fn add_registers_and_bits(
         .collect();
 
     // We collected owning registers to qregs, cregs and added all remaining bits and can now deal with the non-standalone registers
-    for packed_register in non_standalone_registers {
-        match packed_register.register_type {
-            RegisterType::Qreg => {
-                let bits: Vec<ShareableQubit> = packed_register
-                    .bit_indices
-                    .iter()
-                    .filter_map(|&index| {
-                        if index >= 0 {
-                            Some(final_qubit_list[index as usize].clone())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
-                let qreg = QuantumRegister::new_alias(Some(packed_register.name.clone()), bits);
-                qregs.push(qreg);
-            }
-            RegisterType::Creg => {
-                let bits: Vec<ShareableClbit> = packed_register
-                    .bit_indices
-                    .iter()
-                    .filter_map(|&index| {
-                        if index >= 0 {
-                            Some(final_clbit_list[index as usize].clone())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
-                let creg = ClassicalRegister::new_alias(Some(packed_register.name.clone()), bits);
-                cregs.push(creg);
+    for raw_register in non_standalone_registers {
+        match raw_register {
+            formats::RegisterPack::V4(packed_register) => match packed_register.register_type {
+                RegisterType::Qreg => {
+                    let bits: Vec<ShareableQubit> = packed_register
+                        .bit_indices
+                        .iter()
+                        .filter_map(|&index| {
+                            if index >= 0 {
+                                Some(final_qubit_list[index as usize].clone())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+                    let qreg = QuantumRegister::new_alias(Some(packed_register.name.clone()), bits);
+                    qregs.push(qreg);
+                }
+                RegisterType::Creg => {
+                    let bits: Vec<ShareableClbit> = packed_register
+                        .bit_indices
+                        .iter()
+                        .filter_map(|&index| {
+                            if index >= 0 {
+                                Some(final_clbit_list[index as usize].clone())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+                    let creg =
+                        ClassicalRegister::new_alias(Some(packed_register.name.clone()), bits);
+                    cregs.push(creg);
+                }
+            },
+            formats::RegisterPack::V18(packed_register) => {
+                if packed_register.register_attachment == 1 {
+                    return Err(QpyError::InvalidRegister(
+                        "Invalid register attachment type for aliased registers.".to_owned(),
+                    ));
+                }
+                match packed_register.register_type {
+                    RegisterType::Qreg => {
+                        let bits: Vec<ShareableQubit> = packed_register
+                            .bit_indices
+                            .iter()
+                            .filter_map(|&index| {
+                                if index != u32::MAX {
+                                    Some(final_qubit_list[index as usize].clone())
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect();
+                        let qreg =
+                            QuantumRegister::new_alias(Some(packed_register.name.clone()), bits);
+                        qregs.push(qreg);
+                    }
+                    RegisterType::Creg => {
+                        let bits: Vec<ShareableClbit> = packed_register
+                            .bit_indices
+                            .iter()
+                            .filter_map(|&index| {
+                                if index != u32::MAX {
+                                    Some(final_clbit_list[index as usize].clone())
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect();
+                        let creg =
+                            ClassicalRegister::new_alias(Some(packed_register.name.clone()), bits);
+                        cregs.push(creg);
+                    }
+                }
             }
         }
     }

--- a/crates/qpy/src/circuit_writer.rs
+++ b/crates/qpy/src/circuit_writer.rs
@@ -654,7 +654,7 @@ fn pack_py_instruction(
 // packs the quantum registers in the circuit. we pack:
 // 1) registers appearing explicitly in the circuit register list (identified using in_circ_lookup)
 // 2) registers appearing implicitly for bits (in python: as their "_register" data field)
-fn pack_quantum_registers(circuit_data: &CircuitData) -> Vec<formats::RegisterV4Pack> {
+fn pack_quantum_registers(circuit_data: &CircuitData, version: u8) -> Vec<formats::RegisterPack> {
     // let in_circ_lookup: HashSet<QuantumRegister> = circuit_data.qregs().iter().cloned().collect();
     // let mut registers_to_pack: IndexSet<QuantumRegister> =
     //     circuit_data.qregs().iter().cloned().collect();
@@ -689,7 +689,9 @@ fn pack_quantum_registers(circuit_data: &CircuitData) -> Vec<formats::RegisterV4
     );
     registers_to_pack
         .iter()
-        .map(|qreg| pack_quantum_register(qreg, circuit_data, in_circ_lookup.contains(qreg)))
+        .map(|qreg| {
+            pack_quantum_register(qreg, circuit_data, in_circ_lookup.contains(qreg), version)
+        })
         .collect()
 }
 
@@ -697,26 +699,63 @@ fn pack_quantum_register(
     qreg: &QuantumRegister,
     circuit_data: &CircuitData,
     in_circuit: bool,
-) -> formats::RegisterV4Pack {
-    let bit_indices = qreg
-        .bits()
-        .map(|qubit| {
-            circuit_data
-                .qubit_index(&qubit)
-                .map(|index| index as i64)
-                .unwrap_or(-1)
+    version: u8,
+) -> formats::RegisterPack {
+    if version < 18 {
+        let bit_indices = qreg
+            .bits()
+            .map(|qubit| {
+                circuit_data
+                    .qubit_index(&qubit)
+                    .map(|index| index as i64)
+                    .unwrap_or(-1)
+            })
+            .collect();
+
+        formats::RegisterPack::V4(formats::RegisterV4Pack {
+            register_type: RegisterType::Qreg,
+            standalone: qreg.is_owning() as u8,
+            in_circuit: in_circuit as u8,
+            name: qreg.name().to_string(),
+            bit_indices,
         })
-        .collect();
-    formats::RegisterV4Pack {
-        register_type: RegisterType::Qreg,
-        standalone: qreg.is_owning() as u8,
-        in_circuit: in_circuit as u8,
-        name: qreg.name().to_string(),
-        bit_indices,
+    } else {
+        let mut contiguous_indices = true;
+        let mut bit_indices: Vec<u32> = Vec::with_capacity(qreg.len());
+        for qubit in qreg.bits() {
+            if let Some(index) = circuit_data.qubit_index(&qubit) {
+                if let Some(prev) = bit_indices.last()
+                    && *prev != index.saturating_sub(1)
+                {
+                    contiguous_indices = false
+                }
+                bit_indices.push(index);
+            } else {
+                bit_indices.push(u32::MAX);
+                contiguous_indices = false;
+            }
+        }
+        let start_index = bit_indices.first().copied().unwrap_or(u32::MAX);
+        let register_attachment = if qreg.is_owning() && in_circuit && contiguous_indices {
+            bit_indices = vec![];
+            1
+        } else {
+            0
+        };
+        formats::RegisterPack::V18(formats::RegisterV18Pack {
+            register_type: RegisterType::Qreg,
+            standalone: qreg.is_owning() as u8,
+            size: qreg.len() as u32,
+            register_attachment,
+            in_circuit: in_circuit as u8,
+            name: qreg.name().to_string(),
+            start_index,
+            bit_indices,
+        })
     }
 }
 
-fn pack_classical_registers(circuit_data: &CircuitData) -> Vec<formats::RegisterV4Pack> {
+fn pack_classical_registers(circuit_data: &CircuitData, version: u8) -> Vec<formats::RegisterPack> {
     let in_circ_lookup: HashSet<ClassicalRegister> = circuit_data.cregs().iter().cloned().collect();
     let mut registers_to_pack: IndexSet<ClassicalRegister> =
         circuit_data.cregs().iter().cloned().collect();
@@ -744,24 +783,68 @@ fn pack_classical_registers(circuit_data: &CircuitData) -> Vec<formats::Register
     registers_to_pack
         .iter()
         .map(|creg| {
-            let bit_indices = creg
-                .bits()
-                .map(|clbit| {
-                    circuit_data
-                        .clbit_index(&clbit)
-                        .map(|index| index as i64)
-                        .unwrap_or(-1)
-                })
-                .collect();
-            formats::RegisterV4Pack {
-                register_type: RegisterType::Creg,
-                standalone: creg.is_owning() as u8,
-                in_circuit: in_circ_lookup.contains(creg) as u8,
-                name: creg.name().to_string(),
-                bit_indices,
-            }
+            pack_classical_register(creg, circuit_data, in_circ_lookup.contains(creg), version)
         })
         .collect()
+}
+
+fn pack_classical_register(
+    creg: &ClassicalRegister,
+    circuit_data: &CircuitData,
+    in_circuit: bool,
+    version: u8,
+) -> formats::RegisterPack {
+    if version < 18 {
+        let bit_indices = creg
+            .bits()
+            .map(|clbit| {
+                circuit_data
+                    .clbit_index(&clbit)
+                    .map(|index| index as i64)
+                    .unwrap_or(-1)
+            })
+            .collect();
+        formats::RegisterPack::V4(formats::RegisterV4Pack {
+            register_type: RegisterType::Creg,
+            standalone: creg.is_owning() as u8,
+            in_circuit: in_circuit as u8,
+            name: creg.name().to_string(),
+            bit_indices,
+        })
+    } else {
+        let mut contiguous_indices = true;
+        let mut bit_indices: Vec<u32> = Vec::with_capacity(creg.len());
+        for clbit in creg.bits() {
+            if let Some(index) = circuit_data.clbit_index(&clbit) {
+                if let Some(prev) = bit_indices.last()
+                    && *prev != index.saturating_sub(1)
+                {
+                    contiguous_indices = false
+                }
+                bit_indices.push(index);
+            } else {
+                bit_indices.push(u32::MAX);
+                contiguous_indices = false;
+            }
+        }
+        let start_index = bit_indices.first().copied().unwrap_or(u32::MAX);
+        let register_attachment = if creg.is_owning() && in_circuit && contiguous_indices {
+            bit_indices = vec![];
+            1
+        } else {
+            0
+        };
+        formats::RegisterPack::V18(formats::RegisterV18Pack {
+            register_type: RegisterType::Creg,
+            standalone: creg.is_owning() as u8,
+            size: creg.len() as u32,
+            register_attachment,
+            in_circuit: in_circuit as u8,
+            name: creg.name().to_string(),
+            start_index,
+            bit_indices,
+        })
+    }
 }
 
 fn pack_circuit_header(
@@ -774,8 +857,8 @@ fn pack_circuit_header(
         qpy_data,
         ValueEndian::Big,
     )?;
-    let qregs = pack_quantum_registers(qpy_data.circuit_data);
-    let cregs = pack_classical_registers(qpy_data.circuit_data);
+    let qregs = pack_quantum_registers(qpy_data.circuit_data, qpy_data.version);
+    let cregs = pack_classical_registers(qpy_data.circuit_data, qpy_data.version);
     let mut registers = qregs;
     registers.extend(cregs);
     let header = formats::CircuitHeaderV12Pack {
@@ -813,6 +896,7 @@ fn default_layout() -> formats::LayoutV2Pack {
 pub(crate) fn pack_layout(
     transpile_layout: Option<Bound<PyAny>>,
     circuit_data: &CircuitData,
+    version: u8,
 ) -> Result<formats::LayoutV2Pack, QpyError> {
     match transpile_layout {
         None => Ok(default_layout()),
@@ -820,7 +904,7 @@ pub(crate) fn pack_layout(
             if transpile_layout.is_none() {
                 Ok(default_layout())
             } else {
-                pack_transpile_layout(&transpile_layout, circuit_data)
+                pack_transpile_layout(&transpile_layout, circuit_data, version)
             }
         }
     }
@@ -829,6 +913,7 @@ pub(crate) fn pack_layout(
 fn pack_transpile_layout(
     layout: &Bound<PyAny>,
     circuit_data: &CircuitData,
+    version: u8,
 ) -> Result<formats::LayoutV2Pack, QpyError> {
     let mut initial_layout_size = -1; // initial_size
     let mut input_qubit_mapping: HashMap<ShareableQubit, usize> = HashMap::new();
@@ -926,8 +1011,12 @@ fn pack_transpile_layout(
         layout.getattr("_input_qubit_count")?.extract()?
     };
 
-    let extra_registers =
-        pack_extra_registers(&extra_registers, &extra_registers_qubits, circuit_data)?;
+    let extra_registers = pack_extra_registers(
+        &extra_registers,
+        &extra_registers_qubits,
+        circuit_data,
+        version,
+    )?;
 
     let initial_layout_items: Vec<formats::InitialLayoutItemV2Pack> = initial_layout_array
         .iter()
@@ -988,7 +1077,8 @@ fn pack_extra_registers(
     in_circ_regs: &HashSet<QuantumRegister>,
     qubits: &HashSet<ShareableQubit>,
     circuit_data: &CircuitData,
-) -> Result<Vec<formats::RegisterV4Pack>, QpyError> {
+    version: u8,
+) -> Result<Vec<formats::RegisterPack>, QpyError> {
     let mut out_circ_regs: HashSet<QuantumRegister> = HashSet::new();
     for qubit in qubits.iter() {
         if let Some(qreg) = qubit.owning_register()
@@ -999,10 +1089,10 @@ fn pack_extra_registers(
     }
     let mut result = Vec::new();
     for qreg in in_circ_regs.iter() {
-        result.push(pack_quantum_register(qreg, circuit_data, true));
+        result.push(pack_quantum_register(qreg, circuit_data, true, version));
     }
     for qreg in out_circ_regs.iter() {
-        result.push(pack_quantum_register(qreg, circuit_data, false));
+        result.push(pack_quantum_register(qreg, circuit_data, false, version));
     }
     Ok(result)
 }
@@ -1051,6 +1141,7 @@ fn pack_custom_instruction(
             let layout = serialize(&pack_layout(
                 definition.transpile_layout.clone(),
                 &definition.data,
+                qpy_data.version,
             )?)?;
             Some(serialize(&pack_circuit(
                 &definition.data,
@@ -1071,7 +1162,11 @@ fn pack_custom_instruction(
             .py_definition(py)?
             .map(|defn| {
                 let metadata = serialize_metadata(&defn.metadata, None)?;
-                let layout = serialize(&pack_layout(defn.transpile_layout.clone(), &defn.data)?)?;
+                let layout = serialize(&pack_layout(
+                    defn.transpile_layout.clone(),
+                    &defn.data,
+                    qpy_data.version,
+                )?)?;
                 pack_circuit(
                     &defn.data,
                     ExtraCircuitData {
@@ -1255,7 +1350,11 @@ pub(crate) fn pack_circuit(
     let layout = if extra.layout.is_empty() {
         default_layout()
     } else {
-        crate::value::deserialize(&extra.layout)?.0
+        crate::value::deserialize_with_args::<formats::LayoutV2Pack, (u8,)>(
+            &extra.layout,
+            (version,),
+        )?
+        .0
     };
     let state_headers: Vec<formats::AnnotationStateHeaderPack> = qpy_data
         .annotation_handler

--- a/crates/qpy/src/formats.rs
+++ b/crates/qpy/src/formats.rs
@@ -255,9 +255,12 @@ pub struct RegisterV18Pack {
     #[br(count = name_size as usize, try_map = String::from_utf8)]
     #[bw(map = |s| s.as_bytes())]
     pub name: String,
-    #[br(if(register_attachment==1))]
+    #[br(if(register_attachment == 1))]
+    #[bw(if(*register_attachment == 1))]
     pub start_index: u32,
-    #[br(if(register_attachment==0), count = size)]
+
+    #[br(if(register_attachment == 0), count = size)]
+    #[bw(if(*register_attachment == 0))]
     pub bit_indices: Vec<u32>,
 }
 

--- a/crates/qpy/src/formats.rs
+++ b/crates/qpy/src/formats.rs
@@ -61,6 +61,7 @@ pub struct QPYFileHeader {
 #[derive(Debug)]
 #[brw(import (version: u8))]
 pub struct QPYCircuit {
+    #[brw(args(version,))]
     pub header: CircuitHeaderV12Pack,
     #[br(count = header.num_vars)]
     pub standalone_vars: Vec<ExpressionVarDeclarationPack>,
@@ -71,6 +72,7 @@ pub struct QPYCircuit {
     pub instructions: Vec<CircuitInstructionV2Pack>,
     #[brw(if(version < 18), args(version,))]
     pub calibrations: Option<CalibrationsPack>,
+    #[brw(args(version,))]
     pub layout: LayoutV2Pack,
 }
 
@@ -80,6 +82,7 @@ pub struct QPYCircuit {
 #[binrw]
 #[brw(big)]
 #[derive(Debug)]
+#[brw(import (version: u8))]
 pub struct CircuitHeaderV12Pack {
     #[bw(calc = circuit_name.len() as u16)]
     pub name_size: u16,
@@ -101,8 +104,19 @@ pub struct CircuitHeaderV12Pack {
     pub global_phase_data: Bytes,
     #[br(count = metadata_size)]
     pub metadata: Bytes,
-    #[br(count = num_registers)]
-    pub registers: Vec<RegisterV4Pack>,
+    #[br(count = num_registers, args { inner: (version,) })]
+    pub registers: Vec<RegisterPack>,
+}
+
+#[binrw]
+#[derive(Debug)]
+#[br(import (version: u8))]
+pub enum RegisterPack {
+    #[br(pre_assert(version < 18))]
+    V4(RegisterV4Pack),
+
+    #[br(pre_assert(version >= 18))]
+    V18(RegisterV18Pack),
 }
 
 // The data for a specific instruction in the circuit
@@ -224,6 +238,27 @@ pub struct CustomCircuitInstructionDefPack {
     pub data: Bytes,
     #[br(count = base_gate_size)]
     pub base_gate_raw: Bytes,
+}
+
+#[binread]
+#[binwrite]
+#[brw(big)]
+#[derive(Debug)]
+pub struct RegisterV18Pack {
+    pub register_type: RegisterType,
+    pub standalone: u8,
+    pub size: u32,
+    #[bw(calc = name.len() as u16)]
+    pub name_size: u16,
+    pub in_circuit: u8,
+    pub register_attachment: u8,
+    #[br(count = name_size as usize, try_map = String::from_utf8)]
+    #[bw(map = |s| s.as_bytes())]
+    pub name: String,
+    #[br(if(register_attachment==1))]
+    pub start_index: u32,
+    #[br(if(register_attachment==0), count = size)]
+    pub bit_indices: Vec<u32>,
 }
 
 // Register data. Containing its type (qubits/clbits), its size, name,
@@ -392,6 +427,7 @@ impl ConditionPack {
 #[binrw]
 #[brw(big)]
 #[derive(Debug)]
+#[brw(import (version: u8))]
 pub struct LayoutV2Pack {
     pub exists: u8,
     pub initial_layout_size: i32,
@@ -400,8 +436,8 @@ pub struct LayoutV2Pack {
     #[bw(calc = extra_registers.len() as u32)]
     pub extra_registers_length: u32,
     pub input_qubit_count: i32,
-    #[br(count = extra_registers_length)]
-    pub extra_registers: Vec<RegisterV4Pack>,
+    #[br(count = extra_registers_length, args { inner: (version,) })]
+    pub extra_registers: Vec<RegisterPack>,
     #[br(count = initial_layout_size.max(0))]
     pub initial_layout_items: Vec<InitialLayoutItemV2Pack>,
     #[br(count = input_mapping_size.max(0))]

--- a/crates/qpy/src/interface.rs
+++ b/crates/qpy/src/interface.rs
@@ -28,9 +28,12 @@ use crate::bytes::Bytes;
 use crate::circuit_reader::unpack_circuit;
 use crate::circuit_writer::{pack_circuit, pack_layout};
 use crate::error::QpyError;
-use crate::formats::{QPYCircuit, QPYFileHeader};
+use crate::formats::{LayoutV2Pack, QPYCircuit, QPYFileHeader};
 use crate::py_methods::{py_circuit_data_to_quantum_circuit, serialize_metadata};
-use crate::value::{ProgramType, SymbolicEncoding, deserialize, deserialize_with_args, serialize};
+use crate::value::{
+    ProgramType, SymbolicEncoding, deserialize, deserialize_with_args, serialize,
+    serialize_with_args,
+};
 
 use std::io::{Cursor, Seek};
 
@@ -195,8 +198,10 @@ pub fn py_dump_qpy(
         .iter()
         .map(|circuit| {
             let metadata = serialize_metadata(&circuit.metadata, metadata_serializer.as_ref())?;
-            let layout = pack_layout(circuit.transpile_layout.clone(), &circuit.data)
-                .and_then(|layout| serialize(&layout))?;
+            let layout = pack_layout(circuit.transpile_layout.clone(), &circuit.data, version)
+                .and_then(|layout| {
+                    serialize_with_args::<LayoutV2Pack, (u8,)>(&layout, (version,))
+                })?;
             Ok(ExtraCircuitData {
                 name: circuit.name.clone(),
                 metadata,

--- a/crates/qpy/src/value.rs
+++ b/crates/qpy/src/value.rs
@@ -688,7 +688,11 @@ pub(crate) fn serialize_generic_value(
         }
         GenericValue::Null => (ValueType::Null, Bytes::new()),
         GenericValue::CircuitData(circuit_data) => {
-            let layout = serialize(&crate::circuit_writer::pack_layout(None, circuit_data)?)?;
+            let layout = serialize(&crate::circuit_writer::pack_layout(
+                None,
+                circuit_data,
+                qpy_data.version,
+            )?)?;
             let packed_circuit = pack_circuit(
                 circuit_data,
                 ExtraCircuitData {

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -199,6 +199,15 @@ of QPY in qiskit-terra 0.18.0.
    * - Qiskit (qiskit-terra for < 1.0.0) version
      - :func:`.dump` format(s) output versions
      - :func:`.load` maximum supported version (older format versions can always be read)
+   * - 2.6.0
+     - 13, 14, 15, 16, 17, 18
+     - 18
+   * - 2.5.2
+     - 13, 14, 15, 16, 17
+     - 17
+   * - 2.5.1
+     - 13, 14, 15, 16, 17
+     - 17
    * - 2.5.0
      - 13, 14, 15, 16, 17
      - 17
@@ -502,6 +511,38 @@ identifying which of the two it is:
 The register name needs no length of its own because the enclosing field already delimits the
 payload: ``conditional_reg_name_size`` for a condition, and the ``INSTRUCTION_PARAM`` header's
 ``size`` for a parameter.
+
+Changes to REGISTER_PACK
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The representation of registers defined in :ref:`qpy_registers` and updated in :ref:`qpy_version_4`)
+in QPY has changed in Version 18. The first change is the type of register
+index mapping array from ``int64_t`` to ``uint32_t`` (which is what it was prior to QPY v4). The original
+change to ``int64_t`` was done to enable using -1 as a sentinel value for a bit not in the circuit. This
+is not actually needed as we can use the max value of a ``uint32_t`` (4294967295) as the sentinel value.
+In version 18 values of 4294967295 should be treated as -1 was in previous QPY and the bit in that array
+position is not in the circuit.
+
+The :ref:`qpy_registers` header format has also been updated to
+
+.. code-block:: c
+
+    struct {
+        char type;
+        _Bool standalone;
+        uint32_t size;
+        uint16_t name_size;
+        _bool in_circuit;
+        char register_attachment;
+    }
+
+With the addition of the additional byte at the end of the struct for the
+``register_attachment`` field. If this value is 1 this indicates a contiguous
+register attached to a circuit. This will make the array following the
+name with the bit indices be a length of 1 and that contains the
+starting index of the register. The indices are then the range of length
+``size`` from that starting index. For example, if the starting index is 5
+and the ``size`` is 10 the indices are 5, 6, 7, 8, 9, 10, 11, 12, 13, 14.
 
 .. _qpy_version_17:
 

--- a/releasenotes/notes/qpy-smaller-register-representation-4a7459954b008683.yaml
+++ b/releasenotes/notes/qpy-smaller-register-representation-4a7459954b008683.yaml
@@ -1,0 +1,10 @@
+---
+features_qpy:
+  - QPY format version 18 significantly decreases the data size for
+    most :class:`.ClassicalRegister` and :class:`.QuantumRegister` objects in
+    a :class:`.QuantumCircuit`. The constant overhead for registers has
+    increased by 1 byte, but then in the worst case for each bit contained in
+    the register the overhead has decreased from 8 bytes for bit in the register
+    to 4 bytes for bit in the register. In the common case where the registers
+    are added to the circuit contiguously the space requirements goes from 8
+    bytes for bit to 4 bytes total to represent the register.

--- a/test/python/qpy/test_v18.py
+++ b/test/python/qpy/test_v18.py
@@ -15,7 +15,7 @@
 import io
 import struct
 
-from qiskit.circuit import ClassicalRegister, QuantumCircuit, QuantumRegister
+from qiskit.circuit import ClassicalRegister, QuantumCircuit, QuantumRegister, Qubit
 from qiskit.circuit.classical import expr
 from qiskit.qpy import dump, load
 from qiskit.qpy import formats
@@ -34,7 +34,9 @@ class TestV17VsV18(QiskitTestCase):
 
     def test_v18_smaller_than_v17_by_calibration_header(self):
         """v18 output is exactly 2 bytes smaller than v17 (CalibrationsPack removed)."""
-        qc = QuantumCircuit(2)
+        # Use raw bits because register sizes also shrink in QPY v18
+        qubits = [Qubit(), Qubit()]
+        qc = QuantumCircuit(qubits)
         qc.h(0)
         qc.cx(0, 1)
 


### PR DESCRIPTION
This commit updates the register pack representation in QPY to shrink the data requirements. The first change is that the bit indices are switched from being a vec of 64bit signed integers using -1 as a sentinel to u32::MAX. The address space is 32bits in qiskit's data model is a u32 and u32::MAX is already used as a sentinel value in a similar manner so we don't need to preserve the case of a u32::MAX index in the bit indices since that's not valid in Qiskit's data model. This shrinks the data size requirements of registers in a QPY payload in half. The other major change is removing the need of the indices array in the case the bit mapping is a contiguous range of indices. In these cases we only need to store a single integer for the start position of the data. In this case with the size we have the all the details necessary to build the index map from the qpy data already. This can significantly shrink the data size required for registers in most cases because typically registers are added in a contiguous block and we reduce the space required from 4 bytes * num_bits to 4 bytes.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->

TODO:

- [x] Fix LayoutV2Pack handling with extra registers (this is failing to round trip)