### PR TITLE
Preserve seeded pass-manager qubit metadata

### DIFF
--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -59,10 +59,12 @@ class PassManager(BasePassManager):
         input_program: QuantumCircuit,
         **kwargs,
     ) -> DAGCircuit:
-        self.property_set["original_qubit_indices"] = {
-            bit: i for i, bit in enumerate(input_program.qubits)
-        }
-        self.property_set["num_input_qubits"] = input_program.num_qubits
+        if self.property_set["original_qubit_indices"] is None:
+            self.property_set["original_qubit_indices"] = {
+                bit: i for i, bit in enumerate(input_program.qubits)
+            }
+        if self.property_set["num_input_qubits"] is None:
+            self.property_set["num_input_qubits"] = input_program.num_qubits
         return circuit_to_dag(input_program, copy_operations=True)
 
     def _passmanager_backend(

--- a/test/python/transpiler/test_passmanager_run.py
+++ b/test/python/transpiler/test_passmanager_run.py
@@ -12,12 +12,13 @@
 
 """Tests PassManager.run()"""
 
-from qiskit import QuantumRegister, QuantumCircuit
+from qiskit import QuantumRegister, QuantumCircuit, transpile
 from qiskit.circuit.library import CXGate
 from qiskit.transpiler.preset_passmanagers import level_1_pass_manager
 from qiskit.providers.fake_provider import GenericBackendV2
-from qiskit.transpiler import Layout, PassManager
+from qiskit.transpiler import CouplingMap, Layout, PassManager, PropertySet
 from qiskit.transpiler.passmanager_config import PassManagerConfig
+from qiskit.transpiler.passes import Decompose
 from ..legacy_cmaps import ALMADEN_CMAP
 from test import QiskitTestCase
 
@@ -57,6 +58,23 @@ class TestPassManagerRun(QiskitTestCase):
         for qc, new_qc in zip([qc0, qc1], result):
             self.assertIsInstance(new_qc, QuantumCircuit)
             self.assertEqual(new_qc, qc)  # pm has no passes
+
+    def test_preserve_layout_metadata_from_initial_property_set(self):
+        """Test layout metadata in an initial property set is not overwritten."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        laid_out = transpile(
+            circuit,
+            coupling_map=CouplingMap.from_line(3),
+            initial_layout=[0, 2],
+            optimization_level=0,
+        )
+        property_set = PropertySet()
+        laid_out.layout.write_into_property_set(property_set)
+
+        output = PassManager([Decompose()]).run(laid_out, property_set=property_set)
+
+        self.assertEqual(output.layout, laid_out.layout)
 
     def test_default_pass_manager_single(self):
         """Test default_pass_manager.run(circuit).


### PR DESCRIPTION
🚧 WORK IN PROGRESS

Use the existing `property_set` continuation mechanism without overwriting caller-supplied
`original_qubit_indices` or `num_input_qubits`. This keeps a complete `TranspileLayout` bundle
coherent across fresh pass managers, while unset values are still inferred from the input circuit.

Fix #8622

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [x] Some written text was generated by: OpenAI Codex.
- [x] Some submitted code was generated by: OpenAI Codex.
