### PR TITLE
Revert "QPY 18: give Duration and Big integers their own type keys (#16802)

### DIFF
--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -69,7 +69,7 @@ use crate::value::unpack_for_collection;
 use crate::value::{
     BitType, CircuitInstructionType, ExpressionType, ExpressionVarDeclaration, GenericValue,
     QPYReadData, RegisterType, ValueEndian, ValueType, deserialize_with_args,
-    load_param_register_value, load_value, unpack_generic_value,
+    load_param_register_value, load_value, unpack_duration_value, unpack_generic_value,
 };
 
 use ndarray::{Array2, ShapeBuilder};
@@ -576,20 +576,23 @@ fn unpack_control_flow(
         .map_err(|_| QpyError::InvalidInstruction("Unable to find control flow".to_string()))?;
     let control_flow = match control_flow_name {
         ControlFlowType::Box => {
-            // Every param decodes the same way; only the *meaning* of the first one is special, in
-            // that it carries the duration rather than a block.
-            let mut values = instruction
+            // we need specialized handling for the params here, since the first param is duration
+            // which sadly shares the 't' key with tuple, so we can't deserialize using the general `unpack_generic_value`
+            param_values = instruction
                 .params
                 .iter()
-                .map(|param| unpack_generic_value(param, qpy_data, ValueEndian::Little))
-                .collect::<Result<Vec<_>, QpyError>>()?
-                .into_iter();
-            let Some(duration_value) = values.next() else {
+                .skip(1)
+                .map(|param| {
+                    unpack_generic_value(param, qpy_data, ValueEndian::LittleForV17AndBelow)
+                })
+                .collect::<Result<_, QpyError>>()?;
+            let duration_value = if let Some(duration_pack) = instruction.params.first() {
+                unpack_duration_value(duration_pack, qpy_data)?
+            } else {
                 return Err(QpyError::MissingData(
                     "Box control flow instruction missing parameters".to_string(),
                 ));
             };
-            param_values = values.collect();
             let duration = match duration_value {
                 GenericValue::Duration(duration) => Some(BoxDuration::Duration(duration)),
                 GenericValue::Expression(exp) => Some(BoxDuration::Expr(exp.clone())),

--- a/crates/qpy/src/py_methods.rs
+++ b/crates/qpy/src/py_methods.rs
@@ -433,12 +433,6 @@ pub(crate) fn py_convert_to_generic_value(
                 ))
             }
         }
-        // Unreachable: `py_get_type_key` produces neither key -- every Python `int` maps to
-        // `Integer`, and it has no `Duration` branch at all.  Both only arise when *reading*, from
-        // an `'I'`/`'D'` payload, so there is nothing to convert here.
-        ValueType::BigInt | ValueType::Duration => Err(QpyError::ConversionError(
-            "big integer and duration values are not produced from Python objects".to_string(),
-        )),
     }
 }
 

