### PR TITLE
Support typedefs and function pointers in `bindgen`

### DIFF
--- a/crates/bindgen/src/render/ctypes.rs
+++ b/crates/bindgen/src/render/ctypes.rs
@@ -204,10 +204,10 @@ mod parse {
                     is_nullable,
                     never_return,
                 } => {
-                    if !is_nullable {
+                    if *is_nullable {
                         bail!("nullability of funcptrs is not yet handled");
                     }
-                    if !never_return {
+                    if *never_return {
                         bail!("diverging functions not yet handled");
                     }
                     let mut parsed_args = Vec::with_capacity(args.len());
@@ -217,15 +217,14 @@ mod parse {
                             ty: r#type(ty, override_fn)?,
                         });
                     }
-                    let args = parsed_args;
                     let ret = if **ret == VOID {
                         None
                     } else {
                         Some(r#type(ret, override_fn)?)
                     };
                     break TypeKind::FuncPtr(Box::new(simple_ir::Function {
-                        name: String::new(),
-                        args,
+                        name: String::new(), // no function name for function pointers
+                        args: parsed_args,
                         ret,
                     }));
                 }

--- a/crates/bindgen/src/render/ctypes.rs
+++ b/crates/bindgen/src/render/ctypes.rs
@@ -268,6 +268,17 @@ mod parse {
         })
     }
 
+    pub fn r#typedef(
+        val: &ir::Typedef,
+        mut override_fn: impl FnMut(&str) -> Option<Primitive>,
+    ) -> anyhow::Result<simple_ir::Typedef<Primitive>> {
+        let ty = r#type(&val.aliased, &mut override_fn)?;
+        Ok(simple_ir::Typedef {
+            name: val.export_name.clone(),
+            ty,
+        })
+    }
+
     /// Extract all objects from a set of `cbindgen::Bindings`, adding them to ourselves.
     ///
     /// This fails if the bindings contain any unsupported constructs.
