### PR TITLE
Allow `calloc`-like optimisations in `SparsePauliOp` allocations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ license = "Apache-2.0"
 #
 # Each crate can add on specific features freely as it inherits.
 [workspace.dependencies]
-bytemuck = "1.25"
+bytemuck = { version = "1.25", features = ["extern_crate_alloc"] }
 bitfield-struct = "0.13.0"
 indexmap.version = "2.10.0"
 hashbrown.version = "0.15.5"
 num-bigint = "0.4"
-num-complex = "0.4"
+num-complex = { version = "0.4", features = ["bytemuck"] }
 nalgebra = "0.35"
 faer = "0.24"
 numpy = "0.29"

--- a/crates/quantum_info/src/sparse_pauli_op.rs
+++ b/crates/quantum_info/src/sparse_pauli_op.rs
@@ -359,20 +359,15 @@ impl MatrixCompressedPaulis {
     /// Returns a C-ordered [Vec] of the 2D matrix.
     pub fn to_matrix_dense(&self, parallel: bool) -> Array2<Complex64> {
         let side = 1usize << self.num_qubits();
-        #[allow(clippy::uninit_vec)]
-        let mut out = {
-            let mut out = Vec::with_capacity(side * side);
-            // SAFETY: we iterate through the vec in chunks of `side`, and start each row by filling it
-            // with zeros before ever reading from it.  It's fine to overwrite the uninitialised memory
-            // because `Complex64: !Drop`.
-            unsafe { out.set_len(side * side) };
-            out
-        };
+        let len = side * side;
+        // We allocate this here as a double-size `Vec<f64>` instead of `Vec<Complex64>` directly
+        // because `rustc` has special optimisations to lower `vec![0; size]` to calls to `calloc`
+        // when the literal is a primitive, but can't lower `Complex64::zero()` in the same way (as
+        // of Rust 1.98).  From Rust 1.92 onwards this could also be spelt as
+        // `Box::<[Complex64]>::new_zeroed_slice().assume_init().into_vec()`.
+        let mut out = bytemuck::allocation::try_cast_vec::<f64, Complex64>(vec![0.0f64; 2 * len])
+            .expect("Complex<f64> aligns as f64 with exactly double size");
         let write_row = |(i_row, row): (usize, &mut [Complex64])| {
-            // Doing the initialization here means that when we're in parallel contexts, we do the
-            // zeroing across the whole threadpool.  This also seems to give a speed-up in serial
-            // contexts, but I don't understand that. ---Jake
-            row.fill(C_ZERO);
             for ((&x_like, &z_like), &coeff) in self
                 .x_like
                 .iter()

--- a/crates/quantum_info/src/sparse_pauli_op.rs
+++ b/crates/quantum_info/src/sparse_pauli_op.rs
@@ -359,14 +359,7 @@ impl MatrixCompressedPaulis {
     /// Returns a C-ordered [Vec] of the 2D matrix.
     pub fn to_matrix_dense(&self, parallel: bool) -> Array2<Complex64> {
         let side = 1usize << self.num_qubits();
-        let len = side * side;
-        // We allocate this here as a double-size `Vec<f64>` instead of `Vec<Complex64>` directly
-        // because `rustc` has special optimisations to lower `vec![0; size]` to calls to `calloc`
-        // when the literal is a primitive, but can't lower `Complex64::zero()` in the same way (as
-        // of Rust 1.98).  From Rust 1.92 onwards this could also be spelt as
-        // `Box::<[Complex64]>::new_zeroed_slice().assume_init().into_vec()`.
-        let mut out = bytemuck::allocation::try_cast_vec::<f64, Complex64>(vec![0.0f64; 2 * len])
-            .expect("Complex<f64> aligns as f64 with exactly double size");
+        let mut out = bytemuck::allocation::zeroed_vec(side * side);
         let write_row = |(i_row, row): (usize, &mut [Complex64])| {
             for ((&x_like, &z_like), &coeff) in self
                 .x_like

--- a/releasenotes/notes/spo-matrix-calloc-f85048167ecd76da.yaml
+++ b/releasenotes/notes/spo-matrix-calloc-f85048167ecd76da.yaml
@@ -1,0 +1,5 @@
+---
+performance:
+  - |
+    :meth:`.SparsePauliOp.to_matrix` now allocates dense matrices in a way that is more likely to
+    get OS/kernel-level optimizations, especially for large matrices with few nonzero terms.


### PR DESCRIPTION
As of Rust 1.98, `vec![0.0; 2 * len]` lowers to OS/kernel-level "allocate zero-filled" functions, but using a non-primitive type in the `Vec` (like `Complex64`) doesn't permit this optimisation.  We want to use `calloc` instead of manually writing zeros into the vector because it often gets kernel-level support to have zero impact on pages that are never written to, whereas manually issuing write calls across each row guarantees that we have to page in everything.

This has a larger performance impact for large dense matrices with high sparsity factors.

Using a benchmark script:

```python
import timeit
import numpy as np
from qiskit.quantum_info import SparsePauliOp

def make_sparse_list(num_qubits, num_terms, locality, rng):
    terms = []
    for _ in range(num_terms):
        indices = rng.choice(num_qubits, size=locality, replace=False)
        label = "".join(rng.choice(tuple("XYZ")) for _ in indices)
        coeff = complex(rng.normal(), rng.normal())
        terms.append((label, indices, coeff))
    return terms

rng = np.random.default_rng(42)
print(f"{'n':>3} {'terms':>6} {'locality':>8} {'time (s)':>10}")
configs = [
    (6, 10, 2),
    (10, 10, 2),
    (10, 50, 2),
    (10, 100, 4),
    (14, 10, 2),
    (14, 50, 2),
    (14, 100, 4),
]
for num_qubits, num_terms, locality in configs:
    terms = make_sparse_list(num_qubits, num_terms, locality, rng)
    op = SparsePauliOp.from_sparse_list(terms, num_qubits=num_qubits)
    reps, tot = timeit.Timer(op.to_matrix).autorange()
    print(f"{num_qubits:>3} {num_terms:>6} {locality:>8} {tot / reps:>10.4f}")
```

On main (as of aae0d80eaf), on a Macbook Pro M4 Max using 16 threads, the timings were:
```text
  n  terms locality   time (s)
  6     10        2     0.0000
 10     10        2     0.0003
 10     50        2     0.0003
 10    100        4     0.0003
 14     10        2     0.2860
 14     50        2     0.2767
 14    100        4     0.2757
```

With both this commit and gh-16828 in place, the numbers instead become:
```text
  n  terms locality   time (s)
  6     10        2     0.0000
 10     10        2     0.0001
 10     50        2     0.0001
 10    100        4     0.0002
 14     10        2     0.0229
 14     50        2     0.0313
 14    100        4     0.0459
```

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [ ] Some written text was generated by: 
- [x] Some submitted code was generated by: Claude Sonnet 5 

The benchmark script in the commit message is a significantly modified version of a script Julien generated with Claude.  Nothing else is LLM.

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