--- a/crates/qpy/src/value.rs
+++ b/crates/qpy/src/value.rs
@@ -199,13 +199,13 @@ pub struct QPYReadData {
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ValueType {
     Bool = b'b',
-    Integer = b'i',
+    Integer = b'i', // this is also used by "BigInt" which may arise in more specialized contexts
     Float = b'f',
     Complex = b'c',
     CaseDefault = b'd',
     Register = b'R',
     Range = b'r',
-    Tuple = b't',
+    Tuple = b't', // this is also used by "Duration" which may arise in more specialized contexts
     NumpyObject = b'n',
     Parameter = b'p',
     ParameterVector = b'v',
@@ -215,16 +215,7 @@ pub enum ValueType {
     Expression = b'x',
     Modifier = b'm',
     Circuit = b'q',
-    // Added in QPY 18.  Before that, an arbitrary-precision integer shared `Integer`'s key and a
-    // `Duration` shared `Tuple`'s, so a payload could not be decoded from its own bytes; see
-    // `QPY_DISTINCT_VALUE_KEYS_MIN_VERSION`.
-    BigInt = b'I',
-    Duration = b'D',
 }
-
-/// First QPY version in which an arbitrary-precision integer and a `Duration` carry their own type
-/// keys, rather than sharing `Integer`'s and `Tuple`'s.
-pub(crate) const QPY_DISTINCT_VALUE_KEYS_MIN_VERSION: u8 = 18;
 
 pub(crate) fn type_name(type_key: &ValueType) -> String {
     String::from(match type_key {
@@ -245,8 +236,6 @@ pub(crate) fn type_name(type_key: &ValueType) -> String {
         ValueType::Expression => "expression",
         ValueType::Modifier => "modifier",
         ValueType::Circuit => "circuit",
-        ValueType::BigInt => "big integer",
-        ValueType::Duration => "duration",
     })
 }
 
@@ -557,25 +546,19 @@ pub(crate) fn load_value(
             Ok(GenericValue::Bool(value))
         }
         ValueType::Integer => {
-            // Up to QPY 17 this key was shared with an arbitrary-precision integer, and the only way
-            // to tell them apart was the payload length.  From QPY 18 a `BigInt` has its own key, so
-            // an `Integer` is always an i64.
-            if bytes.len() > 8 && qpy_data.version < QPY_DISTINCT_VALUE_KEYS_MIN_VERSION {
-                return load_biguint_value(bytes);
+            // a little tricky since this can be either i64 or biguint
+            if bytes.len() <= 8 {
+                let mut bytes_array: [u8; 8] = [0; 8];
+                for (idx, byte) in bytes.iter().enumerate() {
+                    bytes_array[idx] = *byte;
+                }
+                match endian.resolve(qpy_data.version) {
+                    Endian::Little => Ok(GenericValue::Int64(i64::from_le_bytes(bytes_array))),
+                    Endian::Big => Ok(GenericValue::Int64(i64::from_be_bytes(bytes_array))),
+                }
+            } else {
+                load_biguint_value(bytes)
             }
-            let mut bytes_array: [u8; 8] = [0; 8];
-            for (idx, byte) in bytes.iter().enumerate() {
-                bytes_array[idx] = *byte;
-            }
-            match endian.resolve(qpy_data.version) {
-                Endian::Little => Ok(GenericValue::Int64(i64::from_le_bytes(bytes_array))),
-                Endian::Big => Ok(GenericValue::Int64(i64::from_be_bytes(bytes_array))),
-            }
-        }
-        ValueType::BigInt => load_biguint_value(bytes),
-        ValueType::Duration => {
-            let (duration_pack, _) = deserialize::<DurationPack>(bytes)?;
-            Ok(GenericValue::Duration(unpack_duration(duration_pack)))
         }
         ValueType::Float => {
             let value: f64 = bytes.try_to_f64(endian.resolve(qpy_data.version))?;
@@ -651,10 +634,9 @@ pub(crate) fn load_value(
     }
 }
 
-/// Reads an arbitrary-precision integer.  This is the `BigInt` arm of [`load_value`] from QPY 18 on;
-/// for earlier versions it is also what the length fork in the `Integer` arm falls back to, since
-/// the two shared a key.
-fn load_biguint_value(bytes: &Bytes) -> Result<GenericValue, QpyError> {
+// a specialized method used for biguints (marked by 'i' like Int64)
+// since the general load method will attempt to load a Int64 instead
+pub(crate) fn load_biguint_value(bytes: &Bytes) -> Result<GenericValue, QpyError> {
     let (bigint_pack, _) = deserialize::<BigIntPack>(bytes)?;
     let bigint = unpack_biguint(bigint_pack);
     Ok(GenericValue::BigInt(bigint))
@@ -668,16 +650,7 @@ pub(crate) fn serialize_generic_value(
     Ok(match value {
         GenericValue::Bool(value) => (ValueType::Bool, value.into()),
         GenericValue::Int64(value) => (ValueType::Integer, value.into()),
-        GenericValue::BigInt(bigint) => (
-            if qpy_data.version >= QPY_DISTINCT_VALUE_KEYS_MIN_VERSION {
-                ValueType::BigInt
-            } else {
-                // Up to QPY 17 this reuses `Int64`'s key, and a reader of those versions tells the
-                // two apart by payload length.
-                ValueType::Integer
-            },
-            serialize(&pack_biguint(bigint))?,
-        ),
+        GenericValue::BigInt(bigint) => (ValueType::Integer, serialize(&pack_biguint(bigint))?),
         GenericValue::Float64(value) => (ValueType::Float, value.into()),
         GenericValue::Complex64(value) => (ValueType::Complex, value.into()),
         GenericValue::String(value) => (ValueType::String, value.into()),
@@ -706,13 +679,7 @@ pub(crate) fn serialize_generic_value(
                 });
             }
             (
-                if qpy_data.version >= QPY_DISTINCT_VALUE_KEYS_MIN_VERSION {
-                    ValueType::Duration
-                } else {
-                    // Shared with `Tuple` up to QPY 17, which is why a reader of those versions has
-                    // to be told which of the two a payload holds.
-                    ValueType::Tuple
-                },
+                ValueType::Tuple, // due to historical reasons, 't' is shared between these data types
                 serialize(&pack_duration(duration))?,
             )
         }
@@ -777,6 +744,22 @@ pub(crate) fn unpack_generic_value(
 ) -> Result<GenericValue, QpyError> {
     let result = load_value(value_pack.type_key, &value_pack.data, qpy_data, endian)?;
     Ok(result)
+}
+
+/// dedicated method for handling the special case where the data pack encodes a `Duration` value
+/// this cannot be determined automatically since in the current QPY format, both duration and tuple
+/// share the 't' key.
+pub(crate) fn unpack_duration_value(
+    value_pack: &GenericDataPack,
+    qpy_data: &mut QPYReadData,
+) -> Result<GenericValue, QpyError> {
+    match value_pack.type_key {
+        ValueType::Tuple => {
+            let duration = unpack_duration(deserialize::<DurationPack>(&value_pack.data)?.0);
+            Ok(GenericValue::Duration(duration))
+        }
+        _ => unpack_generic_value(value_pack, qpy_data, ValueEndian::LittleForV17AndBelow), // fallback (duration can also be expression)
+    }
 }
 
 pub(crate) fn pack_for_collection(value: &ForCollection, version: u8) -> GenericValue {
@@ -1109,88 +1092,4 @@ pub(crate) fn creg_by_name(
         .ok_or_else(|| {
             QpyError::InvalidRegister(format!("Could not find classical register {name:?}"))
         })
-}
-
-#[cfg(test)]
-// Tests are allowed to unwrap; the crate-level deny exists for the deserializer, not for fixtures.
-#[allow(clippy::unwrap_used)]
-mod tests {
-    use super::*;
-    use qiskit_circuit::operations::Param;
-
-    /// A `Duration` and an arbitrary-precision integer are not reachable from a Python object
-    /// (`py_get_type_key` has no branch for either), so these round-trips exercise the two new
-    /// QPY 18 keys directly through the value codec.
-    fn round_trip(value: &GenericValue, version: u8) -> (ValueType, GenericValue) {
-        let circuit_data = CircuitData::new(None, None, Param::Float(0.0)).unwrap();
-        let write_data = QPYWriteData {
-            circuit_data: &circuit_data,
-            version,
-            standalone_var_indices: HashMap::new(),
-            annotation_handler: AnnotationHandler::native(),
-        };
-        let (type_key, bytes) = serialize_generic_value(value, &write_data).unwrap();
-        let mut read_data = QPYReadData {
-            circuit_data,
-            version,
-            use_symengine: false,
-            standalone_vars: HashMap::new(),
-            standalone_stretches: HashMap::new(),
-            vectors: HashMap::new(),
-            annotation_handler: AnnotationHandler::native(),
-        };
-        let loaded = load_value(type_key, &bytes, &mut read_data, ValueEndian::Big).unwrap();
-        (type_key, loaded)
-    }
-
-    #[test]
-    fn duration_uses_its_own_key_from_v18() {
-        let value = GenericValue::Duration(Duration::ns(250.0));
-        let (key, loaded) = round_trip(&value, QPY_DISTINCT_VALUE_KEYS_MIN_VERSION);
-        assert_eq!(key, ValueType::Duration);
-        let GenericValue::Duration(duration) = loaded else {
-            panic!("expected a duration, got {loaded:?}");
-        };
-        assert_eq!(duration, Duration::ns(250.0));
-    }
-
-    #[test]
-    fn duration_shares_the_tuple_key_below_v18() {
-        let value = GenericValue::Duration(Duration::dt(100));
-        let circuit_data = CircuitData::new(None, None, Param::Float(0.0)).unwrap();
-        let write_data = QPYWriteData {
-            circuit_data: &circuit_data,
-            version: QPY_DISTINCT_VALUE_KEYS_MIN_VERSION - 1,
-            standalone_var_indices: HashMap::new(),
-            annotation_handler: AnnotationHandler::native(),
-        };
-        let (key, _) = serialize_generic_value(&value, &write_data).unwrap();
-        // The legacy encoding is ambiguous, which is why it cannot simply be read back: a reader has
-        // to be told that this `Tuple` is really a duration.
-        assert_eq!(key, ValueType::Tuple);
-    }
-
-    #[test]
-    fn small_big_integer_round_trips_from_v18() {
-        // Below 18 this is lost: `BigIntPack` prefixes its length, so `BigUint(5)` serializes to
-        // `01 05` and the `Integer` arm's length fork reads those two bytes back as an i64.
-        let value = GenericValue::BigInt(BigUint::from(5u8));
-        let (key, loaded) = round_trip(&value, QPY_DISTINCT_VALUE_KEYS_MIN_VERSION);
-        assert_eq!(key, ValueType::BigInt);
-        let GenericValue::BigInt(bigint) = loaded else {
-            panic!("expected a big integer, got {loaded:?}");
-        };
-        assert_eq!(bigint, BigUint::from(5u8));
-    }
-
-    #[test]
-    fn large_big_integer_round_trips_from_v18() {
-        let big = BigUint::from(u128::MAX) * BigUint::from(7u8);
-        let (key, loaded) = round_trip(&GenericValue::BigInt(big.clone()), 18);
-        assert_eq!(key, ValueType::BigInt);
-        let GenericValue::BigInt(bigint) = loaded else {
-            panic!("expected a big integer, got {loaded:?}");
-        };
-        assert_eq!(bigint, big);
-    }
 }

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -512,25 +512,6 @@ The register name needs no length of its own because the enclosing field already
 payload: ``conditional_reg_name_size`` for a condition, and the ``INSTRUCTION_PARAM`` header's
 ``size`` for a parameter.
 
-Distinct type keys for ``Duration`` and big integers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Version 18 gives two value types a type key of their own, in the ``type`` field of an
-``INSTRUCTION_PARAM`` (see :ref:`qpy_instructions`) and anywhere else a value is stored with its key:
-
-* ``'D'`` for a :class:`.Duration`, which up to :ref:`version 17 <qpy_version_17>` shared ``'t'``
-  with a tuple.  The payload is unchanged: the one-byte unit discriminator followed by that unit's
-  value, exactly as in a ``DURATION`` item.
-* ``'I'`` for an arbitrary-precision integer, which up to version 17 shared ``'i'`` with a 64-bit
-  integer.  The payload is unchanged: one byte of length followed by that many big-endian magnitude
-  bytes.
-
-Reusing those keys is unambiguous for a decoder that knows which kind of value to expect at each
-point in the payload, and up to version 17 a decoder had to rely on that: an ``'i'`` payload longer
-than eight bytes was an arbitrary-precision integer rather than a 64-bit one.  The distinct keys
-additionally allow a value to be decoded from its own key and length, without that context.
-
-Payloads of :ref:`version 17 <qpy_version_17>` and earlier are read exactly as before.
-
 Changes to REGISTER_PACK
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -2257,11 +2238,6 @@ struct (on QPY format :ref:`qpy_version_3` the format is tweak slightly see:
 and in QPY :ref:`qpy_version_3` ``'v'`` represents a
 :class:`~qiskit.circuit.ParameterVectorElement` which is represented by a
 :ref:`qpy_param_vector` struct.
-
-From :ref:`version 18 <qpy_version_18>` two further keys are used: ``'D'`` for a
-:class:`.Duration` and ``'I'`` for an arbitrary-precision integer.  Before that version those
-values shared the keys of a tuple and of a 64-bit integer respectively, and were told apart by
-context rather than by their key.
 
 .. _qpy_param_struct:
 

--- a/releasenotes/notes/qpy-18-duration-bigint-keys-4c7e1a5b9d02f38a.yaml
+++ b/releasenotes/notes/qpy-18-duration-bigint-keys-4c7e1a5b9d02f38a.yaml
@@ -1,9 +1,0 @@
----
-upgrade_qpy:
-  - |
-    QPY has been upgraded to version 18, which gives a :class:`.Duration` value and an
-    arbitrary-precision integer type keys of their own, ``'D'`` and ``'I'``.  Up to version 17 they
-    shared the keys of a tuple and of a 64-bit integer, so a reader had to know from context which
-    of the two a payload held; a value can now be decoded from its own bytes.  The payloads
-    themselves are unchanged, and version 17 and earlier are read exactly as before.  See
-    :ref:`qpy_version_18` for the format description.


### PR DESCRIPTION
In the recently merged #16802 the QPY format was updated to add new type keys for fields in QPY. The intent was that there was some potential key character overlap between various parts and by creating distinct values between them. However, this was misreading how the QPY should be used. The type keys in QPY are a common design pattern used in several places in the format, but were never intended to be in a shared namespace; the keys were supposed to be used for type discrimination in the local evaluation of different instructions. The tension causing the desire for this was the Rust implementation of QPY attempting to globally define all the type keys in a shared enum which is at odds with the intent of the format specification. The change made in #16802 attempting to update the format makes it more confused and adds a lot of extra complexity to the format. Instead this situation should be addressed by updating the rust QPY implementation to move away from the global type key enum and split out the typing to be scoped to the context they're being used (i.e. interpret the duration only when evaluating a delay instruction).

This reverts commit 5cdc8cb992c3d76c2daa964277c617cf4541fa8e.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