@@ -299,9 +310,10 @@ mod parse {
                 ir::ItemContainer::Union(item) => items
                     .unions
                     .push(r#union(item, |path| overrides.get(path).copied())?),
-                ir::ItemContainer::Constant(_)
-                | ir::ItemContainer::Static(_)
-                | ir::ItemContainer::Typedef(_) => {
+                ir::ItemContainer::Typedef(item) => items
+                    .typedefs
+                    .push(r#typedef(item, |path| overrides.get(path).copied())?),
+                ir::ItemContainer::Constant(_) | ir::ItemContainer::Static(_) => {
                     bail!("unhandled item: {item:?}");
                 }
             }
@@ -522,6 +534,7 @@ impl Items {
             structs: vec![complex],
             functions: vec![],
             unions: vec![],
+            typedefs: vec![],
         }
     }
 

--- a/crates/bindgen/src/render/ctypes.rs
+++ b/crates/bindgen/src/render/ctypes.rs
@@ -161,7 +161,7 @@ mod parse {
 
     pub fn r#type(
         mut ty: &ir::Type,
-        mut override_fn: impl FnMut(&str) -> Option<Primitive>,
+        override_fn: &mut dyn FnMut(&str) -> Option<Primitive>,
     ) -> anyhow::Result<simple_ir::Type<Primitive>> {
         let mut ptrs = Vec::new();
         let base = loop {
@@ -198,7 +198,37 @@ mod parse {
                     break TypeKind::Builtin(Primitive::try_from_cbindgen_primitive(ty)?);
                 }
                 ir::Type::Array(..) => bail!("array types not yet handled"),
-                ir::Type::FuncPtr { .. } => bail!("funcptrs not yet handled"),
+                ir::Type::FuncPtr {
+                    ret,
+                    args,
+                    is_nullable,
+                    never_return,
+                } => {
+                    if !is_nullable {
+                        bail!("nullability of funcptrs is not yet handled");
+                    }
+                    if !never_return {
+                        bail!("diverging functions not yet handled");
+                    }
+                    let mut parsed_args = Vec::with_capacity(args.len());
+                    for (name, ty) in args {
+                        parsed_args.push(simple_ir::FunctionArg {
+                            name: name.clone(),
+                            ty: r#type(ty, override_fn)?,
+                        });
+                    }
+                    let args = parsed_args;
+                    let ret = if **ret == VOID {
+                        None
+                    } else {
+                        Some(r#type(ret, override_fn)?)
+                    };
+                    break TypeKind::FuncPtr(Box::new(simple_ir::Function {
+                        name: String::new(),
+                        args,
+                        ret,
+                    }));
+                }
             }
         };
         Ok(simple_ir::Type { ptrs, base })
@@ -223,7 +253,7 @@ mod parse {
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
         let ret = (func.ret != VOID)
-            .then(|| r#type(&func.ret, override_fn))
+            .then(|| r#type(&func.ret, &mut override_fn))
             .transpose()?;
         Ok(simple_ir::Function { name, args, ret })
     }
@@ -335,14 +365,25 @@ mod export {
 
     /// Write this type into an existing string.
     fn render_type(ty: &simple_ir::Type<Primitive>, out: &mut String) {
-        let name = match &ty.base {
-            TypeKind::Builtin(p) => p.qualname(),
-            TypeKind::Custom(c) => c.as_str(),
-        };
         for _ in &ty.ptrs {
             out.push_str("ctypes.POINTER(");
         }
-        out.push_str(name);
+        match &ty.base {
+            TypeKind::Builtin(p) => out.push_str(p.qualname()),
+            TypeKind::Custom(c) => out.push_str(c),
+            TypeKind::FuncPtr(func) => {
+                out.push_str("ctypes.CFUNCTYPE(");
+                match func.ret.as_ref() {
+                    Some(ret) => render_type(ret, out),
+                    None => out.push_str("None"),
+                }
+                for arg in &func.args {
+                    out.push_str(", ");
+                    render_type(&arg.ty, out);
+                }
+                out.push(')');
+            }
+        }
         for _ in &ty.ptrs {
             out.push(')');
         }

--- a/crates/bindgen/src/render/rust.rs
+++ b/crates/bindgen/src/render/rust.rs
@@ -205,8 +205,12 @@ mod parse {
                     is_nullable,
                     never_return,
                 } => {
-                    assert!(!is_nullable, "nullability of funcptrs is not handled");
-                    assert!(!never_return, "diverging functions not handled");
+                    if *is_nullable {
+                        bail!("nullability of funcptrs is not yet handled");
+                    }
+                    if *never_return {
+                        bail!("diverging functions not yet handled");
+                    }
                     let args = args
                         .iter()
                         .map(|(name, ty)| {

--- a/crates/bindgen/src/render/rust.rs
+++ b/crates/bindgen/src/render/rust.rs
@@ -199,7 +199,32 @@ mod parse {
                     break TypeKind::Builtin(Primitive::try_from_cbindgen_primitive(ty)?);
                 }
                 ir::Type::Array(..) => bail!("array types not yet handled"),
-                ir::Type::FuncPtr { .. } => bail!("funcptrs not yet handled"),
+                ir::Type::FuncPtr {
+                    ret,
+                    args,
+                    is_nullable,
+                    never_return,
+                } => {
+                    assert!(!is_nullable, "nullability of funcptrs is not handled");
+                    assert!(!never_return, "diverging functions not handled");
+                    let args = args
+                        .iter()
+                        .map(|(name, ty)| {
+                            Ok(simple_ir::FunctionArg {
+                                name: name.clone(),
+                                ty: r#type(ty)?,
+                            })
+                        })
+                        .collect::<anyhow::Result<Vec<_>>>()?;
+                    let ret = (**ret != ir::Type::Primitive(ir::PrimitiveType::Void))
+                        .then(|| r#type(ret))
+                        .transpose()?;
+                    break TypeKind::FuncPtr(Box::new(simple_ir::Function {
+                        name: String::new(),
+                        args,
+                        ret,
+                    }));
+                }
             }
         };
         Ok(simple_ir::Type { ptrs, base })
@@ -316,6 +341,21 @@ mod export {
         match &ty.base {
             TypeKind::Builtin(ty) => out.push_str(ty.qualname()),
             TypeKind::Custom(name) => out.push_str(name),
+            TypeKind::FuncPtr(func) => {
+                out.push_str("extern \"C\" fn(");
+                if let Some((first, rest)) = func.args.split_first() {
+                    render_type(&first.ty, out);
+                    for arg in rest {
+                        out.push_str(", ");
+                        render_type(&arg.ty, out);
+                    }
+                }
+                out.push(')');
+                if let Some(ret) = func.ret.as_ref() {
+                    out.push_str(" -> ");
+                    render_type(ret, out);
+                }
+            }
         }
     }
 

--- a/crates/bindgen/src/render/rust.rs
+++ b/crates/bindgen/src/render/rust.rs
@@ -261,6 +261,13 @@ mod parse {
         })
     }
 
+    pub fn r#typedef(val: &ir::Typedef) -> anyhow::Result<simple_ir::Typedef<Primitive>> {
+        Ok(simple_ir::Typedef {
+            name: val.export_name.clone(),
+            ty: r#type(&val.aliased)?,
+        })
+    }
+
     /// Extract all objects from a set of `cbindgen::Bindings`, adding them to ourselves.
     ///
     /// This fails if the bindings contain any unsupported constructs.
@@ -278,9 +285,8 @@ mod parse {
                     .push(simple_ir::Struct::opaque(item.export_name.clone())),
                 ir::ItemContainer::Struct(item) => items.structs.push(r#struct(item)?),
                 ir::ItemContainer::Union(item) => items.unions.push(r#union(item)?),
-                ir::ItemContainer::Constant(_)
-                | ir::ItemContainer::Static(_)
-                | ir::ItemContainer::Typedef(_) => {
+                ir::ItemContainer::Typedef(item) => items.typedefs.push(r#typedef(item)?),
+                ir::ItemContainer::Constant(_) | ir::ItemContainer::Static(_) => {
                     bail!("unhandled item: {item:?}");
                 }
             }

--- a/crates/bindgen/src/simple_ir.rs
+++ b/crates/bindgen/src/simple_ir.rs
@@ -26,6 +26,7 @@ pub enum PtrKind {
 pub enum TypeKind<T> {
     Builtin(T),
     Custom(String),
+    FuncPtr(Box<Function<T>>),
 }
 #[derive(Clone, Debug)]
 pub struct Type<T> {

--- a/crates/bindgen/src/simple_ir.rs
+++ b/crates/bindgen/src/simple_ir.rs
@@ -130,11 +130,20 @@ pub struct Union<T> {
 }
 
 #[derive(Clone, Debug)]
+pub struct Typedef<T> {
+    /// The name of the new type.
+    pub name: String,
+    /// The type definition.
+    pub ty: Type<T>,
+}
+
+#[derive(Clone, Debug)]
 pub struct Items<T> {
     pub enums: Vec<Enum>,
     pub structs: Vec<Struct<T>>,
     pub functions: Vec<Function<T>>,
     pub unions: Vec<Union<T>>,
+    pub typedefs: Vec<Typedef<T>>,
 }
 impl<T> Default for Items<T> {
     fn default() -> Self {
@@ -143,6 +152,7 @@ impl<T> Default for Items<T> {
             structs: Default::default(),
             functions: Default::default(),
             unions: Default::default(),
+            typedefs: Default::default(),
         }
     }
 }


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

In the recent passmanager in C infrastructure I stumbled upon exposing typedefs and function pointers from Rust to C. This PR adds support to the bindgen crate.  There's no explicit tests that I've found but I tested this locally -- with something that is not included in this PR though.

We might end up not needing this for the C passmanager, and I'm fine merging something like this at a later stage. But now that I've had this locally and it's working I wanted to open the PR anyways since it seems very useful to have!

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [x] Some submitted code was generated by: Claude Sonnet 5 

Claude added the bit on function pointers, I've tested this locally and went over the changes.

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
