### PR TITLE
Add `cargo` checks to Makefile's `lint` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ lint:
 	tools/find_optional_imports.py
 	tools/find_stray_release_notes.py
 	tools/verify_images.py
+	cargo fmt --check
+	cargo clippy --all-targets -- -D warnings
 
 style:
 	black --check qiskit test tools setup.py docs/conf.py


### PR DESCRIPTION
The CI runs `cargo fmt` and `cargo clippy`, it would be convenient to extend our Makefile's lint target with these jobs and facilitate checking the CI locally. Especially since `cargo clippy` runs with additional arguments. The tox job already contains these.

### AI/LLM disclosure

- [x] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
